### PR TITLE
Make the install script callable from everywhere

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ done
 shift $(($OPTIND-1))
 
 # Set source and target directories, default: all fonts
-nerdfonts_root_dir="${PWD}/patched-fonts"
+nerdfonts_root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/patched-fonts"
 nerdfonts_dirs=("$nerdfonts_root_dir")
 
 # Accept font / directory names, to avoid installing all fonts


### PR DESCRIPTION
#### Description
Installation would fail if you did not first cd in into the nerd-fonts
directory before running install.sh as $nerdfonts_root_dir referenced
${PWD} which is the path your shell is into when calling the script,
not the basepath of the script, parent of "patched-fonts".

#### Requirements / Checklist
- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Make the install script callable from everywhere.

#### How should this be manually tested?
Run the install script from outside the nerd-fonts root dir.

#### Any background context you can provide?
NA
#### What are the relevant tickets (if any)?
NA
#### Screenshots (if appropriate or helpful)
NA

Thanks for the great work guys, cheers !