### PR TITLE
Updated command for Mac OSX Homebrew install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ All fonts are available via [Homebrew Cask Fonts](https://github.com/Homebrew/ho
 
 ```sh
 brew tap homebrew/cask-fonts
-brew cask install font-hack-nerd-font
+brew install --cask font-hack-nerd-font
 ```
 
 ### `Option 5: Clone the Repo`


### PR DESCRIPTION
#### Description

Using a recent version of Homebrew on Mac OSX, the installation instructions don't work, this change updates the instructions in the README to work with newer versions of Homebrew.


**Steps to reproduce:**
1. install Homebrew version 2.7.0
2. run CLI command `brew cask install font-hack-nerd-font`

**Expected result:** ❔ Nerd Fonts would be installed

**Observed result:** ❌ Error from Homebrew with CLI output `Error: Calling brew cask install is disabled! ...`

**Solution:** ✅ Use the CLI command `brew install --cask font-hack-nerd-font` instead


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- ~`N/A` Scripts execute without error (if necessary):~
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table


#### What does this Pull Request (PR) do?

Updates README docs only.

#### How should this be manually tested? `N/A`

#### Any background context you can provide? `N/A`

#### What are the relevant tickets (if any)? `N/A`

#### Screenshots (if appropriate or helpful)

_CLI output pictured below:_
<img width="820" alt="Screen Shot 2020-12-23 at 10 33 42 AM" src="https://user-images.githubusercontent.com/5464587/103013986-0e7e1480-450c-11eb-9238-db9daa51f933.png">