### PR TITLE
Treats fc-cache return of 1 as success

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -290,4 +290,13 @@ esac
 if [[ -n $(which fc-cache) ]]; then
   [ "$quiet" = false ] && fc-cache -vf "$font_dir"
   [ "$quiet" = true ] && fc-cache -f "$font_dir"
+  case $? in
+    [0-1])
+      # Catch fc-cache returning 1 on a success
+      exit 0
+      ;;
+    *)
+      exit $?
+      ;;
+  esac
 fi


### PR DESCRIPTION
Resolves #218 


#### Description

Modifies `install.sh` to treat a return code of 1 from `fc-cache` as a success (and pass 0 through as the return code from the script)

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### How should this be manually tested?
Execute `install.sh` and verify exit code ($?) is 0 on success.

#### What are the relevant tickets (if any)?
#218 
