### PR TITLE
font-patcher: Reintroduce fsType fix

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -52,7 +52,7 @@ class font_patcher:
         self.setup_arguments()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
         try:
-            self.sourceFont = fontforge.open(self.args.font)
+            self.sourceFont = fontforge.open(self.args.font, 1) # 1 = ("fstypepermitted",))
         except Exception:
             sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
         self.setup_font_names()


### PR DESCRIPTION
#### Description

**[why]**
With commit
  f7d6fcb5 `font-patcher: Allow processing of fonts with fsType set`

we added support for fonts with the fsType set. This came up in
issue #686 with font 'Bicubik'.

The solution in that commit uses (modern) textual flags in the
`fontforge` open() method. But they have been only introduced in 2020,
so people using older `fontforge` could not patch anything anymore.
This has been reported in issue #691.

As a quick fix the fsType support has been removed with commit
  ab6fa3c5 `Reverts part of #687 * the patcher refuses to patch all/most fonts with this flag in the open options`

**[how]**
Revert ab6fa3c5 but use the old fashioned numerical open flags
interface instead.

**[note]**
The textual open() flags have been introduced into `fontforge`s python
interface with their commit

https://github.com/fontforge/fontforge/commit/4a76712f0c74090f8aaab7ba67612d1941f05779
```
  Font Open flag improvements
  * Document more Open flags
  * Add string tuple interface to python FontOpen API
```
#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Reintroduce `fsType` fix as per f7d6fcb5 but avoiding problem with older `fontforge`

#### How should this be manually tested?
Try to patch some font from `src/`, try to patch `Bicubik` (or other `fsTyoe` set font).
Use `fontforge` revision 20190801 or older, **and** revision 20200314 or newer.
Just the ability to open the font is enough, no need to inspect the patched fonts.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

_Edit: Just formatting changes_
_Edit: Add version requirements for tests_