### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+!src/glyphs/*.*
+!font-patcher
+!bin/scripts/docker-entrypoint.sh

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,25 @@
+name: Docker release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - bin/scripts/docker-entrypoint.sh
+      - src/glyphs/**
+      - .dockerignore
+      - Dockerfile
+      - font-patcher
+
+jobs:
+  publish-image:
+    name: Publish image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build -t nerdfonts/patcher .
+      - name: Push image
+        run: |
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PAT }}
+          docker push nerdfonts/patcher

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.11
+
+LABEL org.opencontainers.image.title="Nerd Fonts Patcher" \
+      org.opencontainers.image.description="Patches developer targeted fonts with a high number of glyphs (icons)." \
+      org.opencontainers.image.url="https://www.nerdfonts.com/" \
+      org.opencontainers.image.source="https://github.com/ryanoasis/nerd-fonts" \
+      org.opencontainers.image.licenses="MIT"
+
+RUN apk add fontforge --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+    apk add --no-cache py2-pip && \
+    pip install configparser
+
+# sys.stdout.write encoding (py)
+ENV PYTHONIOENCODING=utf-8
+
+VOLUME /in /out
+COPY . /nerd
+
+ENTRYPOINT [ "/bin/sh", "/nerd/bin/scripts/docker-entrypoint.sh" ]

--- a/bin/scripts/docker-entrypoint.sh
+++ b/bin/scripts/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+skip=false
+args=""
+
+# Discard --out option
+for i; do
+    [ "${i}" != "${i% *}" ] && i="\"$i\""
+    if [ "$i" = "--out" ] || [ "$i" = "-o" ]; then
+        skip=true
+    else
+        if [ "$skip" = false ] || [ "$i" == "-*" ]; then
+            args="$args $i"
+        fi
+        skip=false
+    fi
+done
+
+for f in /in/*.otf /in/*.ttf /in/*.woff /in/*.eot; do [ -f $f ] && fontforge -script /nerd/font-patcher -out /out $args $f; done

--- a/readme.md
+++ b/readme.md
@@ -303,6 +303,7 @@ Patching the font of your own choosing for use with the [VimDevIcons ➶][vim-de
 * requires: Python 2 (or Python 3), `python-fontforge` package (version `20141231` or later, see
   the [install instructions](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * alternative install method on OSX: `brew install fontforge`
+* alternative method using Docker: [Docker Hub](https://hub.docker.com/r/nerdfonts/patcher)
 * Usage:
 
 ```
@@ -315,6 +316,11 @@ Patching the font of your own choosing for use with the [VimDevIcons ➶][vim-de
 ./fontforge -script font-patcher PATH_TO_FONT
 ```
 
+* Patching fonts with Docker:
+
+```
+docker run -v /path/to/fonts:/in -v /path/for/output:/out nerdfonts/patcher [OPTIONS]
+```
 
 ```
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
@@ -389,7 +395,8 @@ optional arguments:
 	./font-patcher Inconsolata.otf --fontawesome
 	./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons
 	./font-patcher Inconsolata.otf
-
+    docker run --rm -v ~/myfont/patchme:/in -v ~/myfont/patched:/out nerdfonts/patcher
+    docker run --rm -v ~/Desktop/myfont/patchme:/in -v ~/Desktop/myfont/patched:/out nerdfonts/patcher --fontawesome
 
 <a name="gotta-patch-em-all"></a>
 ## Gotta Patch 'em All Font Patcher!


### PR DESCRIPTION
#### Description

The changes introduce Docker support for Nerd Fonts.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

- Adds a `Dockerfile` alongside `.dockerignore` and a shell script that serves as the entrypoint of the container
- Defines a GitHub Actions workflow for continuous deployment of the image. Of course, any other CI/CD tooling of your choice may be used
- Extends the README with text passages on how to use the image
- References a Docker Hub repository I have created for the project (`nerdfonts/patcher`)

The PR requires some follow-up work:

- Invitation of the project's owner to the Docker Hub organization and transfer of its ownership
- Creation of a [personal access token](https://docs.docker.com/docker-hub/access-tokens/)
- Definition of two [repository secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) `DOCKER_USER` and `DOCKER_PAT` for pushing images to Docker Hub
- README translation

#### How should this be manually tested?

I did an initial push to the Docker repository for testing purposes. You can test the image by following the [instructions](https://hub.docker.com/r/nerdfonts/patcher) on the repository site.

#### Any background context you can provide?

Especially on Windows, the Fonts Patcher is inconvenient to use. An official Docker image would give users an easy-to-use alternative and a possibility to use the latest version of the Fonts Patcher in a pre-configured environment or as part of build pipelines.

#### What are the relevant tickets (if any)?

This PR relates to issue #422 . I have worked on the changes before stumbling over the issue. The Dockerfile is very similar @carlosedp 's work and introduces some improvements: I could greatly reduce the image size by basing the image on Alpine Linux and defined a custom entrypoint so that users can pass options into the container analogous to how you would use the CLI.

#### Screenshots (if appropriate or helpful)

❌