### PR TITLE
Add Caskyadia Mono to RFN replacements

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -347,7 +347,7 @@ class font_patcher:
             'Cascadia Code'  : 'Caskaydia Cove',
             'cascadia code'  : 'caskaydia cove',
             'CascadiaCode'   : 'CaskaydiaCove',
-            'cascadiacode'   : 'caskaydiacove'
+            'cascadiacode'   : 'caskaydiacove',
             'Cascadia Mono'  : 'Caskaydia Mono',
             'cascadia mono'  : 'caskaydia mono',
             'CascadiaMono'   : 'CaskaydiaMono',

--- a/font-patcher
+++ b/font-patcher
@@ -348,6 +348,10 @@ class font_patcher:
             'cascadia code'  : 'caskaydia cove',
             'CascadiaCode'   : 'CaskaydiaCove',
             'cascadiacode'   : 'caskaydiacove'
+            'Cascadia Mono'  : 'Caskaydia Mono',
+            'cascadia mono'  : 'caskaydia mono',
+            'CascadiaMono'   : 'CaskaydiaMono',
+            'cascadiamono'   : 'caskaydiamono'
         }
 
         # remove overly verbose font names


### PR DESCRIPTION
#### Description

Add Caskyadia Mono to RFN replacements.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Add Caskyadia Mono to RFN replacements.

#### How should this be manually tested?

Manually patch Cascadia Mono, the font should be renamed to Caskyadia Mono.

#### Any background context you can provide?

#601

#### What are the relevant tickets (if any)?

#601

#### Screenshots (if appropriate or helpful)

Test results at https://github.com/BiscuitTin/nerd-fonts/actions/runs/1451664880.
