### PR TITLE
Bugfix/fstype font does not open

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -51,7 +51,10 @@ class font_patcher:
         self.extension = ""
         self.setup_arguments()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
-        self.sourceFont = fontforge.open(self.args.font, ("fstypepermitted",))
+        try:
+            self.sourceFont = fontforge.open(self.args.font, ("fstypepermitted",))
+        except Exception:
+            sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
         self.setup_font_names()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)

--- a/font-patcher
+++ b/font-patcher
@@ -51,7 +51,7 @@ class font_patcher:
         self.extension = ""
         self.setup_arguments()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
-        self.sourceFont = fontforge.open(self.args.font)
+        self.sourceFont = fontforge.open(self.args.font, ("fstypepermitted",))
         self.setup_font_names()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

2 commits:

##### font-patcher: Allow processing of fonts with fsType set
    
[why]
Through fsType certain restrictions can be set on a font. When fontforge
is used in interactive mode the user can override the restrictions with
a popup dialogue. The font-patcher script dies instead, without any
meaningful message.
    
[how]
Allow the script to ignore fsType settings when opening.
The restrictions will still persist into the generated patched font.
    
[note]
This came up with Bicubik by Anton Kudin, that has fsType = 2
(modification restriction) set.
    
Fixes: #686

##### font-patcher: Fail with meaningful message if font can not be opened
    
[why]
When fontforge is not able to open the font we fail with a meaninless
exception. Users might think that the font-patcher script itself is
broken.
    
[how]
Exit the script with a hint how to get more information if fontforge was
not able to open the font.
