### PR TITLE
Add sparse-checkout example to only clone one font

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -244,13 +244,21 @@ brew install --cask font-hack-nerd-font
 
 ### `Option 5: Clone the Repo`
 
-> Best option for **full control**, **all** or **most** of the fonts, or **contributing** to development.
+> Best option for **full control**, **all** or **some** of the fonts, or **contributing** to development.
 
-Cloning of this repository is **not** required nor efficient (mostly due to Repository size) if you are simply only interested in a limited set of fonts.
+A full clone of this repository is **not** required nor efficient (mostly due to Repository size) if you are simply only interested in a limited set of fonts.  
 
-However if you do want to clone the repo be sure to _shallow_ clone:
+If you do want to clone the entire repo be sure to _shallow_ clone:
 ```sh
 git clone --depth 1
+```
+
+If you want to clone a sub-directory, use `git sparse-checkout`. The following example requires `Git v2.26`:
+
+```sh
+git clone --filter=blob:none --sparse git@github.com:ryanoasis/nerd-fonts
+cd nerd-fonts
+git sparse-checkout add patched-fonts/JetBrainsMono
 ```
 
 ### `Option 6: Ad Hoc Curl Download`


### PR DESCRIPTION
#### Description

Sparse-checkout was introduced in git v2.25, and improved in v.2.26 with the add mode. This makes it possible to only clone one font instead of the entire repository. I added a description in the README.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [ ] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Add documentation

#### How should this be manually tested?

By performing the steps added

#### Any background context you can provide?

I wanted to to use git but did not want to download the entire repo

#### What are the relevant tickets (if any)?

n/a

#### Screenshots (if appropriate or helpful)

n/a
