### PR TITLE
fix src in elixir screenshot img tag

### DIFF
--- a/patched-fonts/FiraCode/readme.md
+++ b/patched-fonts/FiraCode/readme.md
@@ -34,7 +34,7 @@ Erlang:
 
 Elixir:
 
-<img src="/showcases/elixir.png">
+<img src="./showcases/elixir.png">
 
 Go:
 


### PR DESCRIPTION
#### Description

fixes img src url for elixir screenshot in readme

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
fixes img src url for elixir screenshot in readme

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
