### PR TITLE
ignore *.uuid files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ private.cfg
 node_modules
 # Only apps should have lockfiles
 package-lock.json
+# generated *.uuid files
+*.uuid


### PR DESCRIPTION
#### Description

When using the patched-fonts directory directly with let say Gnome, a bunch of *.uuid files are created and polluting the git environment with new files. This make sure those are ignored.

#### Requirements / Checklist

- [ * ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [ * ] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [ * ] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ N/A ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ N/A ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
add *.uuid into the .gitignore file.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
