### PR TITLE
Change bearing to `int`, since an int is expected

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -817,12 +817,12 @@ class font_patcher:
 
 
     def remove_glyph_neg_bearings(self, glyph):
-        """ Sets passed glyph's bearings 0.0 if they are negative. """
+        """ Sets passed glyph's bearings 0 if they are negative. """
         try:
-            if glyph.left_side_bearing < 0.0:
-                glyph.left_side_bearing = 0.0
-            if glyph.right_side_bearing < 0.0:
-                glyph.right_side_bearing = 0.0
+            if glyph.left_side_bearing < 0:
+                glyph.left_side_bearing = 0
+            if glyph.right_side_bearing < 0:
+                glyph.right_side_bearing = 0
         except:
             pass
 


### PR DESCRIPTION
#### Description

I keep seeing this warning when running `font-patcher`, and realised this is a relatively simple fix. This property expects and `int`, but a `float` is passed and implicitly cast.

This squelches the deprecation warning, and keeps the code future-proof too.

```
/nerd/font-patcher:823: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  glyph.left_side_bearing = 0.0
/nerd/font-patcher:825: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  glyph.right_side_bearing = 0.0
```

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

This squelches the deprecation warning, and keeps the code future-proof too.

#### How should this be manually tested?

Nothing special, just patch a font.

#### Any background context you can provide?

Nothing else to add.

#### What are the relevant tickets (if any)?

(none)

#### Screenshots (if appropriate or helpful)

n/a. console output is included above.