### PR TITLE
font-patcher: Copy selection instead of continuously regenerating

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -647,10 +647,8 @@ class font_patcher:
             careful = True
 
         if exactEncoding is False:
-            sourceFontList = []
+            sourceFontList = list(range(sourceFontStart, sourceFontEnd + 1))
             sourceFontCounter = 0
-            for i in range(sourceFontStart, sourceFontEnd + 1):
-                sourceFontList.append(format(i, 'X'))
 
         scale_factor = 0
         if scaleGlyph:
@@ -685,25 +683,16 @@ class font_patcher:
             if exactEncoding:
                 # use the exact same hex values for the source font as for the symbol font
                 currentSourceFontGlyph = sym_glyph.encoding
-
-                # Save as a hex string without the '0x' prefix
-                copiedToSlot = format(sym_glyph.unicode, 'X')
             else:
                 # use source font defined hex values based on passed in start and end
-                # convince that this string really is a hex:
-                currentSourceFontGlyph = int("0x" + sourceFontList[sourceFontCounter], 16)
-                copiedToSlot = sourceFontList[sourceFontCounter]
+                currentSourceFontGlyph = sourceFontList[sourceFontCounter]
                 sourceFontCounter += 1
-
-            if int(copiedToSlot, 16) < 0:
-                print("Found invalid glyph slot number. Skipping.")
-                continue
 
             if self.args.quiet is False:
                 if self.args.progressbars:
                     update_progress(round(float(index + 1) / glyphSetLength, 2))
                 else:
-                    progressText = "\nUpdating glyph: " + str(sym_glyph) + " " + str(sym_glyph.glyphname) + " putting at: " + copiedToSlot
+                    progressText = "\nUpdating glyph: {} {} putting at: {:X}".format(sym_glyph, sym_glyph.glyphname, currentSourceFontGlyph)
                     sys.stdout.write(progressText)
                     sys.stdout.flush()
 
@@ -711,20 +700,17 @@ class font_patcher:
             sym_dim = get_glyph_dimensions(sym_glyph)
 
             # check if a glyph already exists in this location
-            if copiedToSlot.startswith("uni"):
-                copiedToSlot = copiedToSlot[3:]
-            codepoint = int("0x" + copiedToSlot, 16)
             if careful or 'careful' in sym_attr['params']:
-                if codepoint in self.sourceFont:
+                if currentSourceFontGlyph in self.sourceFont:
                     if self.args.quiet is False:
-                        print("  Found existing Glyph at {}. Skipping...".format(copiedToSlot))
+                        print("  Found existing Glyph at {:X}. Skipping...".format(currentSourceFontGlyph))
                     # We don't want to touch anything so move to next Glyph
                     continue
             else:
                 # If we overwrite an existing glyph all subtable entries regarding it will be wrong
                 # (Probably; at least if we add a symbol and do not substitude a ligature or such)
-                if codepoint in self.sourceFont:
-                    self.sourceFont[codepoint].removePosSub("*")
+                if currentSourceFontGlyph in self.sourceFont:
+                    self.sourceFont[currentSourceFontGlyph].removePosSub("*")
 
             # Select and copy symbol from its encoding point
             # We need to do this select after the careful check, this way we don't

--- a/font-patcher
+++ b/font-patcher
@@ -669,15 +669,14 @@ class font_patcher:
             symbolFont.selection.select((str("ranges"), str("unicode")), symbolFontStart, symbolFontEnd)
             self.sourceFont.selection.select((str("ranges"), str("unicode")), sourceFontStart, sourceFontEnd)
 
-        # Get number of selected non-empty glyphs @TODO FIXME
-        for index, sym_glyph in enumerate(symbolFont.selection.byGlyphs):
-            glyphSetLength += 1
-        # end for
+        # Get number of selected non-empty glyphs
+        symbolFontSelection = list(symbolFont.selection.byGlyphs)
+        glyphSetLength = len(symbolFontSelection)
 
         if self.args.quiet is False:
             sys.stdout.write("Adding " + str(max(1, glyphSetLength)) + " Glyphs from " + setName + " Set \n")
 
-        for index, sym_glyph in enumerate(symbolFont.selection.byGlyphs):
+        for index, sym_glyph in enumerate(symbolFontSelection):
             index = max(1, index)
 
             try:
@@ -822,12 +821,6 @@ class font_patcher:
             # does not overlap the bearings (edges)
             self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
 
-            # reset selection so iteration works properly @TODO fix? rookie misunderstanding?
-            # This is likely needed because the selection was changed when the glyph was copy/pasted
-            if symbolFontStart == 0:
-                symbolFont.selection.all()
-            else:
-                symbolFont.selection.select((str("ranges"), str("unicode")), symbolFontStart, symbolFontEnd)
         # end for
 
         if self.args.quiet is False or self.args.progressbars:

--- a/font-patcher
+++ b/font-patcher
@@ -776,7 +776,7 @@ class font_patcher:
                 if 'overlap' in sym_attr['params']:
                     scale_ratio_x *= 1 + sym_attr['params']['overlap']
                     scale_ratio_y *= 1 + sym_attr['params']['overlap']
-                self.sourceFont.transform(psMat.scale(scale_ratio_x, scale_ratio_y))
+                self.sourceFont[currentSourceFontGlyph].transform(psMat.scale(scale_ratio_x, scale_ratio_y))
 
             # Use the dimensions from the newly pasted and stretched glyph
             sym_dim = get_glyph_dimensions(self.sourceFont[currentSourceFontGlyph])
@@ -807,7 +807,7 @@ class font_patcher:
                     x_align_distance += overlap_width
 
             align_matrix = psMat.translate(x_align_distance, y_align_distance)
-            self.sourceFont.transform(align_matrix)
+            self.sourceFont[currentSourceFontGlyph].transform(align_matrix)
 
             # Needed for setting 'advance width' on each glyph so they do not overlap,
             # also ensures the font is considered monospaced on Windows by setting the

--- a/font-patcher
+++ b/font-patcher
@@ -663,11 +663,9 @@ class font_patcher:
         # and only copy those that are not already contained in the source font
         if symbolFontStart == 0:
             symbolFont.selection.all()
-            self.sourceFont.selection.all()
             careful = True
         else:
             symbolFont.selection.select((str("ranges"), str("unicode")), symbolFontStart, symbolFontEnd)
-            self.sourceFont.selection.select((str("ranges"), str("unicode")), sourceFontStart, sourceFontEnd)
 
         # Get number of selected non-empty glyphs
         symbolFontSelection = list(symbolFont.selection.byGlyphs)


### PR DESCRIPTION
**[why]**
This is a TODO item. Well, two in fact.

The `symbolFont`'s selection is used for two things
- the main loop to iterate over all glyphs to insert
- to select the one glyph that is actually copied over

Because the main loop uses iterators on the selection.
The iterator is not 'stable' but invalidates if the selection
is changed.
The current code therefor restores the old selection before the loop
jumps to the head again.

This design is not very robust.

[how]
We need the selection to copy the symbol glyph.

But we can rewrite the loop that it does not need the selection at every
iteration, but that the selection is copied into a list, and we loop
over that list - which is independent on a later selection state.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Remove two `TODO` items.

#### How should this be manually tested?

Patch one font with and one without this PR. Compare if symbols that we patch in are there and have same size as before.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

_Edit: Fill how-to-test paragraph_