### PR TITLE
font-patcher: Set SFNT Version

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -401,12 +401,13 @@ class font_patcher:
         self.sourceFont.comment = projectInfo
         self.sourceFont.fontlog = projectInfo
 
-        # TODO version not being set for all font types (e.g. ttf)
         # print("Version was {}".format(sourceFont.version))
         if self.sourceFont.version != None:
             self.sourceFont.version += ";" + projectName + " " + version
         else:
             self.sourceFont.version = str(self.sourceFont.cidversion) + ";" + projectName + " " + version
+        self.sourceFont.sfntRevision = None # Auto-set (refreshed) by fontforge
+        self.sourceFont.appendSFNTName(str('English (US)'), str('Version'), "Version " + self.sourceFont.version)
         # print("Version now is {}".format(sourceFont.version))
 
 


### PR DESCRIPTION
#### Description

**[why]**
The Nerd Font Version is not added to the SFNT Version.
This is also a TODO item in `font-patcher`.
The SFNT-Revision is not updated at all.

**[how]**
Set the SFNT Version and Revision.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Set the SFNT Version and let the SFNT Revision be recreated.

#### How should this be manually tested?

#### Any background context you can provide?

`TODO` item in `font-patcher`

#### What are the relevant tickets (if any)?

none

#### Screenshots (if appropriate or helpful)
Here the font is patched first with the `origin/master` version of `font-patcher` and afterwards with this MR applied:

![image](https://user-images.githubusercontent.com/16012374/143840186-964a8ed8-ae49-4d16-a84b-6fb38eb60386.png)

Note the difference in Revision and the changed SFNT Version string.

`query_version` is one of several small `fontforge` helper scripts I use, maybe they should/could be added to `bin/` somewhere. I am unsure if this is appropriate.