### PR TITLE
Extend FontNameReplacements for Anka/Coder

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -327,7 +327,8 @@ class font_patcher:
             'Liberation': 'Literation',
             'iAWriter'  : 'iMWriting',
             'iA Writer' : 'iM Writing',
-            'iA-Writer' : 'iM-Writing'
+            'iA-Writer' : 'iM-Writing',
+            'Anka/Coder': 'AnaConder'
         }
 
         # remove overly verbose font names


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Renaming Anka/Coder font to AnaConder, so the script not run into an error because of the / in the name and comply with SIL Open Font License (OFL)

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
