### PR TITLE
[fix] CI's error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,6 @@ language: bash
 # Use container-based infrastructure for quicker build start-up
 sudo: false
 
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
-
-before-script:
-  - "sudo apt-get install cabal-install"
-  - "cabal update"
-  - "cabal install shellcheck"
-
 script:
  - bash -c 'shopt -s globstar; shellcheck --exclude SC2034 **/*.sh'
 


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

I fixed CI's error.

shellcheck comes standard with travis. Therefore, there is no need to install it explicitly. 
With this patch, lint will work properly.

##### reference

> https://github.com/koalaman/shellcheck/wiki/TravisCI

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Fix CI's error.

#### How should this be manually tested?
Nothing. Please see travis-ci's status.

#### Any background context you can provide?

> https://travis-ci.org/github/kazukazuinaina/nerd-fonts/builds/699502908

It ispassing status in my fork repo.

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
