### PR TITLE
Prepend a full-stop to dir. name

### DIFF
--- a/patched-fonts/Hack/Regular/readme.md
+++ b/patched-fonts/Hack/Regular/readme.md
@@ -54,7 +54,7 @@ Frequently asked questions are answered in our [FAQ](FAQ.md).
 1. Download the [latest version of Hack][ttf_latest].
 2. Extract the files from the archive (`.zip`).
 3. Copy the font files to either your system font folder (often `/usr/share/fonts/`) or user font folder (often `~/.local/share/fonts/` or `/usr/local/share/fonts`).
-4. Copy the font configuration file in `config/fontconfig/` to either the system font configuration folder (often `/etc/fonts/conf.d/`) or the font user folder (often `~/.config/fontconfig/conf.d`)
+4. Copy the font configuration file in `.config/fontconfig/` to either the system font configuration folder (often `/etc/fonts/conf.d/`) or the font user folder (often `~/.config/fontconfig/conf.d`)
 5. Clear and regenerate your font cache and indexes with the following command:
 
 ```


### PR DESCRIPTION
This is a minuscule oversight, but .config is a hidden directory


#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [ ] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [ ] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
