### PR TITLE
Add license file for 3270font, fix #112

### DIFF
--- a/patched-fonts/3270/LICENSE.txt
+++ b/patched-fonts/3270/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright (c) 2011-2016, Ricardo Banffy.
+Copyright (c) 1993-2011, Paul Mattes.
+Copyright (c) 2004-2005, Don Russell.
+Copyright (c) 2004, Dick Altenbern.
+Copyright (c) 1990, Jeff Sparkes.
+Copyright (c) 1989, Georgia Tech Research Corporation (GTRC), Atlanta, GA 30332.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the names of Ricardo Banffy, Paul Mattes, Don Russell, Dick Altenbern, Jeff Sparkes, GTRC nor the names of their contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY RICARDO BANFFY, PAUL MATTES, DON RUSSELL, DICK ALTENBERN, JEFF SPARKES AND GTRC "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL RICARDO BANFFY, PAUL MATTES, DON RUSSELL, DICK ALTENBERN, JEFF SPARKES OR GTRC BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The Debian Logo glyph is based on the Debian Open Use Logo and is Copyright (c) 1999 Software in the Public Interest, Inc., and it is incorporated here under the terms of the Creative Commons Attribution-ShareAlike 3.0 Unported License. The logo is released under the terms of the GNU Lesser General Public License, version 3 or any later version, or, at your option, of the Creative Commons Attribution-ShareAlike 3.0 Unported License.


### PR DESCRIPTION
#### Description

Missing license file. The 3270font project builds upon work that dates back to the 1980's and requires distribution of the license file (updated, if needed) along with derived works. From the license, "Redistributions in binary form must reproduce the above copyright notice".

#### What does this Pull Request (PR) do?

Add a missing license file

#### How should this be manually tested?

N/A

#### Any background context you can provide?

Binary distribution needs referred license

#### What are the relevant tickets (if any)?

112

#### Screenshots (if appropriate or helpful)

N/A