### PR TITLE
Mark an outdated AUR font package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,7 +276,7 @@ cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complet
 The following fonts are available via [AUR packages](https://aur.archlinux.org/) on Arch Linux:
 
 * [Nerd Fonts Complete (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete (single-width)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
+* [Nerd Fonts Complete (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
 * [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
 * [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
 * [Nerd Fonts Git (out of date)](https://aur.archlinux.org/packages/nerd-fonts-git/)


### PR DESCRIPTION
#### Description

Package nerd-fonts-complete-mono-glyphs in AUR is out of date since 2017-10-03. I added a little text next to it in readme.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
