### PR TITLE
Fix the negative error number

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,7 @@ if [ ! -z "$*" ]; then
       if [[ ! -d "$nerdfonts_root_dir/$font" ]]; then
         echo -e "Font $font doesn't exist. Options are: \\n"
         find "$nerdfonts_root_dir" -maxdepth 1 -type d \( \! -name "$(basename "$nerdfonts_root_dir")" \) -exec basename {} \;
-        exit -1
+        exit 255
       fi
       nerdfonts_dirs=( "${nerdfonts_dirs[@]}" "$nerdfonts_root_dir/$font" )
     fi


### PR DESCRIPTION
#### Description

This fixes the shellcheck error. Running on my laptop, `exit -1` results in an actual return code of 255, so make that explicit.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

This should help with the Travis CI failures.
