### PR TITLE
font-patcher: Improve 'Mono' compatibility with Windows

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -78,6 +78,13 @@ class font_patcher:
             # Force width to be equal on all glyphs to ensure the font is considered monospaced on Windows.
             # This needs to be done on all characters, as some information seems to be lost from the original font file.
             self.set_sourcefont_glyph_widths()
+            # For some Windows applications (e.g. 'cmd') that is not enough. But they seem to honour the Panose table
+            # https://forum.high-logic.com/postedfiles/Panose.pdf
+            panose = list(self.sourceFont.os2_panose)
+            if panose[0] == 0 or panose[0] == 2: # 0 (1st value) = family kind; 0 = any (default); 2 = latin text and display
+                panose[0] = 2 # Assert kind
+                panose[3] = 9 # 3 (4th value) = propotion; 9 = monospaced
+                self.sourceFont.os2_panose = tuple(panose)
 
         # Prevent opening and closing the fontforge font. Makes things faster when patching
         # multiple ranges using the same symbol font.


### PR DESCRIPTION
#### Description

**[why]**
Some of the patched Mono fonts do not turn up in the font chooser
of Windows `CMD` and `PowerShell` (and probably more).

**[how]**
For some reasons Windows does not identify the fonts as being strictly
monospaced, so they are hidden in that font choosers.

For the monospaced fonts we set now the Panose proportion 'monospaced'.
Windows seems to honor the Panose properties.

It is not clear why we need to set the old Panose props, especially as
Cascadia Code does not (!) set them and is still detected as monospaced.

Anyhow, the way Windows detects if a font is monospaced is a mystery (at
least for me), and this works, so ;-)

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Only for `font-patcher --mono`:

Set/overwrite `OS/2` - `Panose` - `Propotion` to `Monospaced`
_WHEN_ `OS/2` - `Panose` - `Family Kind` is `Any` or `Latin-Text`

Set `OS/2` - `Panose` - `Family Kind` to `Latin-Text`
_WHEN_ it was `Any` before

#### How should this be manually tested?
Try to select font in MS-Windows `cmd` application font chooser.

#### Any background context you can provide?
Cheat sheet for Panose: https://forum.high-logic.com/postedfiles/Panose.pdf

#### What are the relevant tickets (if any)?
For example #586 

#### Screenshots (if appropriate or helpful)
