### PR TITLE
Open files relative to the script's directory

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -65,7 +65,8 @@ parser.add_argument('-ext', '--extension', type=str, nargs='?', dest='extension'
 parser.add_argument('-out', '--outputdir', type=str, nargs='?', dest='outputdir', help='The directory to output the patched font file to', default=".")
 args = parser.parse_args()
 
-changelog = open("changelog.md", "r")
+__dir__ = os.path.dirname(__file__)
+changelog = open(__dir__ + "/changelog.md", "r")
 minimumVersion = 20141231
 actualVersion = int(fontforge.version())
 # un-comment following line for testing invalid version error handling
@@ -669,7 +670,7 @@ for patch in PATCH_SET:
             if symfont:
                 symfont.close()
                 symfont = None
-            symfont = fontforge.open("src/glyphs/"+patch['Filename'])
+            symfont = fontforge.open(__dir__+"/src/glyphs/"+patch['Filename'])
             # Match the symbol font size to the source font size
             symfont.em = sourceFont.em
             PreviousSymbolFilename = patch['Filename']


### PR DESCRIPTION
#### Description
If you try to run the `font-patcher` script outside of its directory, it will fail to open the files.

#### Requirements / Checklist
- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Allows the script to be run from any directory.