### PR TITLE
Bugfix/diacritics in mono

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -784,6 +784,11 @@ class font_patcher:
         """ Makes self.sourceFont monospace compliant """
 
         for glyph in self.sourceFont.glyphs():
+            if (glyph.width == self.font_dim['width']):
+                # Don't tough the (negative) bearings if the width is ok
+                # Ligartures will have these.
+                continue
+
             self.remove_glyph_neg_bearings(glyph)
             self.set_glyph_width_mono(glyph)
 

--- a/font-patcher
+++ b/font-patcher
@@ -789,7 +789,14 @@ class font_patcher:
                 # Ligartures will have these.
                 continue
 
-            self.remove_glyph_neg_bearings(glyph)
+            if (glyph.width != 0):
+                # If the width is zero this glyph is intened to be printed on top of another one.
+                # In this case we need to keep the negative bearings to shift it 'left'.
+                # Things like &Auml; have these: composed of U+0041 'A' and U+0308 'double dot above'
+                #
+                # If width is not zero, correct the bearings such that they are within the width:
+                self.remove_glyph_neg_bearings(glyph)
+
             self.set_glyph_width_mono(glyph)
 
 


### PR DESCRIPTION
#### Description

For some reason reading a font into `fontforge` looses data on glyphs. As
a workaround the `font-patcher` script has the switch `--mono` to
ascertain an equal width of all glyphs. An example is Cascadia Code, that is detected as monospaced by Windows. Reading in and just generating creates a font that is not detected as monospaced by Windows anymore.

But the `--mono` switch has issues, that this PR shall fix.

The `--mono` switch works in two steps: First each glyph is checked for
negative bearings. If these are found they are set to hard fixed zero.
Afterwards the glyph width is set to the font global width.
    
The ligature glyphs of previously monospaced fonts have already the correct width,
they just have negative bearings that they indeed need.
here is no reason to change the (correct) bearings to get a monospaced font.
In strict monospaced fonts that would be impossible, but the ligatures are only used in
applications that could work with negative bearings and so they should
be there. Strict monospaced usage does ignore the bearings anyhow.

**Change: Do not change bearings if width is already ok**

Some glyphs are just used as overlays for 'real' glyphs. These can be
for example U+0300 .. U+036F (the 'COMBINING ...' diactritics) like
* U+0300, gravecomb, COMBINING GRAVE ACCENT
* U+0301, acutecomb, COMBINING ACUTE ACCENT
* U+0308, uni0308, COMBINING DIAERESIS
    
They are never used on their own, at least they are overlayed over a
blanc (U+0020, space).
    
For the font rendering engine they need to have the correct negative
bearings, so they are shifted to take no space by themselves.
    
The font-patcher script does not allow negative bearings in monospaced
fonts. This makes sense if every glyph is in itself a 'letter' that
should not reach beyond it's allotted (monospaced) space.

Overlay glyphs can be identified by the width of zero.    

**Change: Do not change bearings of overlay glyphs**

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Change the `font-patcher`'s `--mono` mode such that:
* Do not change bearings if width is already ok
* Do not change bearings of overlay glyphs

#### How should this be manually tested?

Patch some fonts like Inconsolata and Cascadia Code with `--mono`.
Check that Windows detects them as monospaced.
Check &Auml; (not on the console but in a real font rendering application)
Check ligatures (e.g. `!=` (Cascadia Code has them) in for example Visual Code with ligature mode enabled.

#### Any background context you can provide?

This came up when working on a Nerd Font patched version of Cascadia Code [here](https://github.com/adam7/delugia-code). [This](https://github.com/adam7/delugia-code/pull/12) is the relevant PR over there.

#### What are the relevant tickets (if any)?
PR #374

#### Screenshots (if appropriate or helpful)

Shifted (too far right) ligatures of `--mono` patched Cascadia Code in Visual Studio:

![Selection_239](https://user-images.githubusercontent.com/16012374/67461629-0abbdd00-f63e-11e9-8661-f598567102a4.png)

which are `::` `!=` `++` `==` in this snippet.

Wrong placement of diacritics:

![CascadiaCodeNerdFontM-Regular  Cascadia Code Nerd Font Mono ttf (UnicodeBmp)_247](https://user-images.githubusercontent.com/16012374/67462040-0fcd5c00-f63f-11e9-89fa-fdbcf825d54b.png)

(Note glyphs in bottom 4 rows.)

Be careful, in strictly monospaced usage the font looks ok (see below), the bug is visible only in a propotional-font-able application. The same font (that has the issues shown above) works fine on the console:

![Terminal_248](https://user-images.githubusercontent.com/16012374/67462788-7dc65300-f640-11e9-8779-b7845e83841d.png)

(Note `// Äther` comment and correct non-ligature `!=` etc.)