### PR TITLE
Fix FAQ links in .github/

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ By posting an issue you acknowledge the following:
 
 - [ ] A brief but descriptive _title_ of your issue
 - [ ] I have searched the [issues](https://github.com/ryanoasis/nerd-fonts/issues) for my issue and found nothing related and/or helpful
-- [ ] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts#faq--troubleshooting)
+- [ ] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ)
 - [ ] I have read or at least glanced at the [Wiki](https://github.com/ryanoasisnerd-fonts/wiki)
 
 These items you must provide answers to. Make sure to add **all the information needed to understand the issue** so that someone can help. If the info is missing we'll add the 'Needs more information' label and _may_ choose to close the issue until there is enough information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ _Please explain the changes you made here._
 #### Requirements / Checklist
 
 - [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
-- [ ] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts#faq)
+- [ ] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ)
 - [ ] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
 - [ ] Scripts execute without error (if necessary):
   - If any of the scripts were modified they have been tested and execute without error, e.g.:


### PR DESCRIPTION
#### Description

Fix link to FAQ in GitHub files.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts#faq)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table