### PR TITLE
Fix font table relative urls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -615,7 +615,7 @@ Patched Font internal links
 [p-arimo]:patched-fonts/Arimo
 [p-bigblueterm]:patched-fonts/BigBlueTerminal
 [p-bitstream]:patched-fonts/BitstreamVeraSansMono
-[p-blex]:patched-font/Blex
+[p-blex]:patched-fonts/Blex
 [p-cousine]:patched-fonts/Cousine
 [p-dejavu]:patched-fonts/DejaVuSansMono
 [p-droid]:patched-fonts/DroidSansMono
@@ -635,9 +635,9 @@ Patched Font internal links
 [p-monofur]:patched-fonts/Monofur
 [p-monoid]:patched-fonts/Monoid
 [p-mplus]:patched-fonts/MPlus
-[p-noto]:patched-font/Noto
-[p-opendyslexic]:patched-font/OpenDyslexic
-[p-overpass]:patched-font/Overpass
+[p-noto]:patched-fonts/Noto
+[p-opendyslexic]:patched-fonts/OpenDyslexic
+[p-overpass]:patched-fonts/Overpass
 [p-profont]:patched-fonts/ProFont
 [p-proggy-clean]:patched-fonts/ProggyClean
 [p-roboto]:patched-fonts/RobotoMono

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -632,9 +632,9 @@ Patched Font internal links
 [p-monofur]:patched-fonts/Monofur
 [p-monoid]:patched-fonts/Monoid
 [p-mplus]:patched-fonts/MPlus
-[p-noto]:patched-font/Noto
-[p-opendyslexic]:patched-font/OpenDyslexic
-[p-overpass]:patched-font/Overpass
+[p-noto]:patched-fonts/Noto
+[p-opendyslexic]:patched-fonts/OpenDyslexic
+[p-overpass]:patched-fonts/Overpass
 [p-profont]:patched-fonts/ProFont
 [p-proggy-clean]:patched-fonts/ProggyClean
 [p-roboto]:patched-fonts/RobotoMono


### PR DESCRIPTION
#### Description

Small change really. Fixed some 404ing links in the font table.

#### Requirements / Checklist

- [ X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [ X] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [ X] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ X] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ X] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
