### PR TITLE
font-patcher: Give meaningful error messages on trivial open fails

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -51,6 +51,10 @@ class font_patcher:
         self.extension = ""
         self.setup_arguments()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
+        if not os.path.isfile(self.args.font):
+            sys.exit("{}: Font file does not exist: {}".format(projectName, self.args.font))
+        if not os.access(self.args.font, os.R_OK):
+            sys.exit("{}: Can not open font file for reading: {}".format(projectName, self.args.font))
         try:
             self.sourceFont = fontforge.open(self.args.font)
         except Exception:


### PR DESCRIPTION
#### Description

**[why]**
When the font file is not existing the message we get is either
unreadable or misleading (at least for normal users).

**[how]**
Explicitly state why we can not open a font file, at least in the cases
where we can.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?
Improve error messages on font open fail.

#### How should this be manually tested?
Try to patch a non-existing font file. Try to patch a write-only file.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/issues/512#issuecomment-981716897

#### Screenshots (if appropriate or helpful)
With this MR:

![image](https://user-images.githubusercontent.com/16012374/144001387-5d7a05bf-099e-461b-a034-4e28b597f16d.png)
