### PR TITLE
Fix test flag for $__i_weather_loaded

### DIFF
--- a/bin/scripts/lib/i_weather.sh
+++ b/bin/scripts/lib/i_weather.sh
@@ -3,7 +3,7 @@
 # Codepoints: F000, F0EB, Nerd Fonts moved F328-F413
 # Nerd Fonts Version: 2.0.0
 # Script Version 1.0.0
-test _n "$__i_weather_loaded" && return || __i_weather_loaded=1
+test -n "$__i_weather_loaded" && return || __i_weather_loaded=1
 i='' i_weather_day_cloudy_gusts=$i
 i='' i_weather_day_cloudy_windy=$i
 i='' i_weather_day_cloudy=$i


### PR DESCRIPTION
#### Description

Fixes a typo int he test command, changing the underscore in `_n` to a hyphen `-n`.
The underscore caused the test to fail.

#### Requirements / Checklist

- [✅] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [✅] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [✅] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [✅] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [✅] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Corrects a typo in a `test` command flag

#### How should this be manually tested?
`source ./bin/scripts/lib/i_weather.sh`
The above will result in error "-bash: test: _n: unary operator expected" before this change, and no error after.

#### Any background context you can provide?
N/A

#### What are the relevant tickets (if any)?
N/A

#### Screenshots (if appropriate or helpful)
N/A