### PR TITLE
font-patcher: Remove obsolete metadata on glyph exchange

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -706,16 +706,20 @@ class font_patcher:
             sym_dim = get_glyph_dimensions(sym_glyph)
 
             # check if a glyph already exists in this location
+            if copiedToSlot.startswith("uni"):
+                copiedToSlot = copiedToSlot[3:]
+            codepoint = int("0x" + copiedToSlot, 16)
             if careful or 'careful' in sym_attr['params']:
-                if copiedToSlot.startswith("uni"):
-                    copiedToSlot = copiedToSlot[3:]
-                codepoint = int("0x" + copiedToSlot, 16)
                 if codepoint in self.sourceFont:
                     if self.args.quiet is False:
                         print("  Found existing Glyph at {}. Skipping...".format(copiedToSlot))
-
                     # We don't want to touch anything so move to next Glyph
                     continue
+            else:
+                # If we overwrite an existing glyph all subtable entries regarding it will be wrong
+                # (Probably; at least if we add a symbol and do not substitude a ligature or such)
+                if codepoint in self.sourceFont:
+                    self.sourceFont[codepoint].removePosSub("*")
 
             # Select and copy symbol from its encoding point
             # We need to do this select after the careful check, this way we don't


### PR DESCRIPTION
**[why]**
When we overwrite a glyph that originally had some special handling, be
it a substitution or position table entry (GPOS/GSUB), that special
handling is usually not appropriate anymore and has to be removed.

If we need special lookup table entries for the new glyph we would have
to add them later anyhow, because we can not rely on their existance.

In Issue #509 it was a ligature entry, that replaced 'f' followed by 'i'
with the 'fi' ligature. The ligature glyph is overwritten by us with a
telephone symbol and the substitution table entry makes no sense
anymore.

**[how]**
If we overwrite a preexisting codepoint we remove it from all lookup
tables.

Thanks to all other reporters with details.

Fixes: #509 #254

Reported-by: mangelozzi <mangelozzi@gmail.com>
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Remove obsolete ligature (and other) information on any glyph we replace.

#### How should this be manually tested?

Patch for example
* Overpass
* M+ (also `ffi`)
* Inconsolata
* Ubuntu
* Monaco
* Share Tech Mono (?)

and look if the `fi` ligatures were removed: Either in `fontforge` or by installing the font and typing text in a ligature aware environment (i.e. `writer`) and check that there is no ligature for `fi` anymore.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
