### PR TITLE
Adding PowerShell script to let Windows have one-key-installation.

### DIFF
--- a/patched-fonts/install.ps1
+++ b/patched-fonts/install.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Installs the provided fonts.
+.DESCRIPTION
+    Installs all the provided fonts by default.  The FontName
+    parameter can be used to pick a subset of fonts to install.
+.EXAMPLE
+    C:\PS> ./install.ps1
+    Installs all the fonts located in the Git repository.
+.EXAMPLE
+    C:\PS> ./install.ps1 furamono-, hack-*
+    Installs all the FuraMono and Hack fonts.
+.EXAMPLE
+    C:\PS> ./install.ps1 d* -WhatIf
+    Shows which fonts would be installed without actually installing the fonts.
+    Remove the "-WhatIf" to install the fonts.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    # Specifies the font name to install.  Default value will install all fonts.
+    [Parameter(Position=0)]
+    [string[]]
+    $FontName = '*'
+)
+
+$fontFiles = New-Object 'System.Collections.Generic.List[System.IO.FileInfo]'
+foreach ($aFontName in $FontName) {
+    Get-ChildItem $PSScriptRoot -Filter "${aFontName}.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
+    Get-ChildItem $PSScriptRoot -Filter "${aFontName}.otf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
+}
+
+$fonts = $null
+foreach ($fontFile in $fontFiles) {
+    if ($PSCmdlet.ShouldProcess($fontFile.Name, "Install Font")) {
+        if (!$fonts) {
+            $shellApp = New-Object -ComObject shell.application
+            $fonts = $shellApp.NameSpace(0x14)
+        }
+        $fonts.CopyHere($fontFile.FullName)
+    }
+}


### PR DESCRIPTION
#### Description
The PowerShell script "install.ps1" from the repository of Powerline Fonts works on Nerd Fonts too with the instruction( https://medium.com/@slmeng/how-to-install-powerline-fonts-in-windows-b2eedecace58 ).

#### What does this Pull Request (PR) do?
Adding PowerShell script to let Windows have one-key-installation.

#### How should this be manually tested?
Follow the instruction here, and see if the fonts were installed:
https://medium.com/@slmeng/how-to-install-powerline-fonts-in-windows-b2eedecace58

#### Any background context you can provide?
Since there were no one-key-installation script for Windows in the repository before, I've made some 
attempts and found that this script works just fine.

#### What are the relevant tickets (if any)?
Issue #223

