### PR TITLE
font-patcher: Really set SubFamily to what we want

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -394,7 +394,12 @@ class font_patcher:
         self.sourceFont.appendSFNTName(str('English (US)'), str('Preferred Family'), self.sourceFont.familyname)
         self.sourceFont.appendSFNTName(str('English (US)'), str('Family'), self.sourceFont.familyname)
         self.sourceFont.appendSFNTName(str('English (US)'), str('Compatible Full'), self.sourceFont.fullname)
-        self.sourceFont.appendSFNTName(str('English (US)'), str('SubFamily'), subFamily)
+        # Fontforge does not allow to set SubFamily to any value (see commit message), so
+        # instead of self.sourceFont.appendSFNTName(str('English (US)'), str('SubFamily'), subFamily) we do:
+        sfnt_list = list(self.sourceFont.sfnt_names)
+        sfnt_list[subFamilyTupleIndex] = ( sfnt_list[subFamilyTupleIndex][0], sfnt_list[subFamilyTupleIndex][1], subFamily )
+        self.sourceFont.sfnt_names = tuple(sfnt_list)
+
         self.sourceFont.comment = projectInfo
         self.sourceFont.fontlog = projectInfo
 


### PR DESCRIPTION
#### Description

**[why]**  
The most convenient way to set something in the SFNT table is by using
Fontforge's `appendSFNTName()`. When we try to set the _SubFamily_, this
will succeed in many instances, but not in all. Sometimes the function
seems to be ignored.

This is for example the case for `VictorMono-Medium.ttf` where we want to
set the _SubFamily_ `"Regular"`, but the final patched file has the
_SubFamily_ `"Medium"`.

**[how]**  
The reason for the unexpected behavior of Fontforge is as follows. It
almost seems like a bug, but then it is coded explicitely in this way.
Maybe noone ever stumbled about it, or it has only been designed only
with creating new fonts in mind.

Fontforge lets you set any value, unless it is the default value. If it
is the default value it does not set anything. It also does not remove
a previously existing non-default value. Why it is done this way is
unclear:
```
  fontforge/python.c SetSFNTName() line 11431
    return( 1 ); /* If they set it to the default, there's nothing to do */
```

Then is the question: What is the default? It is taken from the
currently set `fontname` (??!). The `fontname` is parsed and everything
behind the dash is the default _SubFamily_:
```
  fontforge/tottf.c DefaultTTFEnglishNames()
  fontforge/splinefont.c _GetModifiers()
```

To stick to the example above, the `fontname` is there
`"VictorMonoNerdFontM-Medium"`. Afterwards we want to set the _SubFamily_ to
`"Medium"` - which is the 'default' and Fontforge decides that nothing has
to be done. Albeigth the current SubFamily is `"Regular"` (from the source
font load).

Well.

To fix this without touching Fontforge we need to set the _SubFamily_
directly in the SFNT table, which is a little bit unhandy but possible.

Now in the generated files the _SubFamily_ is again as expected the same
es the `fontname`'s last part.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
In progress of fixing issue #663 
#### Screenshots (if appropriate or helpful)
`font-patcher` run with debug stuff enabled, see https://gist.github.com/Finii/a496cff7eb38933b169110be3e4e8af2

![image](https://user-images.githubusercontent.com/16012374/143482241-47a8610f-23e6-462e-9016-f990f6128f1d.png)
