### PR TITLE
Change the font family name for mono fonts

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -172,6 +172,8 @@ if args.windows:
         familyname = familyname[:maxFamilyLength]
 else:
     familyname += " " + projectNameSingular
+    if args.single:
+        familyname += " Mono"
 
 # Don't truncate the subfamily to keep fontname unique.  MacOS treats fonts with
 # the same name as the same font, even if subFamily is different.


### PR DESCRIPTION
#### Description

Add " Mono" to the font family name when generating single-wide fonts.

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [X] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [X] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [X] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [X] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### How should this be manually tested?

Run `./font-patcher` with the `-s` flag and check the generated fonts.

#### What are the relevant tickets (if any)?

Fixes #176.
