### PR TITLE
Update .dockerignore to ensure glyphs are included

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 **
-!src/glyphs/*.*
+!src/glyphs
 !font-patcher
 !bin/scripts/docker-entrypoint.sh


### PR DESCRIPTION
#### Description

This fixes the Docker image build after changes in 9633b4d3 moved `PowerlineSymbols.otf` into a subdirectory. Previously, the `.dockerignore` line for `src/glyphs/*.*` would exclude any subdirectories in `src/glyphs` from being included. Without this change, a complete font build fails:

```
The requested file, PowerlineSymbols.otf, does not exist
Traceback (most recent call last):
  File "/nerd/font-patcher", line 950, in <module>
    main()
  File "/nerd/font-patcher", line 945, in main
    patcher.patch()
  File "/nerd/font-patcher", line 98, in patch
    symfont = fontforge.open(self.args.glyphdir + patch['Filename'])
OSError: Open failed
```

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Read or at least glanced at the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting)
- [x] Read or at least glanced at the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki)
- [x] Scripts execute without error (if necessary):
  - If any of the scripts were modified they have been tested and execute without error, e.g.:
    - `./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons`
    - `./gotta-patch-em-all-font-patcher\!.sh Hermit`
- [ ] Extended the README and documentation if necessary, e.g. You added a new font please update the table
