### PR TITLE
readme: mention python-fontforge minimum version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ See: [Font Patcher](#font-patcher) for usage
 </h2>
 
 Patching the font of your own choosing for use with the [vim-webdevicons](https://github.com/ryanoasis/vim-webdevicons) vim plugin:
-* requires: python2, python-fontforge package
+* requires: python2, python-fontforge package (version 20141231 or later)
 * usage:
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,8 @@ See: [Font Patcher](#font-patcher) for usage
 </h2>
 
 Patching the font of your own choosing for use with the [vim-webdevicons](https://github.com/ryanoasis/vim-webdevicons) vim plugin:
-* requires: python2, python-fontforge package (version 20141231 or later)
+* requires: python2, python-fontforge package (version 20141231 or later, see
+  the [install instructions](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * usage:
 
 ```


### PR DESCRIPTION
@ryanoasis 
Can you provide information about how to install it best?
The Ubuntu repos do not provide it (20120731.b-5+b3 being the latest in Debian/Ubuntu).

Is manually installing the way to go?
There is no package on PyPI, is there?

*Edit*: the Fontforge book has install instructions, and I've added a link to it.