### PR TITLE
Fix ps installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,10 +8,10 @@
     C:\PS> ./install.ps1
     Installs all the fonts located in the Git repository.
 .EXAMPLE
-    C:\PS> ./install.ps1 furamono-, hack-*
-    Installs all the FuraMono and Hack fonts.
+    C:\PS> ./install.ps1 FiraCode, Hack
+    Installs all the FiraCode and Hack fonts.
 .EXAMPLE
-    C:\PS> ./install.ps1 d* -WhatIf
+    C:\PS> ./install.ps1 DejaVuSansMono -WhatIf
     Shows which fonts would be installed without actually installing the fonts.
     Remove the "-WhatIf" to install the fonts.
 #>

--- a/install.ps1
+++ b/install.ps1
@@ -25,7 +25,7 @@ dynamicparam {
     $ParamAttribute.ParameterSetName = '__AllParameterSets'
     $Attributes.Add($ParamAttribute)
 
-    [string[]]$FontNames = Get-ChildItem $PSScriptRoot -Directory -Name
+    [string[]]$FontNames = Join-Path $PSScriptRoot patched-fonts | Get-ChildItem -Directory -Name
     $Attributes.Add([ValidateSet]::new(($FontNames)))
 
     $Parameter = [Management.Automation.RuntimeDefinedParameter]::new('FontName',  [string[]], $Attributes)
@@ -41,7 +41,7 @@ end {
 
     $fontFiles = [Collections.Generic.List[System.IO.FileInfo]]::new()
 
-    Push-Location $PSScriptRoot
+    Join-Path $PSScriptRoot patched-fonts | Push-Location
     foreach ($aFontName in $FontName) {
         Get-ChildItem $aFontName -Filter "*.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
         Get-ChildItem $aFontName -Filter "*.otf" -Recurse | Foreach-Object {$fontFiles.Add($_)}

--- a/patched-fonts/install.ps1
+++ b/patched-fonts/install.ps1
@@ -24,10 +24,13 @@ param(
 )
 
 $fontFiles = New-Object 'System.Collections.Generic.List[System.IO.FileInfo]'
+
+Push-Location $PSScriptRoot
 foreach ($aFontName in $FontName) {
-    Get-ChildItem $PSScriptRoot -Filter "${aFontName}.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
-    Get-ChildItem $PSScriptRoot -Filter "${aFontName}.otf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
+    Get-ChildItem $aFontName -Filter "*.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
+    Get-ChildItem $aFontName -Filter "*.otf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
 }
+Pop-Location
 
 $fonts = $null
 foreach ($fontFile in $fontFiles) {

--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,12 @@ _Note_: **Requires cloning** the repo as of now
 ./install.sh
 ```
 
+or, in Powershell (Windows only):
+
+```pwsh
+./install.ps1
+```
+
 #### Single font:
 
 * Installs a single Font of your choice
@@ -229,6 +235,14 @@ _Note_: **Requires cloning** the repo as of now
 ./install.sh <FontName>
 ./install.sh Hack
 ./install.sh HeavyData
+```
+
+or, in Powershell (Windows only):
+
+```pwsh
+./install.ps1 <FontName>
+./install.ps1 Hack
+./install.ps1 HeavyData
 ```
 
 ### `Option 4: Homebrew Fonts`


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Fixes Powershell install script for Windows

#### How should this be manually tested?

- Be on Windows
- `./install.ps1 Hack`

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#569 
Possibly, #410 
Related: #357 

#### Screenshots (if appropriate or helpful)

- VS Code settings.json contains `"terminal.integrated.fontFamily": "MesloLGM NF, Hack NF"`
- Powerline theme works:
  ![image](https://user-images.githubusercontent.com/3678789/105926111-414e8780-6039-11eb-9fd1-e2cf9b438ab8.png)
