### PR TITLE
Add monospace font family to config

### DIFF
--- a/10-nerd-font-symbols.conf
+++ b/10-nerd-font-symbols.conf
@@ -2,6 +2,10 @@
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
   <alias>
+    <family>monospace</family>
+    <prefer><family>Symbols Nerd Font</family></prefer>
+  </alias>
+  <alias>
     <family>Heavy Data</family>
     <prefer><family>Symbols Nerd Font</family></prefer>
   </alias>


### PR DESCRIPTION
#### Description

Added `monospace` family to font config.
This is needed to make "Monospace Regular" (aka DejaVu Sans Mono) work in gnome terminal.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table
