### PR TITLE
font-patcher: remove_ligatures() never displays warnings

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -413,10 +413,10 @@ class font_patcher:
                     print("Successfully removed subtable:", subtable)
                 except Exception:
                     print("Failed to remove subtable:", subtable)
-            elif self.args.removeligatures:
-                print("Unable to read configfile, unable to remove ligatures")
-            else:
-                print("No configfile given, skipping configfile related actions")
+        elif self.args.removeligatures:
+            print("Unable to read configfile, unable to remove ligatures")
+        else:
+            print("No configfile given, skipping configfile related actions")
 
 
     def check_position_conflicts(self):


### PR DESCRIPTION
https://github.com/ryanoasis/nerd-fonts/blob/bc4416e176d4ac2092345efd7bcb4abef9d6411e/font-patcher#L416-L419

It seems that the `elif` block is meant to check the case where:
  - `--removeligatures` is set
  - AND no config file is provided.

I guess those blocks are over-indented? For now, no warning or info message is printed even in the very case.