### PR TITLE
Fix link address

### DIFF
--- a/_posts/2017-01-02-features.md
+++ b/_posts/2017-01-02-features.md
@@ -101,7 +101,7 @@ style: container
           <!-- <h4>colorls</h4> --><p>A Ruby gem that beautifies the terminal's ls command, with color and font-awesome icons</p>
         </div>
         <div class="col-xs-12 col-md-3 col-lg-4">
-          <a href="https://github.com/ryanoasis/vim-devicons" target="_blank" aria-label="Go to The Fish Shell Framework Github Page" rel="noreferrer">
+          <a href="https://github.com/oh-my-fish/oh-my-fish" target="_blank" aria-label="Go to The Fish Shell Framework Github Page" rel="noreferrer">
           <h3><img src="/assets/img/Fish-Shell-Network.svg" alt="The Fish Shell Framework" /></h3>
           <h4>The Fish Shell Framework</h4></a><p>Oh My Fish provides core infrastructure to allow you to install packages which extend or modify the look of your shell. It's fast, extensible and easy to use.</p>
         </div>


### PR DESCRIPTION
#### Description

The link to the fish shell on the home page points to vim-devicons. This PR fixes it.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
