### PR TITLE
Allow a single font-family to be installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,21 @@
 # Set source and target directories
 powerline_fonts_dir="${PWD}/patched-fonts"
 
+# Accept a font / directory name, to avoid installing all fonts
+if [ ! -z "$1" ];
+then
+  # Ensure thar directory exists, and offer suggestions if not
+
+  if [[ ! -d "$powerline_fonts_dir/$1" ]];
+  then
+    echo -e "That font directory doesn't exist. Options are: \n"
+    ls "$powerline_fonts_dir"
+    exit -1
+  fi
+
+  powerline_fonts_dir="$powerline_fonts_dir/$1"
+fi
+
 find_command="find \"$powerline_fonts_dir\" \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
 
 if [[ $(uname) == 'Darwin' ]]; then
@@ -22,4 +37,9 @@ if [[ -n $(which fc-cache) ]]; then
   fc-cache -f "$font_dir"
 fi
 
-echo "All fonts installed to $font_dir"
+if [ ! -z "$1" ];
+then
+  echo "$1 font installed to $font_dir"
+else
+  echo "All fonts installed to $font_dir"
+fi

--- a/readme.md
+++ b/readme.md
@@ -176,8 +176,16 @@ Installs all of the patched Fonts (_Warning: This is a lot of Fonts adding up to
 
 * Linux & Mac OS X
 
+To install all fonts:
 ```sh
 ./install.sh
+```
+
+To install a single font:
+```sh
+./install.sh <FontName>
+./install.sh Hack
+./install.sh HeavyData
 ```
 
 #### Examples


### PR DESCRIPTION
#### Description

Allow a single font-family to be installed, instead of everything by default

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts#faq)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Allows the installation of a single font

#### How should this be manually tested?

`./install Hack` should only install the Hack family

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![screen shot 2016-05-09 at 09 42 03](https://cloud.githubusercontent.com/assets/145816/15107858/66ecc862-15ca-11e6-9c02-906dcfa7666b.png)
