### PR TITLE
Consider font style when generating familyname and fontname

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -84,10 +84,12 @@ if args.single:
 sourceFont = fontforge.open(args.font)
 
 fontname, style = re.match("^([^-]*)(?:(-.*))?$", sourceFont.fontname).groups()
-familyname = sourceFont.familyname
+style = style.replace('-', '')
+
+familyname = sourceFont.familyname.replace(style, "").rstrip()
 # fullname (filename) can always use long/verbose font name, even in windows
 fullname = sourceFont.fullname + verboseAdditionalFontNameSuffix
-fontname = fontname + additionalFontNameSuffix.replace(" ", "")
+fontname = fontname + additionalFontNameSuffix.replace(" ", "") + "-" + style
 
 if args.windows:
     maxLength = 31

--- a/font-patcher
+++ b/font-patcher
@@ -84,7 +84,7 @@ if args.single:
 sourceFont = fontforge.open(args.font)
 
 fontname, style = re.match("^([^-]*)(?:(-.*))?$", sourceFont.fontname).groups()
-style = style.replace('-', '')
+style = style.replace("-", "")
 
 familyname = sourceFont.familyname.replace(style, "").rstrip()
 # fullname (filename) can always use long/verbose font name, even in windows

--- a/font-patcher
+++ b/font-patcher
@@ -83,9 +83,7 @@ if args.single:
 
 sourceFont = fontforge.open(args.font)
 
-fontname, style = re.match("^([^-]*)(?:(-.*))?$", sourceFont.fontname).groups()
-style = style.replace("-", "")
-
+fontname, style = re.match("^([^-]*)(?:-(.*))?$", sourceFont.fontname).groups()
 familyname = sourceFont.familyname.replace(style, "").rstrip()
 # fullname (filename) can always use long/verbose font name, even in windows
 fullname = sourceFont.fullname + verboseAdditionalFontNameSuffix


### PR DESCRIPTION
These small modifications to the font patching script take the separate font styles into account when generating the font family and font name of the generated fonts. This ideally consolidates all of the fonts under a single font family each as a unique font style when the patched fonts are installed.

I'm not fully aware of the standards used with regards to the dashes in the different strings that are assumed in this pull request so additional normalization may need to be done in order to prevent these changes from causing problems on fonts that have non-standard or incorrect metadata. I'm happy to put research into this if this is a desired modification to the script.