### PR TITLE
font-patcher: Use correct source font metrics

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -553,6 +553,9 @@ class font_patcher:
                 self.sourceFont.os2_winascent += 1
 
             # Make the line size identical for windows and mac
+            # ! This is broken because hhea* is changed but os2_typo* is not
+            # ! On the other hand we need intact (i.e. original) typo values
+            # ! in get_sourcefont_dimensions() @TODO FIXME
             self.sourceFont.hhea_ascent = self.sourceFont.os2_winascent
             self.sourceFont.hhea_descent = -self.sourceFont.os2_windescent
 
@@ -572,6 +575,9 @@ class font_patcher:
             'width' : 0,
             'height': 0,
         }
+        if self.sourceFont.os2_use_typo_metrics:
+            self.font_dim['ymin'] = self.sourceFont.os2_typodescent
+            self.font_dim['ymax'] = self.sourceFont.os2_typoascent
 
         # Find the biggest char width
         # Ignore the y-values, os2_winXXXXX values set above are used for line height


### PR DESCRIPTION
#### Description

**[why]**
With a source font where Win Ascent/Descent differs from Typo
Ascend/Descent newly added symbols that are intended to be centered
_within the visual space_ can end up too far up or down.

The happens for example when patching CascadiaCode. Added glyphs like
the Ubuntu logo (unicode 0xF31B) is not centered between the square
brackets or on a line with the less then and other centered glyphs.

**[how]**
The calculation takes the Win Ascent/Descent to calculate the visual
hight. That information is a mix of hight and line spacing and can be
misleading.

Therefore, if use_typo_metrics is set in a font, we obey that flag
and use the typo metrics values instead.

**[note]**
Some websites with further information follow.

https://github.com/googlefonts/gf-docs/tree/main/VerticalMetrics
  > Hhea metrics are used in Mac OS X, whilst Microsoft uses
  > Typo when Use_Typo_Metrics is enabled

https://docs.microsoft.com/en-us/typography/opentype/otspec160/os2#fsselection
https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [X] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [X] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [X] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [X] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### How should this be manually tested?

This need visual inspection of the generated fonts. Only some fonts are affected, I will give a list of these in a comment below (with a script that creates that list).

#### Any background context you can provide?

This came up as Issue https://github.com/adam7/delugia-code/issues/53 at [`Delugia Code`](https://github.com/adam7/delugia-code), where we use `font-patcher` also to patch `Cascadia Code`, but with some (few) specialties. That repo stems from the time when `Cascadia Code` was not part of `Nerd Fonts` and is (almost) obsolete now (except for the added specialties).

#### What are the relevant tickets (if any)?

#592 

#### Screenshots (if appropriate or helpful)

Screenshots will follow as comments after the 'affected fonts' list.