### PR TITLE
Fix font preview link

### DIFF
--- a/_posts/2017-01-03-downloads.md
+++ b/_posts/2017-01-03-downloads.md
@@ -28,7 +28,7 @@ page: font-downloads
         {% if font.linkPreviewFont != false %}
         <h4 class="inlineblock bg-purple border-white text-white nerd-font-button">
           <i class="nf nf-oct-link_external"></i>
-          <a href="https://app.programmingfonts.org/#{{ font.linkPreviewFont }}" target="_blank" alt="Full Preview of {{ font.patchedName }} on ProgrammingFonts.org" class="inlineblock">Preview <span>on ProgrammingFonts.org</span></a>
+          <a href="https://www.programmingfonts.org/#{{ font.linkPreviewFont }}" target="_blank" alt="Full Preview of {{ font.patchedName }} on ProgrammingFonts.org" class="inlineblock">Preview <span>on ProgrammingFonts.org</span></a>
         </h4>
         {% endif %}
       </div>


### PR DESCRIPTION
This appears to be the canonical URL these days. The `app.` subdomain has become a redirect page (with a message explaining that).