### PR TITLE
allow setting custom glyph storage directory

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -85,7 +85,7 @@ class font_patcher:
                     if symfont:
                         symfont.close()
                         symfont = None
-                    symfont = fontforge.open(__dir__ + "/src/glyphs/" + patch['Filename'])
+                    symfont = fontforge.open(self.args.glyphdir + patch['Filename'])
 
                     # Match the symbol font size to the source font size
                     symfont.em = self.sourceFont.em
@@ -143,6 +143,7 @@ class font_patcher:
         parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.')
         parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
         parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
+        parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')
 
         # progress bar arguments - https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
         progressbars_group_parser = parser.add_mutually_exclusive_group(required=False)


### PR DESCRIPTION
#### Description

 allow setting custom glyph storage directory

Useful for allowing installation in system wide
locations as a package from the package manager.
This way the script can be installed in /usr/bin
and glyphs can be in /usr/share/nerd-fonts/glyphs.

Signed-off-by: Aisha Tammy <floss@bsd.ac>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table
