### PR TITLE
font-parser: Allow patching without --ext

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -69,7 +69,7 @@ class font_patcher:
         self.sourceFont.encoding = 'UnicodeFull'  # Update the font encoding to ensure that the Unicode glyphs are available
         self.onlybitmaps = self.sourceFont.onlybitmaps  # Fetch this property before adding outlines. NOTE self.onlybitmaps initialized and never used
         if self.args.extension == "":
-            self.extension = os.path.splitext(self.sourceFont.path)[1]
+            self.extension = os.path.splitext(self.args.font)[1]
         else:
             self.extension = '.' + self.args.extension
 


### PR DESCRIPTION
**[why]**
Sometimes fontforge returns `None` for `font.path`. That should not be the
case according to specs:
```
font.path
    (readonly) Returns a string containing the name of the file from
    which the font was originally read (in this session), or if this
    is a new font, returns a made up filename in the current directory
    named something like “Untitled1.sfd”. See also font.sfd_path.
```
This seems to be the case for fonts that do not have a `fullname` set.
I did not search for nor file any issue at Fontforge.

**[how]**
In fact we already have the original font file name, and we want to
retain its extension anyhow (if nothing is specified), so we use the
filename that we opened to determine the extension.

**[note]**
Related: #412
Related: #641

**[note]**
This was the sole usage of font.path.
Has been introduced with commit d8b760aee which looks uncritical.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [x] Extended the README and documentation if necessary, e.g. You added a new font please update the table

#### What does this Pull Request (PR) do?

Use the specified filename directly to detect the filename instead of the round trip through Fontforge that somehow sometimes fails.

#### How should this be manually tested?

Patch for example `SourceHanCodeJP-Regular.otf` or `Noto Sans CJK Bold.otf`

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
#412 #641
#### Screenshots (if appropriate or helpful)

_Edit: Typo_