### PR TITLE
Fix Project Motivation ToC link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,7 @@ The following Sankey flow diagram shows the current glyph sets included:
   * [**Other Good Fonts to Patch**](#other-good-fonts-to-patch)
   * [**Contributing**](#contributing)
 
-[**Project History**](#project-history)
-  * [**Motivation**](#motivation-original-rationale)
+[**Project Motivation**](#project-motivation)
 
 **Additional Info**
   * [**Unstable file paths on master**](#unstable-file-paths)


### PR DESCRIPTION
#### Description

Minor changes to readme.md
- Remove Project History ToC link
- Fix anchor name in Project Motivation ToC link