### PR TITLE
Fix Typo on Source Code Pro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ echo $i_oct_heart
 | [ProFont (x11) Nerd Font][p-profont]              |                                   | NO   | 1000    | ![w] ![m2] ![l]   |
 | [ProggyClean Nerd Font][p-proggy-clean]           |                                   | NO   | 2048    | Imperfect         |
 | [Roboto Mono][p-roboto]                           |                                   | NO   | 2048    | ![w] ![m2] ![l]   |
-| [Sauce Code Nerd Font][p-source-code-pro]         | [Source][f-source]                | YES  | 1000    | ![w] ![m2] ![l]   |
+| [Source Code Nerd Font][p-source-code-pro]        | [Source][f-source]                | YES  | 1000    | ![w] ![m2] ![l]   |
 | [Shure Tech Mono Nerd Font*][p-share-tech-mono]   | [Share Tech Mono][f-share]        | YES  | 1000    | ![w] ![m2] ![l]   |
 | [Space Mono Nerd Font][p-space-mono]              | [Space Mono][f-space]             | NO   | 1000    | ![w] ![m2] ![l]   |
 | [Terminess Nerd Font*][p-terminus]                | [Terminus Font][f-terminus]       | YES  | 1000    | ![w] ![m2] ![l]   |


### PR DESCRIPTION
#### Description

The font name should be `Source Code Pro` instead of `Sauce Code Pro`

#### Requirements / Checklist

- [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [ ] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [ ] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table