### PR TITLE
fix '__dir__' set to empty

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -62,7 +62,7 @@ parser.add_argument('-ext', '--extension', type=str, nargs='?', dest='extension'
 parser.add_argument('-out', '--outputdir', type=str, nargs='?', dest='outputdir', help='The directory to output the patched font file to', default=".")
 args = parser.parse_args()
 
-__dir__ = os.path.dirname(__file__)
+__dir__ = os.path.dirname(os.path.abspath(__file__))
 minimumVersion = 20141231
 actualVersion = int(fontforge.version())
 # un-comment following line for testing invalid version error handling


### PR DESCRIPTION
#### Description

When running `fontforge -script font-patcher ...`, glyph files in src/glyphs are not located, emitting these messages:
```
Traceback (most recent call last):
지정된 파일 original-source.otf 은 존재하지 않습니다. (meaning the file does not exist)
  File "font-patcher", line 707, in <module>
    symfont = fontforge.open(__dir__+"/src/glyphs/"+patch['Filename'])
EnvironmentError: Open failed
```
The cause of the error was cured by setting `__dir__` to explicit absolute path.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
fix `__dir__` to have the correct path, not empty in script "font-patcher"