### PR TITLE
Added chocolatey install scripts

### DIFF
--- a/chocolatey/Pipfile
+++ b/chocolatey/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyyaml = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/chocolatey/Pipfile.lock
+++ b/chocolatey/Pipfile.lock
@@ -1,0 +1,41 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "95508a89f4c6aa1090777242e6a45312cc48d3a587f1abb43929eed9b4f17ca2"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pyyaml": {
+            "hashes": [
+                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
+                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
+                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
+                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
+                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
+                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
+                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
+                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
+                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
+                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
+                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
+                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
+                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
+            ],
+            "index": "pypi",
+            "version": "==3.12"
+        }
+    },
+    "develop": {}
+}

--- a/chocolatey/README.md
+++ b/chocolatey/README.md
@@ -1,0 +1,28 @@
+# Chocolatey packages for nerd-fonts
+
+Script to generate chocolatey packages for nerd-fonts.
+
+## Requirements
+
+- [pipenv](https://github.com/pypa/pipenv/)
+- [PyYAML](https://pyyaml.org/)
+- [chocolatey](https://chocolatey.org/)
+
+## Setup
+
+- Run `pipenv install` to setup the virtual environment.
+- Ensure that `choco` binary is in the `PATH`.
+
+## Usage
+
+Run the `generate_packages.py` which reads `fonts.yml` file and generates the chocolatey packages.
+
+### fonts.yml
+
+The `YAML` file describes the fonts to be packaged.
+
+- `version`: The version of nerd-fonts to be downloaded.
+- `fonts.name`: The name of the nerd-font as per the `github release assets`.
+- `fonts.sha256`: The `SHA256` hash of the zip file.
+- `fonts.installed_fonts`: The list of fonts in the zip file.
+

--- a/chocolatey/base.nuspec
+++ b/chocolatey/base.nuspec
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id></id>
+    <version></version>
+    <packageSourceUrl>https://github.com/ryanoasis/nerd-fonts</packageSourceUrl>
+    <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
+    <owners>ryanoasis</owners>
+    <!-- ============================== -->
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <!-- This section is about the software itself -->
+    <title></title>
+    <authors>Ryan L McIntyre</authors>
+    <!-- projectUrl is required for the community feed -->
+    <projectUrl>https://nerdfonts.com/</projectUrl>
+    <iconUrl>https://imgur.com/pEDFEje</iconUrl>
+    <!-- <copyright>Year Software Vendor</copyright> -->
+    <!-- If there is a license Url available, it is required for the community feed -->
+    <licenseUrl>https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/ryanoasis/nerd-fonts</projectSourceUrl>
+    <docsUrl>https://github.com/ryanoasis/nerd-fonts/wiki</docsUrl>
+    <!--<mailingListUrl></mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/ryanoasis/nerd-fonts/issues</bugTrackerUrl>
+    <tags>hasklig hasklug nerd-fonts fonts ligatures coding-fonts</tags>
+    <summary>
+      Iconic font aggregator, collection, and patcher. 40+ patched fonts, over 3,600
+      glyph/icons, includes popular collections such as Font Awesome &amp; fonts such as Hack.
+    </summary>
+    <description>
+      Nerd Fonts takes popular programming fonts and adds a bunch of Glyphs.
+      There is also a font patcher available if your desired font isn't already patched.
+      For more high level information see the wiki.
+    </description>
+    <releaseNotes>
+# New Features
+  - Added new fonts:
+    - Noto (all variations) (#213)
+    - Overpass Mono (fixes #177)
+    - BigBlue Terminal (fixes #170)
+    - Dyslexic (fixes #217)
+    - Iosevka Term variant (no ligatures) (fixes #198)
+    - FiraCode TTF variant (fixes #244)
+    - SourceCodePro italics variant (fixes #236)
+  - Added new glyph sets:
+    - Material Design Icons
+    - Weather
+  - Added new glyphs to core:
+    - Elm (fixes #172)
+    - Elixir (fixes #228)
+    - Electron (fixes #237)
+  - Added new translations:
+    - Added Traditional Chinese of readme (partially fixes #118) (PR #222) (@MindyTai)
+    - Added French readme (partially fixes #118) (PR #251) (@pgrimaud)
+  - Added ability to remove ligatures via the `--removeligatures` option in font-patcher
+  - Added `--configfile` option to font-patcher
+
+# Updates / Improvements
+  - Updated Hack font to latest version (v3.003) (fixes #216) (with help from @chrissimpkins)
+  - Updated Iosevka to the latest version (v1.14.0) (fixes #229)
+  - Updated Fantasque Sans Mono to the latest version (v1.7.2) (fixes #240)
+  - Updated MPlus version from 1.018 to 1.063
+  - Updated documentation for urxvt wcwidth implementations (fixes #155)
+  - Updated logos and Sankey diagram
+
+# Breaking Updates / Improvements / Changes
+  - Updated Font Logos (formerly Font Linux) to latest version (fixes #157)
+
+# Fixes
+  - Fixed incorrect exitcode returned from installer (fixes #218) (PR #230 @Phuurl)
+  - Fixed 3270 font not being valid/installable on Windows (fixes #12, #196)
+  - Fixed weather variables script typo (PR #242 @snown)
+  - Fixed Monospaced fonts having ligatures by default (fixed Meslo Mono having ligatures) 
+  (fixes #186)
+  - Fixed Hasklig ExtraLight &amp; Light variants (fixes #231)
+    </releaseNotes>
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>

--- a/chocolatey/fonts.yml
+++ b/chocolatey/fonts.yml
@@ -1,0 +1,111 @@
+version: 2.0.0
+fonts:
+  - name: FiraCode
+    sha256: 09894D24BF3D61493DBA052187A9200497135A4B885CB837BCB637AD2E62070F
+    installed_fonts:
+      - Fura Code Bold Nerd Font Complete Mono Windows Compatible.otf
+      - Fura Code Bold Nerd Font Complete Mono Windows Compatible.ttf
+      - Fura Code Bold Nerd Font Complete Mono.otf
+      - Fura Code Bold Nerd Font Complete Mono.ttf
+      - Fura Code Bold Nerd Font Complete Windows Compatible.otf
+      - Fura Code Bold Nerd Font Complete Windows Compatible.ttf
+      - Fura Code Bold Nerd Font Complete.otf
+      - Fura Code Bold Nerd Font Complete.ttf
+      - Fura Code Light Nerd Font Complete Mono Windows Compatible.otf
+      - Fura Code Light Nerd Font Complete Mono Windows Compatible.ttf
+      - Fura Code Light Nerd Font Complete Mono.otf
+      - Fura Code Light Nerd Font Complete Mono.ttf
+      - Fura Code Light Nerd Font Complete Windows Compatible.otf
+      - Fura Code Light Nerd Font Complete Windows Compatible.ttf
+      - Fura Code Light Nerd Font Complete.otf
+      - Fura Code Light Nerd Font Complete.ttf
+      - Fura Code Medium Nerd Font Complete Mono Windows Compatible.otf
+      - Fura Code Medium Nerd Font Complete Mono Windows Compatible.ttf
+      - Fura Code Medium Nerd Font Complete Mono.otf
+      - Fura Code Medium Nerd Font Complete Mono.ttf
+      - Fura Code Medium Nerd Font Complete Windows Compatible.otf
+      - Fura Code Medium Nerd Font Complete Windows Compatible.ttf
+      - Fura Code Medium Nerd Font Complete.otf
+      - Fura Code Medium Nerd Font Complete.ttf
+      - Fura Code Regular Nerd Font Complete Mono Windows Compatible.otf
+      - Fura Code Regular Nerd Font Complete Mono Windows Compatible.ttf
+      - Fura Code Regular Nerd Font Complete Mono.otf
+      - Fura Code Regular Nerd Font Complete Mono.ttf
+      - Fura Code Regular Nerd Font Complete Windows Compatible.otf
+      - Fura Code Regular Nerd Font Complete Windows Compatible.ttf
+      - Fura Code Regular Nerd Font Complete.otf
+      - Fura Code Regular Nerd Font Complete.ttf
+      - Fura Code Retina Nerd Font Complete Mono Windows Compatible.otf
+      - Fura Code Retina Nerd Font Complete Mono Windows Compatible.ttf
+      - Fura Code Retina Nerd Font Complete Mono.otf
+      - Fura Code Retina Nerd Font Complete Mono.ttf
+      - Fura Code Retina Nerd Font Complete Windows Compatible.otf
+      - Fura Code Retina Nerd Font Complete Windows Compatible.ttf
+      - Fura Code Retina Nerd Font Complete.otf
+      - Fura Code Retina Nerd Font Complete.ttf
+  - name: Hasklig
+    sha256: 1FD1D88F2EC48424654888E4C7AFAD7A423E4229F40B09BE323DBF4A04600DBD
+    installed_fonts:
+      - Hasklug Black Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Black Italic Nerd Font Complete Mono.otf
+      - Hasklug Black Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Black Italic Nerd Font Complete.otf
+      - Hasklug Black Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Black Nerd Font Complete Mono.otf
+      - Hasklug Black Nerd Font Complete Windows Compatible.otf
+      - Hasklug Black Nerd Font Complete.otf
+      - Hasklug Bold Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Bold Italic Nerd Font Complete Mono.otf
+      - Hasklug Bold Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Bold Italic Nerd Font Complete.otf
+      - Hasklug Bold Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Bold Nerd Font Complete Mono.otf
+      - Hasklug Bold Nerd Font Complete Windows Compatible.otf
+      - Hasklug Bold Nerd Font Complete.otf
+      - Hasklug ExtraLight Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug ExtraLight Italic Nerd Font Complete Mono.otf
+      - Hasklug ExtraLight Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug ExtraLight Italic Nerd Font Complete.otf
+      - Hasklug ExtraLight Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug ExtraLight Nerd Font Complete Mono.otf
+      - Hasklug ExtraLight Nerd Font Complete Windows Compatible.otf
+      - Hasklug ExtraLight Nerd Font Complete.otf
+      - Hasklug Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Italic Nerd Font Complete Mono.otf
+      - Hasklug Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Italic Nerd Font Complete.otf
+      - Hasklug Light Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Light Italic Nerd Font Complete Mono.otf
+      - Hasklug Light Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Light Italic Nerd Font Complete.otf
+      - Hasklug Light Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Light Nerd Font Complete Mono.otf
+      - Hasklug Light Nerd Font Complete Windows Compatible.otf
+      - Hasklug Light Nerd Font Complete.otf
+      - Hasklug Medium Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Medium Italic Nerd Font Complete Mono.otf
+      - Hasklug Medium Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Medium Italic Nerd Font Complete.otf
+      - Hasklug Medium Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Medium Nerd Font Complete Mono.otf
+      - Hasklug Medium Nerd Font Complete Windows Compatible.otf
+      - Hasklug Medium Nerd Font Complete.otf
+      - Hasklug Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Nerd Font Complete Mono.otf
+      - Hasklug Nerd Font Complete Windows Compatible.otf
+      - Hasklug Nerd Font Complete.otf
+      - Hasklug Semibold Italic Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Semibold Italic Nerd Font Complete Mono.otf
+      - Hasklug Semibold Italic Nerd Font Complete Windows Compatible.otf
+      - Hasklug Semibold Italic Nerd Font Complete.otf
+      - Hasklug Semibold Nerd Font Complete Mono Windows Compatible.otf
+      - Hasklug Semibold Nerd Font Complete Mono.otf
+      - Hasklug Semibold Nerd Font Complete Windows Compatible.otf
+      - Hasklug Semibold Nerd Font Complete.otf
+  - name: Inconsolata
+    sha256: 7EF196CE9FA7B4BC3F9E0290A0DE0FBEFEE123A705BA84A1993D6336A92A5164
+    installed_fonts:
+      - Inconsolata Nerd Font Complete Mono Windows Compatible.otf
+      - Inconsolata Nerd Font Complete Mono.otf
+      - Inconsolata Nerd Font Complete Windows Compatible.otf
+      - Inconsolata Nerd Font Complete.otf

--- a/chocolatey/generate_packages.py
+++ b/chocolatey/generate_packages.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+import os
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+import yaml
+
+XMLNS = {'nuspec': 'http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd'}
+
+
+def pwd():
+    """ Current dir of the script. """
+    return os.path.realpath(os.path.dirname(sys.argv[0]))
+
+
+def kebab_case(inp):
+    """ Convert from `CamelCase` to `kebab-case`. """
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', inp)
+    return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s1).lower()
+
+
+def generate_nuspec(font, version):
+    """ Write the `.nuspec` file. """
+    font_id = kebab_case(font) + '-nerd-font'
+    # Parse the tree
+    tree = ET.parse('base.nuspec')
+    root = tree.getroot()
+    # id
+    id_ = root[0].find('nuspec:id', namespaces=XMLNS)
+    id_.text = font_id
+    # version
+    ver_ = root[0].find('nuspec:version', namespaces=XMLNS)
+    ver_.text = version
+    # title
+    title_ = root[0].find('nuspec:title', namespaces=XMLNS)
+    title_.text = font + ' Nerd Font'
+
+    font_dir = os.path.join(pwd(), font_id)
+    if not os.path.exists(font_dir):
+        os.mkdir(font_dir)
+
+    with open(os.path.join(font_dir, font_id + '.nuspec'), 'wb') as f:
+        f.write(ET.tostring(root, encoding='utf8'))
+
+    # Copy tools
+    tools_src_dir = os.path.join(pwd(), 'tools')
+    tools_dest_dir = os.path.join(font_dir, 'tools')
+    if os.path.exists(tools_dest_dir):
+        shutil.rmtree(tools_dest_dir)
+    shutil.copytree(tools_src_dir, tools_dest_dir)
+
+
+def generate_choco_scripts(font, version, sha256_hash, installed_fonts):
+    """ Generates chocolatey install and uninstall scripts """
+    # Install script
+    font_id = kebab_case(font)
+    tools_dir = os.path.join(pwd(), font_id + '-nerd-font', 'tools')
+    with open(os.path.join(tools_dir, 'chocolateyinstall.ps1'), 'r+') as f:
+        script = f.read()
+        script = script.format(
+            font=font,
+            version='v%s' % (version),
+            hash=sha256_hash)
+        f.seek(0)
+        f.write(script)
+
+    with open(os.path.join(tools_dir, 'chocolateybeforemodify.ps1'), 'r+') as f:
+        script = f.read()
+        script = script.format(fonts=','.join('"%s"' % (x) for x in installed_fonts))
+        f.seek(0)
+        f.write(script)
+
+
+def main():
+    """ Generate chocolatey `.nuspec` files. """
+
+    print('Reading config')
+    with open('fonts.yml') as f:
+        config = yaml.load(f)
+
+    # generate `.nuspec`
+    for font in config['fonts']:
+        print('Generating chocolatey package for', font['name'])
+        generate_nuspec(font['name'], config['version'])
+        generate_choco_scripts(font['name'], config['version'], font['sha256'],
+                               font['installed_fonts'])
+
+    # create choco `.nupkg` package
+    for dir_ in os.listdir(pwd()):
+        if os.path.isdir(dir_) and dir_ != 'tools':
+            subprocess.call
+            print('Packaging', dir_)
+            subprocess.call(['choco', 'pack'], cwd=os.path.join(pwd(), dir_))
+
+    print('Done')
+
+
+if __name__ == '__main__':
+    main()

--- a/chocolatey/tools/Add-Font.ps1
+++ b/chocolatey/tools/Add-Font.ps1
@@ -1,0 +1,614 @@
+﻿#########################################################################################
+#   MICROSOFT LEGAL STATEMENT FOR SAMPLE SCRIPTS/CODE
+#########################################################################################
+#   This Sample Code is provided for the purpose of illustration only and is not 
+#   intended to be used in a production environment.
+#
+#   THIS SAMPLE CODE AND ANY RELATED INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY 
+#   OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED 
+#   WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+#   We grant You a nonexclusive, royalty-free right to use and modify the Sample Code 
+#   and to reproduce and distribute the object code form of the Sample Code, provided 
+#   that You agree: 
+#   (i)    to not use Our name, logo, or trademarks to market Your software product 
+#          in which the Sample Code is embedded; 
+#   (ii)   to include a valid copyright notice on Your software product in which 
+#          the Sample Code is embedded; and 
+#   (iii)  to indemnify, hold harmless, and defend Us and Our suppliers from and 
+#          against any claims or lawsuits, including attorneys’ fees, that arise 
+#          or result from the use or distribution of the Sample Code.
+#########################################################################################
+
+#******************************************************************************
+# File:     Add-Font.ps1
+# Date:     08/28/2013
+# Version:  1.0.1
+#
+# Purpose:  PowerShell script to install Windows fonts.
+#
+# Usage:    Add-Font -help | -path "<Font file or folder path>"
+#
+# Copyright (C) 2010 Microsoft Corporation
+#
+#
+# Revisions:
+# ----------
+# 1.0.0   09/22/2010   Created script.
+# 1.0.1   08/28/2013   Fixed help text.  Added quotes around paths in messages.
+#
+#******************************************************************************
+
+#requires -Version 2.0
+
+#*******************************************************************
+# Declare Parameters
+#*******************************************************************
+param(
+    [string] $path = "",
+    [switch] $help = $false
+)
+
+
+#*******************************************************************
+# Declare Global Variables and Constants
+#*******************************************************************
+
+# Define constants
+set-variable CSIDL_FONTS 0x14 -option constant
+
+# Create hashtable containing valid font file extensions and text to append to Registry entry name.
+$hashFontFileTypes = @{}
+$hashFontFileTypes.Add(".fon", "")
+$hashFontFileTypes.Add(".fnt", "")
+$hashFontFileTypes.Add(".ttf", " (TrueType)")
+$hashFontFileTypes.Add(".ttc", " (TrueType)")
+$hashFontFileTypes.Add(".otf", " (OpenType)")
+# Type 1 fonts require handling multiple resource files.
+# Not supported in this script
+#$hashFontFileTypes.Add(".mmm", "")
+#$hashFontFileTypes.Add(".pbf", "")
+#$hashFontFileTypes.Add(".pfm", "")
+
+# Initialize variables
+$invocation = (Get-Variable MyInvocation -Scope 0).Value
+$scriptPath = Split-Path $Invocation.MyCommand.Path
+$fontRegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
+
+
+#*******************************************************************
+#  Load C# code
+#*******************************************************************
+$fontCSharpCode = @'
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace FontResource
+{
+    public class AddRemoveFonts
+    {
+        private static IntPtr HWND_BROADCAST = new IntPtr(0xffff);
+        private static IntPtr HWND_TOP = new IntPtr(0);
+        private static IntPtr HWND_BOTTOM = new IntPtr(1);
+        private static IntPtr HWND_TOPMOST = new IntPtr(-1);
+        private static IntPtr HWND_NOTOPMOST = new IntPtr(-2);
+        private static IntPtr HWND_MESSAGE = new IntPtr(-3);
+
+        [DllImport("gdi32.dll")]
+        static extern int AddFontResource(string lpFilename);
+
+        [DllImport("gdi32.dll")]
+        static extern int RemoveFontResource(string lpFileName);
+
+        [DllImport("user32.dll",CharSet=CharSet.Auto)]
+        private static extern int SendMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostMessage(IntPtr hWnd, WM Msg, IntPtr wParam, IntPtr lParam);
+
+        public static int AddFont(string fontFilePath) {
+            FileInfo fontFile = new FileInfo(fontFilePath);
+            if (!fontFile.Exists) 
+            {
+                return 0; 
+            }
+            try 
+            {
+                int retVal = AddFontResource(fontFilePath);
+
+                //This version of SendMessage is a blocking call until all windows respond.
+                //long result = SendMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                //Alternatively PostMessage instead of SendMessage to prevent application hang
+                bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                return retVal;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static int RemoveFont(string fontFileName) {
+            //FileInfo fontFile = new FileInfo(fontFileName);
+            //if (!fontFile.Exists) 
+            //{
+            //    return false; 
+            //}
+            try 
+            {
+                int retVal = RemoveFontResource(fontFileName);
+
+                //This version of SendMessage is a blocking call until all windows respond.
+                //long result = SendMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                //Alternatively PostMessage instead of SendMessage to prevent application hang
+                bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                return retVal;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public enum WM : uint
+        {
+            NULL = 0x0000,
+            CREATE = 0x0001,
+            DESTROY = 0x0002,
+            MOVE = 0x0003,
+            SIZE = 0x0005,
+            ACTIVATE = 0x0006,
+            SETFOCUS = 0x0007,
+            KILLFOCUS = 0x0008,
+            ENABLE = 0x000A,
+            SETREDRAW = 0x000B,
+            SETTEXT = 0x000C,
+            GETTEXT = 0x000D,
+            GETTEXTLENGTH = 0x000E,
+            PAINT = 0x000F,
+            CLOSE = 0x0010,
+            QUERYENDSESSION = 0x0011,
+            QUERYOPEN = 0x0013,
+            ENDSESSION = 0x0016,
+            QUIT = 0x0012,
+            ERASEBKGND = 0x0014,
+            SYSCOLORCHANGE = 0x0015,
+            SHOWWINDOW = 0x0018,
+            WININICHANGE = 0x001A,
+            SETTINGCHANGE = WM.WININICHANGE,
+            DEVMODECHANGE = 0x001B,
+            ACTIVATEAPP = 0x001C,
+            FONTCHANGE = 0x001D,
+            TIMECHANGE = 0x001E,
+            CANCELMODE = 0x001F,
+            SETCURSOR = 0x0020,
+            MOUSEACTIVATE = 0x0021,
+            CHILDACTIVATE = 0x0022,
+            QUEUESYNC = 0x0023,
+            GETMINMAXINFO = 0x0024,
+            PAINTICON = 0x0026,
+            ICONERASEBKGND = 0x0027,
+            NEXTDLGCTL = 0x0028,
+            SPOOLERSTATUS = 0x002A,
+            DRAWITEM = 0x002B,
+            MEASUREITEM = 0x002C,
+            DELETEITEM = 0x002D,
+            VKEYTOITEM = 0x002E,
+            CHARTOITEM = 0x002F,
+            SETFONT = 0x0030,
+            GETFONT = 0x0031,
+            SETHOTKEY = 0x0032,
+            GETHOTKEY = 0x0033,
+            QUERYDRAGICON = 0x0037,
+            COMPAREITEM = 0x0039,
+            GETOBJECT = 0x003D,
+            COMPACTING = 0x0041,
+            COMMNOTIFY = 0x0044,
+            WINDOWPOSCHANGING = 0x0046,
+            WINDOWPOSCHANGED = 0x0047,
+            POWER = 0x0048,
+            COPYDATA = 0x004A,
+            CANCELJOURNAL = 0x004B,
+            NOTIFY = 0x004E,
+            INPUTLANGCHANGEREQUEST = 0x0050,
+            INPUTLANGCHANGE = 0x0051,
+            TCARD = 0x0052,
+            HELP = 0x0053,
+            USERCHANGED = 0x0054,
+            NOTIFYFORMAT = 0x0055,
+            CONTEXTMENU = 0x007B,
+            STYLECHANGING = 0x007C,
+            STYLECHANGED = 0x007D,
+            DISPLAYCHANGE = 0x007E,
+            GETICON = 0x007F,
+            SETICON = 0x0080,
+            NCCREATE = 0x0081,
+            NCDESTROY = 0x0082,
+            NCCALCSIZE = 0x0083,
+            NCHITTEST = 0x0084,
+            NCPAINT = 0x0085,
+            NCACTIVATE = 0x0086,
+            GETDLGCODE = 0x0087,
+            SYNCPAINT = 0x0088,
+            NCMOUSEMOVE = 0x00A0,
+            NCLBUTTONDOWN = 0x00A1,
+            NCLBUTTONUP = 0x00A2,
+            NCLBUTTONDBLCLK = 0x00A3,
+            NCRBUTTONDOWN = 0x00A4,
+            NCRBUTTONUP = 0x00A5,
+            NCRBUTTONDBLCLK = 0x00A6,
+            NCMBUTTONDOWN = 0x00A7,
+            NCMBUTTONUP = 0x00A8,
+            NCMBUTTONDBLCLK = 0x00A9,
+            NCXBUTTONDOWN = 0x00AB,
+            NCXBUTTONUP = 0x00AC,
+            NCXBUTTONDBLCLK = 0x00AD,
+            INPUT_DEVICE_CHANGE = 0x00FE,
+            INPUT = 0x00FF,
+            KEYFIRST = 0x0100,
+            KEYDOWN = 0x0100,
+            KEYUP = 0x0101,
+            CHAR = 0x0102,
+            DEADCHAR = 0x0103,
+            SYSKEYDOWN = 0x0104,
+            SYSKEYUP = 0x0105,
+            SYSCHAR = 0x0106,
+            SYSDEADCHAR = 0x0107,
+            UNICHAR = 0x0109,
+            KEYLAST = 0x0109,
+            IME_STARTCOMPOSITION = 0x010D,
+            IME_ENDCOMPOSITION = 0x010E,
+            IME_COMPOSITION = 0x010F,
+            IME_KEYLAST = 0x010F,
+            INITDIALOG = 0x0110,
+            COMMAND = 0x0111,
+            SYSCOMMAND = 0x0112,
+            TIMER = 0x0113,
+            HSCROLL = 0x0114,
+            VSCROLL = 0x0115,
+            INITMENU = 0x0116,
+            INITMENUPOPUP = 0x0117,
+            MENUSELECT = 0x011F,
+            MENUCHAR = 0x0120,
+            ENTERIDLE = 0x0121,
+            MENURBUTTONUP = 0x0122,
+            MENUDRAG = 0x0123,
+            MENUGETOBJECT = 0x0124,
+            UNINITMENUPOPUP = 0x0125,
+            MENUCOMMAND = 0x0126,
+            CHANGEUISTATE = 0x0127,
+            UPDATEUISTATE = 0x0128,
+            QUERYUISTATE = 0x0129,
+            CTLCOLORMSGBOX = 0x0132,
+            CTLCOLOREDIT = 0x0133,
+            CTLCOLORLISTBOX = 0x0134,
+            CTLCOLORBTN = 0x0135,
+            CTLCOLORDLG = 0x0136,
+            CTLCOLORSCROLLBAR = 0x0137,
+            CTLCOLORSTATIC = 0x0138,
+            MOUSEFIRST = 0x0200,
+            MOUSEMOVE = 0x0200,
+            LBUTTONDOWN = 0x0201,
+            LBUTTONUP = 0x0202,
+            LBUTTONDBLCLK = 0x0203,
+            RBUTTONDOWN = 0x0204,
+            RBUTTONUP = 0x0205,
+            RBUTTONDBLCLK = 0x0206,
+            MBUTTONDOWN = 0x0207,
+            MBUTTONUP = 0x0208,
+            MBUTTONDBLCLK = 0x0209,
+            MOUSEWHEEL = 0x020A,
+            XBUTTONDOWN = 0x020B,
+            XBUTTONUP = 0x020C,
+            XBUTTONDBLCLK = 0x020D,
+            MOUSEHWHEEL = 0x020E,
+            MOUSELAST = 0x020E,
+            PARENTNOTIFY = 0x0210,
+            ENTERMENULOOP = 0x0211,
+            EXITMENULOOP = 0x0212,
+            NEXTMENU = 0x0213,
+            SIZING = 0x0214,
+            CAPTURECHANGED = 0x0215,
+            MOVING = 0x0216,
+            POWERBROADCAST = 0x0218,
+            DEVICECHANGE = 0x0219,
+            MDICREATE = 0x0220,
+            MDIDESTROY = 0x0221,
+            MDIACTIVATE = 0x0222,
+            MDIRESTORE = 0x0223,
+            MDINEXT = 0x0224,
+            MDIMAXIMIZE = 0x0225,
+            MDITILE = 0x0226,
+            MDICASCADE = 0x0227,
+            MDIICONARRANGE = 0x0228,
+            MDIGETACTIVE = 0x0229,
+            MDISETMENU = 0x0230,
+            ENTERSIZEMOVE = 0x0231,
+            EXITSIZEMOVE = 0x0232,
+            DROPFILES = 0x0233,
+            MDIREFRESHMENU = 0x0234,
+            IME_SETCONTEXT = 0x0281,
+            IME_NOTIFY = 0x0282,
+            IME_CONTROL = 0x0283,
+            IME_COMPOSITIONFULL = 0x0284,
+            IME_SELECT = 0x0285,
+            IME_CHAR = 0x0286,
+            IME_REQUEST = 0x0288,
+            IME_KEYDOWN = 0x0290,
+            IME_KEYUP = 0x0291,
+            MOUSEHOVER = 0x02A1,
+            MOUSELEAVE = 0x02A3,
+            NCMOUSEHOVER = 0x02A0,
+            NCMOUSELEAVE = 0x02A2,
+            WTSSESSION_CHANGE = 0x02B1,
+            TABLET_FIRST = 0x02c0,
+            TABLET_LAST = 0x02df,
+            CUT = 0x0300,
+            COPY = 0x0301,
+            PASTE = 0x0302,
+            CLEAR = 0x0303,
+            UNDO = 0x0304,
+            RENDERFORMAT = 0x0305,
+            RENDERALLFORMATS = 0x0306,
+            DESTROYCLIPBOARD = 0x0307,
+            DRAWCLIPBOARD = 0x0308,
+            PAINTCLIPBOARD = 0x0309,
+            VSCROLLCLIPBOARD = 0x030A,
+            SIZECLIPBOARD = 0x030B,
+            ASKCBFORMATNAME = 0x030C,
+            CHANGECBCHAIN = 0x030D,
+            HSCROLLCLIPBOARD = 0x030E,
+            QUERYNEWPALETTE = 0x030F,
+            PALETTEISCHANGING = 0x0310,
+            PALETTECHANGED = 0x0311,
+            HOTKEY = 0x0312,
+            PRINT = 0x0317,
+            PRINTCLIENT = 0x0318,
+            APPCOMMAND = 0x0319,
+            THEMECHANGED = 0x031A,
+            CLIPBOARDUPDATE = 0x031D,
+            DWMCOMPOSITIONCHANGED = 0x031E,
+            DWMNCRENDERINGCHANGED = 0x031F,
+            DWMCOLORIZATIONCOLORCHANGED = 0x0320,
+            DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
+            GETTITLEBARINFOEX = 0x033F,
+            HANDHELDFIRST = 0x0358,
+            HANDHELDLAST = 0x035F,
+            AFXFIRST = 0x0360,
+            AFXLAST = 0x037F,
+            PENWINFIRST = 0x0380,
+            PENWINLAST = 0x038F,
+            APP = 0x8000,
+            USER = 0x0400,
+            CPL_LAUNCH = USER+0x1000,
+            CPL_LAUNCHED = USER+0x1001,
+            SYSTIMER = 0x118
+        }
+
+    }
+}
+'@
+Add-Type $fontCSharpCode
+
+
+#*******************************************************************
+# Declare Functions
+#*******************************************************************
+
+#*******************************************************************
+# Function Get-SpecialFolder()
+#
+# Purpose:  Convert a CSIDL string to a folder parh string
+#
+# Input:    $id    CSIDL folder identifier string
+#
+# Returns:  Folder path
+#
+#*******************************************************************
+function Get-SpecialFolder($id)
+{
+    $shell = New-Object –COM "Shell.Application"
+    $folder = $shell.NameSpace($id)
+    $specialFolder = $folder.Self.Path
+    $specialFolder
+}
+
+
+#*******************************************************************
+# Function Add-SingleFont()
+#
+# Purpose:  Install a font file
+#
+# Input:    $file    Font file path
+#
+# Returns:  0 - success, 1 - failure
+#
+#*******************************************************************
+function Add-SingleFont($filePath)
+{
+    try
+    {
+        [string]$filePath = (resolve-path $filePath).path
+        [string]$fileDir  = split-path $filePath
+        [string]$fileName = split-path $filePath -leaf
+        [string]$fileExt = (Get-Item $filePath).extension
+        [string]$fileBaseName = $fileName -replace($fileExt ,"")
+
+        $shell = new-object -com shell.application
+        $myFolder = $shell.Namespace($fileDir)
+        $fileobj = $myFolder.Items().Item($fileName)
+        $fontName = $myFolder.GetDetailsOf($fileobj,21)
+
+        if ($fontName -eq "") { $fontName = $fileBaseName }
+
+        copy-item $filePath -destination $fontsFolderPath
+
+        $fontFinalPath = Join-Path $fontsFolderPath $fileName
+        $retVal = [FontResource.AddRemoveFonts]::AddFont($fontFinalPath)
+
+        if ($retVal -eq 0) {
+            Write-Host "Font `'$($filePath)`'`' installation failed"
+            Write-Host ""
+            1
+        }
+        else
+        {
+            Write-Host "Font `'$($filePath)`' installed successfully"
+            Write-Host ""
+            Set-ItemProperty -path "$($fontRegistryPath)" -name "$($fontName)$($hashFontFileTypes.item($fileExt))" -value "$($fileName)" -type STRING
+            0
+        }
+        ""
+    }
+    catch
+    {
+        Write-Host "An error occured installing `'$($filePath)`'"
+        Write-Host ""
+        Write-Host "$($error[0].ToString())"
+        Write-Host ""
+        $error.clear()
+        1
+    }
+}
+
+
+#*******************************************************************
+# Function Show-Usage()
+#
+# Purpose:   Shows the correct usage to the user.
+#
+# Input:     None
+#
+# Output:    Help messages are displayed on screen.
+#
+#*******************************************************************
+function Show-Usage()
+{
+$usage = @'
+Add-Font.ps1
+This script is used to install Windows fonts.
+
+Usage:
+Add-Font.ps1 -help | -path "<Font file or folder path>"
+
+Parameters:
+
+    -help
+     Displays usage information.
+
+    -path
+     May be either the path to a font file to install or the path to a folder 
+     containing font files to install.  Valid file types are .fon, .fnt,
+     .ttf,.ttc, .otf, .mmm, .pbf, and .pfm
+
+Examples:
+    Add-Font.ps1
+    Add-Font.ps1 -path "C:\Custom Fonts\MyFont.ttf"
+    Add-Font.ps1 -path "C:\Custom Fonts"
+'@
+
+$usage
+}
+
+
+#*******************************************************************
+# Function Process-Arguments()
+#
+# Purpose: To validate parameters and their values
+#
+# Input:   All parameters
+#
+# Output:  Exit script if parameters are invalid
+#
+#*******************************************************************
+function Process-Arguments()
+{
+    ## Write-host 'Processing Arguments'
+
+    if ($unnamedArgs.Length -gt 0)
+    {
+        write-host "The following arguments are not defined:"
+        $unnamedArgs
+    }
+
+    if ($help -eq $true) 
+    { 
+        Show-Usage
+        break
+    }
+
+    if ((Test-Path $path -PathType Leaf) -eq $true)
+    {
+        If ($hashFontFileTypes.ContainsKey((Get-Item $path).Extension))
+        {
+            $retVal = Add-SingleFont $path
+            if ($retVal -ne 0)
+            {
+                exit 1
+            }
+            else
+            {
+                exit 0
+            }
+        }
+        else
+        {
+            "`'$($path)`' not a valid font file type"
+            ""
+            exit 1
+        }
+    }
+    elseif ((Test-Path $path -PathType Container) -eq $true)
+    {
+        $bErrorOccured = $false
+        foreach($file in (Get-Childitem $path))
+        {
+
+            if ($hashFontFileTypes.ContainsKey($file.Extension))
+            {
+                $retVal = Add-SingleFont (Join-Path $path $file.Name)
+                if ($retVal -ne 0)
+                {
+                    $bErrorOccured = $true
+                }
+            }
+            else
+            {
+                "`'$(Join-Path $path $file.Name)`' not a valid font file type"
+                ""
+            }
+        }
+
+        If ($bErrorOccured -eq $true)
+        { 
+            exit 1 
+        }
+        else
+        {
+            exit 0
+        }
+    }
+    else
+    {
+        "`'$($path)`' not found"
+        ""
+        exit 1
+    }
+}
+
+
+#*******************************************************************
+# Main Script
+#*******************************************************************
+
+$fontsFolderPath = Get-SpecialFolder($CSIDL_FONTS)
+Process-Arguments
+

--- a/chocolatey/tools/Remove-Font.ps1
+++ b/chocolatey/tools/Remove-Font.ps1
@@ -1,0 +1,618 @@
+﻿#########################################################################################
+#   MICROSOFT LEGAL STATEMENT FOR SAMPLE SCRIPTS/CODE
+#########################################################################################
+#   This Sample Code is provided for the purpose of illustration only and is not 
+#   intended to be used in a production environment.
+#
+#   THIS SAMPLE CODE AND ANY RELATED INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY 
+#   OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED 
+#   WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+#   We grant You a nonexclusive, royalty-free right to use and modify the Sample Code 
+#   and to reproduce and distribute the object code form of the Sample Code, provided 
+#   that You agree: 
+#   (i)    to not use Our name, logo, or trademarks to market Your software product 
+#          in which the Sample Code is embedded; 
+#   (ii)   to include a valid copyright notice on Your software product in which 
+#          the Sample Code is embedded; and 
+#   (iii)  to indemnify, hold harmless, and defend Us and Our suppliers from and 
+#          against any claims or lawsuits, including attorneys’ fees, that arise 
+#          or result from the use or distribution of the Sample Code.
+#########################################################################################
+
+#******************************************************************************
+# File:     Remove-Font.ps1
+# Date:     08/28/2013
+# Version:  1.0.1
+#
+# Purpose:  PowerShell script to uninstall a Windows font.
+#
+# Usage:    Remove-Font -help | -path "<Font file name>"
+#
+# Copyright (C) 2010 Microsoft Corporation
+#
+#
+# Revisions:
+# ----------
+# 1.0.0   09/22/2010   Created script.
+# 1.0.1   08/28/2013   Now checking if $error[0] is not null before trying to
+#                      echo that value in Remove-SingleFont so as not to
+#                      generate an error when none occurred.
+#
+#******************************************************************************
+
+#requires -Version 2.0
+
+#*******************************************************************
+# Declare Parameters
+#*******************************************************************
+param(
+    [string] $file = "",
+    [switch] $help = $false
+)
+
+
+#*******************************************************************
+# Declare Global Variables and Constants
+#*******************************************************************
+
+# Define constants
+set-variable CSIDL_FONTS 0x14 -option constant
+
+# Create hashtable containing valid font file extensions and text to append to Registry entry name.
+$hashFontFileTypes = @{}
+$hashFontFileTypes.Add(".fon", "")
+$hashFontFileTypes.Add(".fnt", "")
+$hashFontFileTypes.Add(".ttf", " (TrueType)")
+$hashFontFileTypes.Add(".ttc", " (TrueType)")
+$hashFontFileTypes.Add(".otf", " (OpenType)")
+# Type 1 fonts require handling multiple resource files.
+# Not supported in this script
+#$hashFontFileTypes.Add(".mmm", "")
+#$hashFontFileTypes.Add(".pbf", "")
+#$hashFontFileTypes.Add(".pfm", "")
+
+# Initialize variables
+$invocation = (Get-Variable MyInvocation -Scope 0).Value
+$scriptPath = Split-Path $Invocation.MyCommand.Path
+$fontRegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
+
+
+#*******************************************************************
+#  Load C# code
+#*******************************************************************
+$fontCSharpCode = @'
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace FontResource
+{
+    public class AddRemoveFonts
+    {
+        private static IntPtr HWND_BROADCAST = new IntPtr(0xffff);
+        private static IntPtr HWND_TOP = new IntPtr(0);
+        private static IntPtr HWND_BOTTOM = new IntPtr(1);
+        private static IntPtr HWND_TOPMOST = new IntPtr(-1);
+        private static IntPtr HWND_NOTOPMOST = new IntPtr(-2);
+        private static IntPtr HWND_MESSAGE = new IntPtr(-3);
+
+        [DllImport("gdi32.dll")]
+        static extern int AddFontResource(string lpFilename);
+
+        [DllImport("gdi32.dll")]
+        static extern int RemoveFontResource(string lpFileName);
+
+        [DllImport("user32.dll",CharSet=CharSet.Auto)]
+        private static extern int SendMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostMessage(IntPtr hWnd, WM Msg, IntPtr wParam, IntPtr lParam);
+
+        public static int AddFont(string fontFilePath) {
+            FileInfo fontFile = new FileInfo(fontFilePath);
+            if (!fontFile.Exists) 
+            {
+                return 0; 
+            }
+            try 
+            {
+                int retVal = AddFontResource(fontFilePath);
+
+                //This version of SendMessage is a blocking call until all windows respond.
+                //long result = SendMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                //Alternatively PostMessage instead of SendMessage to prevent application hang
+                bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                return retVal;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static int RemoveFont(string fontFileName) {
+            //FileInfo fontFile = new FileInfo(fontFileName);
+            //if (!fontFile.Exists) 
+            //{
+            //    return false; 
+            //}
+            try 
+            {
+                int retVal = RemoveFontResource(fontFileName);
+
+                //This version of SendMessage is a blocking call until all windows respond.
+                //long result = SendMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                //Alternatively PostMessage instead of SendMessage to prevent application hang
+                bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+
+                return retVal;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public enum WM : uint
+        {
+            NULL = 0x0000,
+            CREATE = 0x0001,
+            DESTROY = 0x0002,
+            MOVE = 0x0003,
+            SIZE = 0x0005,
+            ACTIVATE = 0x0006,
+            SETFOCUS = 0x0007,
+            KILLFOCUS = 0x0008,
+            ENABLE = 0x000A,
+            SETREDRAW = 0x000B,
+            SETTEXT = 0x000C,
+            GETTEXT = 0x000D,
+            GETTEXTLENGTH = 0x000E,
+            PAINT = 0x000F,
+            CLOSE = 0x0010,
+            QUERYENDSESSION = 0x0011,
+            QUERYOPEN = 0x0013,
+            ENDSESSION = 0x0016,
+            QUIT = 0x0012,
+            ERASEBKGND = 0x0014,
+            SYSCOLORCHANGE = 0x0015,
+            SHOWWINDOW = 0x0018,
+            WININICHANGE = 0x001A,
+            SETTINGCHANGE = WM.WININICHANGE,
+            DEVMODECHANGE = 0x001B,
+            ACTIVATEAPP = 0x001C,
+            FONTCHANGE = 0x001D,
+            TIMECHANGE = 0x001E,
+            CANCELMODE = 0x001F,
+            SETCURSOR = 0x0020,
+            MOUSEACTIVATE = 0x0021,
+            CHILDACTIVATE = 0x0022,
+            QUEUESYNC = 0x0023,
+            GETMINMAXINFO = 0x0024,
+            PAINTICON = 0x0026,
+            ICONERASEBKGND = 0x0027,
+            NEXTDLGCTL = 0x0028,
+            SPOOLERSTATUS = 0x002A,
+            DRAWITEM = 0x002B,
+            MEASUREITEM = 0x002C,
+            DELETEITEM = 0x002D,
+            VKEYTOITEM = 0x002E,
+            CHARTOITEM = 0x002F,
+            SETFONT = 0x0030,
+            GETFONT = 0x0031,
+            SETHOTKEY = 0x0032,
+            GETHOTKEY = 0x0033,
+            QUERYDRAGICON = 0x0037,
+            COMPAREITEM = 0x0039,
+            GETOBJECT = 0x003D,
+            COMPACTING = 0x0041,
+            COMMNOTIFY = 0x0044,
+            WINDOWPOSCHANGING = 0x0046,
+            WINDOWPOSCHANGED = 0x0047,
+            POWER = 0x0048,
+            COPYDATA = 0x004A,
+            CANCELJOURNAL = 0x004B,
+            NOTIFY = 0x004E,
+            INPUTLANGCHANGEREQUEST = 0x0050,
+            INPUTLANGCHANGE = 0x0051,
+            TCARD = 0x0052,
+            HELP = 0x0053,
+            USERCHANGED = 0x0054,
+            NOTIFYFORMAT = 0x0055,
+            CONTEXTMENU = 0x007B,
+            STYLECHANGING = 0x007C,
+            STYLECHANGED = 0x007D,
+            DISPLAYCHANGE = 0x007E,
+            GETICON = 0x007F,
+            SETICON = 0x0080,
+            NCCREATE = 0x0081,
+            NCDESTROY = 0x0082,
+            NCCALCSIZE = 0x0083,
+            NCHITTEST = 0x0084,
+            NCPAINT = 0x0085,
+            NCACTIVATE = 0x0086,
+            GETDLGCODE = 0x0087,
+            SYNCPAINT = 0x0088,
+            NCMOUSEMOVE = 0x00A0,
+            NCLBUTTONDOWN = 0x00A1,
+            NCLBUTTONUP = 0x00A2,
+            NCLBUTTONDBLCLK = 0x00A3,
+            NCRBUTTONDOWN = 0x00A4,
+            NCRBUTTONUP = 0x00A5,
+            NCRBUTTONDBLCLK = 0x00A6,
+            NCMBUTTONDOWN = 0x00A7,
+            NCMBUTTONUP = 0x00A8,
+            NCMBUTTONDBLCLK = 0x00A9,
+            NCXBUTTONDOWN = 0x00AB,
+            NCXBUTTONUP = 0x00AC,
+            NCXBUTTONDBLCLK = 0x00AD,
+            INPUT_DEVICE_CHANGE = 0x00FE,
+            INPUT = 0x00FF,
+            KEYFIRST = 0x0100,
+            KEYDOWN = 0x0100,
+            KEYUP = 0x0101,
+            CHAR = 0x0102,
+            DEADCHAR = 0x0103,
+            SYSKEYDOWN = 0x0104,
+            SYSKEYUP = 0x0105,
+            SYSCHAR = 0x0106,
+            SYSDEADCHAR = 0x0107,
+            UNICHAR = 0x0109,
+            KEYLAST = 0x0109,
+            IME_STARTCOMPOSITION = 0x010D,
+            IME_ENDCOMPOSITION = 0x010E,
+            IME_COMPOSITION = 0x010F,
+            IME_KEYLAST = 0x010F,
+            INITDIALOG = 0x0110,
+            COMMAND = 0x0111,
+            SYSCOMMAND = 0x0112,
+            TIMER = 0x0113,
+            HSCROLL = 0x0114,
+            VSCROLL = 0x0115,
+            INITMENU = 0x0116,
+            INITMENUPOPUP = 0x0117,
+            MENUSELECT = 0x011F,
+            MENUCHAR = 0x0120,
+            ENTERIDLE = 0x0121,
+            MENURBUTTONUP = 0x0122,
+            MENUDRAG = 0x0123,
+            MENUGETOBJECT = 0x0124,
+            UNINITMENUPOPUP = 0x0125,
+            MENUCOMMAND = 0x0126,
+            CHANGEUISTATE = 0x0127,
+            UPDATEUISTATE = 0x0128,
+            QUERYUISTATE = 0x0129,
+            CTLCOLORMSGBOX = 0x0132,
+            CTLCOLOREDIT = 0x0133,
+            CTLCOLORLISTBOX = 0x0134,
+            CTLCOLORBTN = 0x0135,
+            CTLCOLORDLG = 0x0136,
+            CTLCOLORSCROLLBAR = 0x0137,
+            CTLCOLORSTATIC = 0x0138,
+            MOUSEFIRST = 0x0200,
+            MOUSEMOVE = 0x0200,
+            LBUTTONDOWN = 0x0201,
+            LBUTTONUP = 0x0202,
+            LBUTTONDBLCLK = 0x0203,
+            RBUTTONDOWN = 0x0204,
+            RBUTTONUP = 0x0205,
+            RBUTTONDBLCLK = 0x0206,
+            MBUTTONDOWN = 0x0207,
+            MBUTTONUP = 0x0208,
+            MBUTTONDBLCLK = 0x0209,
+            MOUSEWHEEL = 0x020A,
+            XBUTTONDOWN = 0x020B,
+            XBUTTONUP = 0x020C,
+            XBUTTONDBLCLK = 0x020D,
+            MOUSEHWHEEL = 0x020E,
+            MOUSELAST = 0x020E,
+            PARENTNOTIFY = 0x0210,
+            ENTERMENULOOP = 0x0211,
+            EXITMENULOOP = 0x0212,
+            NEXTMENU = 0x0213,
+            SIZING = 0x0214,
+            CAPTURECHANGED = 0x0215,
+            MOVING = 0x0216,
+            POWERBROADCAST = 0x0218,
+            DEVICECHANGE = 0x0219,
+            MDICREATE = 0x0220,
+            MDIDESTROY = 0x0221,
+            MDIACTIVATE = 0x0222,
+            MDIRESTORE = 0x0223,
+            MDINEXT = 0x0224,
+            MDIMAXIMIZE = 0x0225,
+            MDITILE = 0x0226,
+            MDICASCADE = 0x0227,
+            MDIICONARRANGE = 0x0228,
+            MDIGETACTIVE = 0x0229,
+            MDISETMENU = 0x0230,
+            ENTERSIZEMOVE = 0x0231,
+            EXITSIZEMOVE = 0x0232,
+            DROPFILES = 0x0233,
+            MDIREFRESHMENU = 0x0234,
+            IME_SETCONTEXT = 0x0281,
+            IME_NOTIFY = 0x0282,
+            IME_CONTROL = 0x0283,
+            IME_COMPOSITIONFULL = 0x0284,
+            IME_SELECT = 0x0285,
+            IME_CHAR = 0x0286,
+            IME_REQUEST = 0x0288,
+            IME_KEYDOWN = 0x0290,
+            IME_KEYUP = 0x0291,
+            MOUSEHOVER = 0x02A1,
+            MOUSELEAVE = 0x02A3,
+            NCMOUSEHOVER = 0x02A0,
+            NCMOUSELEAVE = 0x02A2,
+            WTSSESSION_CHANGE = 0x02B1,
+            TABLET_FIRST = 0x02c0,
+            TABLET_LAST = 0x02df,
+            CUT = 0x0300,
+            COPY = 0x0301,
+            PASTE = 0x0302,
+            CLEAR = 0x0303,
+            UNDO = 0x0304,
+            RENDERFORMAT = 0x0305,
+            RENDERALLFORMATS = 0x0306,
+            DESTROYCLIPBOARD = 0x0307,
+            DRAWCLIPBOARD = 0x0308,
+            PAINTCLIPBOARD = 0x0309,
+            VSCROLLCLIPBOARD = 0x030A,
+            SIZECLIPBOARD = 0x030B,
+            ASKCBFORMATNAME = 0x030C,
+            CHANGECBCHAIN = 0x030D,
+            HSCROLLCLIPBOARD = 0x030E,
+            QUERYNEWPALETTE = 0x030F,
+            PALETTEISCHANGING = 0x0310,
+            PALETTECHANGED = 0x0311,
+            HOTKEY = 0x0312,
+            PRINT = 0x0317,
+            PRINTCLIENT = 0x0318,
+            APPCOMMAND = 0x0319,
+            THEMECHANGED = 0x031A,
+            CLIPBOARDUPDATE = 0x031D,
+            DWMCOMPOSITIONCHANGED = 0x031E,
+            DWMNCRENDERINGCHANGED = 0x031F,
+            DWMCOLORIZATIONCOLORCHANGED = 0x0320,
+            DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
+            GETTITLEBARINFOEX = 0x033F,
+            HANDHELDFIRST = 0x0358,
+            HANDHELDLAST = 0x035F,
+            AFXFIRST = 0x0360,
+            AFXLAST = 0x037F,
+            PENWINFIRST = 0x0380,
+            PENWINLAST = 0x038F,
+            APP = 0x8000,
+            USER = 0x0400,
+            CPL_LAUNCH = USER+0x1000,
+            CPL_LAUNCHED = USER+0x1001,
+            SYSTIMER = 0x118
+        }
+
+    }
+}
+'@
+Add-Type $fontCSharpCode
+
+
+#*******************************************************************
+# Declare Functions
+#*******************************************************************
+
+#*******************************************************************
+# Function Get-SpecialFolder()
+#
+# Purpose:  Convert a CSIDL string to a folder parh string
+#
+# Input:    $id    CSIDL folder identifier string
+#
+# Returns:  Folder path
+#
+#*******************************************************************
+function Get-SpecialFolder($id)
+{
+    $shell = New-Object –COM "Shell.Application"
+    $folder = $shell.NameSpace($id)
+    $specialFolder = $folder.Self.Path
+    $specialFolder
+}
+
+
+#*******************************************************************
+# Function Get-RegistryStringNameFromValue()
+#
+# Purpose:  Return the Registry value name
+#
+# Input:    $keyPath    Regsitry key drive path
+#           $valueData  Regsitry value sting data
+#
+# Returns:  Registry string value name
+#
+#*******************************************************************
+function Get-RegistryStringNameFromValue([string] $keyPath, [string] $valueData)
+{
+    $pattern = [Regex]::Escape($valueData)
+
+    foreach($property in (Get-ItemProperty $keyPath).PsObject.Properties)
+    {
+        ## Skip the property if it was one PowerShell added
+        if(($property.Name -eq "PSPath") -or
+            ($property.Name -eq "PSChildName"))
+        {
+            continue
+        }
+        ## Search the text of the property
+        $propertyText = "$($property.Value)"
+        if($propertyText -match $pattern)
+        {
+            "$($property.Name)"
+        }
+    }
+}
+
+
+#*******************************************************************
+# Function Remove-SingleFont()
+#
+# Purpose:  Uninstall a font file
+#
+# Input:    $file    Font file name
+#
+# Returns:  0 - success, 1 - failure
+#
+#*******************************************************************
+function Remove-SingleFont($file)
+{
+    try
+    {
+        $fontFinalPath = Join-Path $fontsFolderPath $file
+        $retVal = [FontResource.AddRemoveFonts]::RemoveFont($fontFinalPath)
+        if ($retVal -eq 0) {
+            Write-Host "Font `'$($file)`' removal failed"
+            Write-Host ""
+            1
+        }
+        else
+        {
+            $fontRegistryvaluename = (Get-RegistryStringNameFromValue $fontRegistryPath $file)
+            Write-Host "Font: $($fontRegistryvaluename)"
+            if ($fontRegistryvaluename -ne "")
+            {
+                Remove-ItemProperty -path $fontRegistryPath -name $fontRegistryvaluename
+            }
+            Remove-Item $fontFinalPath
+            if ($error[0] -ne $null)
+            {
+                Write-Host "An error occured removing $`'$($file)`'"
+                Write-Host ""
+                Write-Host "$($error[0].ToString())"
+                $error.clear()
+            }
+            else
+            {
+                Write-Host "Font `'$($file)`' removed successfully"
+                Write-Host ""
+            }
+            0
+        }
+        ""
+    }
+    catch
+    {
+        Write-Host "An error occured removing `'$($file)`'"
+        Write-Host ""
+        Write-Host "$($error[0].ToString())"
+        Write-Host ""
+        $error.clear()
+        1
+    }
+}
+
+
+#*******************************************************************
+# Function Show-Usage()
+#
+# Purpose:   Shows the correct usage to the user.
+#
+# Input:     None
+#
+# Output:    Help messages are displayed on screen.
+#
+#*******************************************************************
+function Show-Usage()
+{
+$usage = @'
+Remove-Font.ps1
+This script is used to uninstall a Windows font.
+
+Usage:
+Remove-Font.ps1 -help | -path "<Font file name>"
+
+Parameters:
+
+    -help
+     Displays usage information.
+
+    -file
+     Font file name.  Files located in \Windows\Fonts.  Valid file 
+     types are .fon, .fnt, .ttf,.ttc, .otf, .mmm, .pbf, and .pfm
+
+Examples:
+    Remove-Font.ps1
+    Remove-Font.ps1 -file "MyFont.ttf"
+'@
+
+$usage
+}
+
+
+#*******************************************************************
+# Function Process-Arguments()
+#
+# Purpose: To validate parameters and their values
+#
+# Input:   All parameters
+#
+# Output:  Exit script if parameters are invalid
+#
+#*******************************************************************
+function Process-Arguments()
+{
+    ## Write-host 'Processing Arguments'
+
+    if ($unnamedArgs.Length -gt 0)
+    {
+        write-host "The following arguments are not defined:"
+        $unnamedArgs
+    }
+
+    if ($help -eq $true) 
+    { 
+        Show-Usage
+        break
+    }
+
+    $fontFilePath = Join-Path $fontsFolderPath $file
+    if ((Test-Path $fontFilePath -PathType Leaf) -eq $true)
+    {
+        If ($hashFontFileTypes.ContainsKey((Get-Item $fontFilePath).Extension))
+        {
+            $retVal = Remove-SingleFont $file
+            if ($retVal -ne 0)
+            {
+                exit 1
+            }
+            else
+            {
+                exit 0
+            }
+        }
+        else
+        {
+            "`'$($fontFilePath)`' not a valid font file type"
+            ""
+            exit 1
+        }
+    }
+    else
+    {
+        "`'$($fontFilePath)`' not found"
+        ""
+        exit 1
+    }
+}
+
+
+#*******************************************************************
+# Main Script
+#*******************************************************************
+
+$fontsFolderPath = Get-SpecialFolder($CSIDL_FONTS)
+Process-Arguments
+

--- a/chocolatey/tools/chocolateybeforemodify.ps1
+++ b/chocolatey/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,11 @@
+﻿# Removing fonts
+function Get-CurrentDirectory
+{{
+  $thisName = $MyInvocation.MyCommand.Name
+  [IO.Path]::GetDirectoryName((Get-Content function:$thisName).File)
+}}
+
+$RemoveFont = Join-Path (Get-CurrentDirectory) "Remove-Font.ps1"
+foreach ($font in ({fonts})) {{
+  & "$RemoveFont" "$font"
+}}

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+﻿$tools = Split-Path $MyInvocation.MyCommand.Definition
+$package = Join-Path (Split-Path $tools) "fonts"
+ 
+function Get-CurrentDirectory
+{{
+  $thisName = $MyInvocation.MyCommand.Name
+  [IO.Path]::GetDirectoryName((Get-Content function:$thisName).File)
+}}
+
+Install-ChocolateyZipPackage `
+  -PackageName "$env:ChocolateyPackageName" `
+  -Url 'https://github.com/ryanoasis/nerd-fonts/releases/download/{version}/{font}.zip' `
+  -Checksum '{hash}' `
+  -ChecksumType 'SHA256' `
+  -UnzipLocation $package
+ 
+$AddFont = Join-Path (Get-CurrentDirectory) 'Add-Font.ps1'
+& $AddFont -Path "$package"
+Remove-Item -Recurse -Force $package


### PR DESCRIPTION
#### Description

Chocolatey package generation scripts. Added a few fonts that I use. Rest can be added as described in the README.

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [X] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [X] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [X] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Adds chocolatey packages and respective generating scripts.

#### How should this be manually tested?

- Run the `generate_packages.py` to generate chocolatey packages for the fonts.
- Go inside any generated folder and run `choco install <font-id> -s .`
    - e.g: `choco install hasklig-nerd-font -s .`
- Fonts should get installed successfully

#### Any background context you can provide?

Chocolatey is a package manager for windows. Easy installation of fonts using the commands like `choco install hasklig-nerd-font`.

#### What are the relevant tickets (if any)?

#223 

#### Screenshots (if appropriate or helpful)
