### PR TITLE
Feature: Allow symbol scaling in nonmono (down to 2 'widths')

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -102,6 +102,9 @@ while getopts ":chijtv-:" option; do
         checkfont)
           activate_checkfont
           ;;
+        help)
+          show_help
+          exit 0;;
         info)
           activate_info
           ;;

--- a/font-patcher
+++ b/font-patcher
@@ -989,10 +989,14 @@ class font_patcher:
         if stretch == 'pa':
             # We want to preserve x/y aspect ratio, so find biggest scale factor that allows symbol to fit
             scale_ratio_x = min(scale_ratio_x, scale_ratio_y)
+            if not self.args.single:
+                # non monospaced fonts just scale down on 'pa', not up
+                scale_ratio_x = min(scale_ratio_x, 1.0)
             scale_ratio_y = scale_ratio_x
         else:
             # Keep the not-stretched direction
-            if not 'x' in stretch:
+            if not self.args.single or not 'x' in stretch:
+                # non monospaced fonts scale y, on 'y' scale request (not x)
                 scale_ratio_x = 1.0
             if not 'y' in stretch:
                 scale_ratio_y = 1.0
@@ -1105,21 +1109,6 @@ class font_patcher:
                 (scale_ratio_x, scale_ratio_y) = (glyph_scale_data[0], glyph_scale_data[0])
             else:
                 (scale_ratio_x, scale_ratio_y) = self.get_scale_factors(sym_dim, sym_attr['stretch'])
-
-            if not self.args.single:
-                # any special logic we want to apply for double-width variation
-                # would go here:
-                # non monospaced fonts scale y, on 'y' scale request
-                # non monospaced fonts just scale down on 'pa', not up
-                if sym_attr['stretch'] == 'pa':
-                    # both scale factors are the same, thus we can limit them
-                    # individually, which is still the same
-                    scale_ratio_x = min(scale_ratio_x, 1.0)
-                    scale_ratio_y = min(scale_ratio_y, 1.0)
-                else:
-                    scale_ratio_x = 1.0
-                    if not 'y' in sym_attr['stretch']:
-                        scale_ratio_y = 1.0
 
             overlap = sym_attr['params'].get('overlap')
 

--- a/font-patcher
+++ b/font-patcher
@@ -969,17 +969,33 @@ class font_patcher:
         # print("FINAL", self.font_dim)
 
 
-    def get_scale_factor(self, sym_dim):
-        scale_ratio = 1
+    def get_scale_factors(self, sym_dim, stretch):
+        """ Get scale in x and y as tuple """
+        # It is possible to have empty glyphs, so we need to skip those.
+        if not sym_dim['width'] or not sym_dim['height']:
+            return (1.0, 1.0)
 
-        # We want to preserve x/y aspect ratio, so find biggest scale factor that allows symbol to fit
-        scale_ratio_x = self.font_dim['width'] / sym_dim['width']
-        scale_ratio_y = self.font_dim['height'] / sym_dim['height']
-        if scale_ratio_x > scale_ratio_y:
-            scale_ratio = scale_ratio_y
+        # For monospaced fonts all chars need to be maximum 'one' space wide
+        target_width = self.font_dim['width']
+        scale_ratio_x = target_width / sym_dim['width']
+
+        # font_dim['height'] represents total line height, keep our symbols sized based upon font's em
+        # Use the font_dim['height'] only for explicit 'y' scaling (not 'pa')
+        target_height = self.font_dim['height']
+        scale_ratio_y = target_height / sym_dim['height']
+
+        if stretch == 'pa':
+            # We want to preserve x/y aspect ratio, so find biggest scale factor that allows symbol to fit
+            scale_ratio_x = min(scale_ratio_x, scale_ratio_y)
+            scale_ratio_y = scale_ratio_x
         else:
-            scale_ratio = scale_ratio_x
-        return scale_ratio
+            # Keep the not-stretched direction
+            if not 'x' in stretch:
+                scale_ratio_x = 1.0
+            if not 'y' in stretch:
+                scale_ratio_y = 1.0
+
+        return (scale_ratio_x, scale_ratio_y)
 
 
     def copy_glyphs(self, sourceFontStart, symbolFont, symbolFontStart, symbolFontEnd, exactEncoding, scaleRules, setName, attributes):
@@ -1039,6 +1055,10 @@ class font_patcher:
                 currentSourceFontGlyph = sourceFontStart + sourceFontCounter
                 sourceFontCounter += 1
 
+            # For debugging process only limited glyphs
+            # if currentSourceFontGlyph != 0xe7bd:
+            #     continue
+
             if not self.args.quiet:
                 if self.args.progressbars:
                     update_progress(round(float(index + 1) / glyphSetLength, 2))
@@ -1077,48 +1097,20 @@ class font_patcher:
 
             # Prepare symbol glyph dimensions
             sym_dim = get_glyph_dimensions(self.sourceFont[currentSourceFontGlyph])
-            scale_ratio_x = 1
-            scale_ratio_y = 1
+            if glyph_scale_data is not None:
+                # This is roughly alike get_scale_factors(glyph_scale_data[1], 'pa')
+                # Except we do not have glyph_scale_data[1] always...
+                (scale_ratio_x, scale_ratio_y) = (glyph_scale_data[0], glyph_scale_data[0])
+            else:
+                (scale_ratio_x, scale_ratio_y) = self.get_scale_factors(sym_dim, sym_attr['stretch'])
 
-            # Now that we have copy/pasted the glyph, if we are creating a monospace
-            # font we need to scale and move the glyphs.  It is possible to have
-            # empty glyphs, so we need to skip those.
-            if self.args.single and sym_dim['width'] and sym_dim['height']:
-                # If we want to preserve that aspect ratio of the glyphs we need to
-                # find the largest possible scaling factor that will allow the glyph
-                # to fit in both the x and y directions
-                if sym_attr['stretch'] == 'pa':
-                    scale_ratio_x = None
-                    if glyph_scale_data:
-                        # We want to preserve the relative size of each glyph in a glyph group
-                        scale_ratio_x = glyph_scale_data[0]
-                    if scale_ratio_x is None:
-                        # In the remaining cases, each glyph is sized independently to each other
-                        scale_ratio_x = self.get_scale_factor(sym_dim)
-                    scale_ratio_y = scale_ratio_x
-                else:
-                    if 'x' in sym_attr['stretch']:
-                        # Stretch the glyph horizontally to fit the entire available width
-                        scale_ratio_x = None
-                        if glyph_scale_data is not None and glyph_scale_data[1] is not None:
-                            scale_ratio_x = self.font_dim['width'] / glyph_scale_data[1]['width']
-                        if scale_ratio_x is None:
-                            scale_ratio_x = self.font_dim['width'] / sym_dim['width']
-            # end if single width
-
-            # non-monospace (double width glyphs)
-            # elif sym_dim['width'] and sym_dim['height']:
-                    # any special logic we want to apply for double-width variation
-                    # would go here
-
-            if 'y' in sym_attr['stretch']:
-                # Stretch the glyph vertically to total line height (good for powerline separators)
-                # Currently stretching vertically for both monospace and double-width
-                scale_ratio_y = None
-                if glyph_scale_data is not None and glyph_scale_data[1] is not None:
-                    scale_ratio_y = self.font_dim['height'] / glyph_scale_data[1]['height']
-                if scale_ratio_y is None:
-                    scale_ratio_y = self.font_dim['height'] / sym_dim['height']
+            if not self.args.single:
+                # any special logic we want to apply for double-width variation
+                # would go here:
+                # non monospaced fonts just scale y, on 'y' scale request (not 'pa')
+                scale_ratio_x = 1.0
+                if not 'y' in sym_attr['stretch']:
+                    scale_ratio_y = 1.0
 
             overlap = sym_attr['params'].get('overlap')
 
@@ -1286,7 +1278,7 @@ class font_patcher:
         #   'bbdims':      [ dim_dict1,   dim_dict2, ] }
         #
         # Each item in 'ScaleGroups' (a range or an explicit list) forms a group of glyphs that shall be
-        # as rescaled all with the same and maximum possible (for the included glyphs) factor.
+        # as rescaled all with the same and maximum possible (for the included glyphs) 'pa' factor.
         # If the 'bbdims' is present they all shall be shifted in the same way.
         #
         # Previously this structure has been used:
@@ -1307,7 +1299,7 @@ class font_patcher:
             scaleRules['ScaleGroups'] = []
         for group in scaleRules['ScaleGroups']:
             sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
-            scale = self.get_scale_factor(sym_dim)
+            scale = self.get_scale_factors(sym_dim, 'pa')[0]
             scaleRules['scales'].append(scale)
             scaleRules['bbdims'].append(sym_dim)
 
@@ -1320,7 +1312,7 @@ class font_patcher:
                 else:
                     group_list.append(i)
             sym_dim = get_glyph_dimensions(symbolFont[scaleRules['ScaleGlyph']])
-            scale = self.get_scale_factor(sym_dim)
+            scale = self.get_scale_factors(sym_dim, 'pa')[0]
             scaleRules['ScaleGroups'].append(group_list)
             scaleRules['scales'].append(scale)
             scaleRules['bbdims'].append(None) # The 'old' style keeps just the scale, not the positioning

--- a/font-patcher
+++ b/font-patcher
@@ -245,6 +245,7 @@ class font_patcher:
         self.sourceFont = None  # class 'fontforge.font'
         self.patch_set = None  # class 'list'
         self.font_dim = None  # class 'dict'
+        self.font_extrawide = False
         self.onlybitmaps = 0
         self.essential = set()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
@@ -274,6 +275,11 @@ class font_patcher:
                 panose[0] = 2 # Assert kind
                 panose[3] = 9 # 3 (4th value) = propotion; 9 = monospaced
                 self.sourceFont.os2_panose = tuple(panose)
+
+        # For very wide (almost square or wider) fonts we do not want to generate 2 cell wide Powerline glyphs
+        if self.font_dim['height'] * 1.8 < self.font_dim['width'] * 2:
+            print("Very wide and short font, disabling 2 cell Powerline glyphs")
+            self.font_extrawide = True
 
         # Prevent opening and closing the fontforge font. Makes things faster when patching
         # multiple ranges using the same symbol font.
@@ -1036,14 +1042,18 @@ class font_patcher:
             sys.stdout.write("Adding " + str(max(1, glyphSetLength)) + " Glyphs from " + setName + " Set \n")
 
         currentSourceFontGlyph = -1 # initialize for the exactEncoding case
+        width_warning = False
 
         for index, sym_glyph in enumerate(symbolFontSelection):
             index = max(1, index)
 
-            try:
-                sym_attr = attributes[sym_glyph.unicode]
-            except KeyError:
+            sym_attr = attributes.get(sym_glyph.unicode)
+            if sym_attr is None:
                 sym_attr = attributes['default']
+
+            if self.font_extrawide:
+                # Do not allow 'xy2' scaling
+                sym_attr['stretch'] = sym_attr['stretch'].replace('2', '')
 
             if exactEncoding:
                 # Use the exact same hex values for the source font as for the symbol font.

--- a/font-patcher
+++ b/font-patcher
@@ -1116,17 +1116,18 @@ class font_patcher:
 
             overlap = sym_attr['params'].get('overlap')
 
-            if scale_ratio_x != 1 or scale_ratio_y != 1:
+            if scale_ratio_x != 1.0 or scale_ratio_y != 1.0:
+                if glyph_scale_data is not None and glyph_scale_data[1] is not None:
+                    dim = glyph_scale_data[1]
+                else:
+                    dim = sym_dim
                 if overlap:
-                    scale_ratio_x *= 1 + overlap
-                    scale_ratio_y *= 1 + overlap
+                    scale_ratio_x *= 1.0 + (self.font_dim['width'] / (dim['width'] * scale_ratio_x)) * overlap
+                    scale_ratio_y *= 1.0 + (self.font_dim['width'] / (dim['width'] * scale_ratio_y)) * overlap
+
                 # Size in x to size in y ratio limit (to prevent over-wide glyphs)
                 xy_ratio_max = sym_attr['params'].get('xy-ratio')
                 if (xy_ratio_max):
-                    if glyph_scale_data is not None and glyph_scale_data[1] is not None:
-                        dim = glyph_scale_data[1]
-                    else:
-                        dim = sym_dim
                     xy_ratio = dim['width'] * scale_ratio_x / (dim['height'] * scale_ratio_y)
                     if xy_ratio > xy_ratio_max:
                         scale_ratio_x = scale_ratio_x * xy_ratio_max / xy_ratio

--- a/font-patcher
+++ b/font-patcher
@@ -720,6 +720,7 @@ class font_patcher:
 
             # Waveform
             0xe0c8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
+            0xe0ca: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
 
             # Hexagons
             0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},

--- a/font-patcher
+++ b/font-patcher
@@ -999,8 +999,7 @@ class font_patcher:
             scale_ratio_y = scale_ratio_x
         else:
             # Keep the not-stretched direction
-            if not self.args.single or not 'x' in stretch:
-                # non monospaced fonts scale y, on 'y' scale request (not x)
+            if not 'x' in stretch:
                 scale_ratio_x = 1.0
             if not 'y' in stretch:
                 scale_ratio_y = 1.0

--- a/font-patcher
+++ b/font-patcher
@@ -1130,7 +1130,7 @@ class font_patcher:
             if overlap:
                 scale_ratio_x *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_x)) * overlap
                 y_overlap = min(0.01, overlap) # never aggressive vertical overlap
-                scale_ratio_y *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_y)) * y_overlap
+                scale_ratio_y *= 1.0 + (self.font_dim['height'] / (sym_dim['height'] * scale_ratio_y)) * y_overlap
 
             # Size in x to size in y ratio limit (to prevent over-wide glyphs)
             xy_ratio_max = sym_attr['params'].get('xy-ratio')

--- a/font-patcher
+++ b/font-patcher
@@ -682,33 +682,33 @@ class font_patcher:
 
             # Arrow tips
             0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
-            0xe0b1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
+            0xe0b1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
             0xe0b2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
-            0xe0b3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
+            0xe0b3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
 
             # Rounded arcs
             0xe0b4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.59}},
-            0xe0b5: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.5}},
+            0xe0b5: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
             0xe0b6: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.59}},
-            0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.5}},
+            0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
 
             # Bottom Triangles
             0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
             0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Top Triangles
             0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
             0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Flames
             0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
-            0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
+            0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
             0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
-            0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
+            0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Small squares
             0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.3.3"
+script_version = "3.4.0"
 
 version = "2.3.0-RC"
 projectName = "Nerd Fonts"
@@ -976,7 +976,8 @@ class font_patcher:
             return (1.0, 1.0)
 
         # For monospaced fonts all chars need to be maximum 'one' space wide
-        target_width = self.font_dim['width']
+        # other fonts allows double width glyphs (for 'pa', 'x' scale target is still one space)
+        target_width = self.font_dim['width'] * (1.0 if self.args.single or stretch != 'pa' else 2.0)
         scale_ratio_x = target_width / sym_dim['width']
 
         # font_dim['height'] represents total line height, keep our symbols sized based upon font's em
@@ -1107,10 +1108,17 @@ class font_patcher:
             if not self.args.single:
                 # any special logic we want to apply for double-width variation
                 # would go here:
-                # non monospaced fonts just scale y, on 'y' scale request (not 'pa')
-                scale_ratio_x = 1.0
-                if not 'y' in sym_attr['stretch']:
-                    scale_ratio_y = 1.0
+                # non monospaced fonts scale y, on 'y' scale request
+                # non monospaced fonts just scale down on 'pa', not up
+                if sym_attr['stretch'] == 'pa':
+                    # both scale factors are the same, thus we can limit them
+                    # individually, which is still the same
+                    scale_ratio_x = min(scale_ratio_x, 1.0)
+                    scale_ratio_y = min(scale_ratio_y, 1.0)
+                else:
+                    scale_ratio_x = 1.0
+                    if not 'y' in sym_attr['stretch']:
+                        scale_ratio_y = 1.0
 
             overlap = sym_attr['params'].get('overlap')
 

--- a/font-patcher
+++ b/font-patcher
@@ -978,7 +978,11 @@ class font_patcher:
 
         # For monospaced fonts all chars need to be maximum 'one' space wide
         # other fonts allows double width glyphs (for 'pa', 'x' scale target is still one space)
-        target_width = self.font_dim['width'] * (1.0 if self.args.single or stretch != 'pa' else 2.0)
+        if self.args.single or stretch != 'pa':
+            relative_width = 1.0
+        else:
+            relative_width = 2.0
+        target_width = self.font_dim['width'] * relative_width
         scale_ratio_x = target_width / sym_dim['width']
 
         # font_dim['height'] represents total line height, keep our symbols sized based upon font's em

--- a/font-patcher
+++ b/font-patcher
@@ -724,7 +724,7 @@ class font_patcher:
             0xe0ca: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
 
             # Hexagons
-            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
             0xe0cd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Legos

--- a/font-patcher
+++ b/font-patcher
@@ -1107,6 +1107,8 @@ class font_patcher:
             # Prepare symbol glyph dimensions
             sym_dim = get_glyph_dimensions(self.sourceFont[currentSourceFontGlyph])
             if glyph_scale_data is not None:
+                if glyph_scale_data[1] is not None:
+                    sym_dim = glyph_scale_data[1] # Use combined bounding box
                 # This is roughly alike get_scale_factors(glyph_scale_data[1], 'pa')
                 # Except we do not have glyph_scale_data[1] always...
                 (scale_ratio_x, scale_ratio_y) = (glyph_scale_data[0], glyph_scale_data[0])
@@ -1114,23 +1116,18 @@ class font_patcher:
                 (scale_ratio_x, scale_ratio_y) = self.get_scale_factors(sym_dim, sym_attr['stretch'])
 
             overlap = sym_attr['params'].get('overlap')
+            if overlap:
+                scale_ratio_x *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_x)) * overlap
+                scale_ratio_y *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_y)) * overlap
+
+            # Size in x to size in y ratio limit (to prevent over-wide glyphs)
+            xy_ratio_max = sym_attr['params'].get('xy-ratio')
+            if (xy_ratio_max):
+                xy_ratio = sym_dim['width'] * scale_ratio_x / (sym_dim['height'] * scale_ratio_y)
+                if xy_ratio > xy_ratio_max:
+                    scale_ratio_x = scale_ratio_x * xy_ratio_max / xy_ratio
 
             if scale_ratio_x != 1.0 or scale_ratio_y != 1.0:
-                if glyph_scale_data is not None and glyph_scale_data[1] is not None:
-                    dim = glyph_scale_data[1]
-                else:
-                    dim = sym_dim
-                if overlap:
-                    scale_ratio_x *= 1.0 + (self.font_dim['width'] / (dim['width'] * scale_ratio_x)) * overlap
-                    scale_ratio_y *= 1.0 + (self.font_dim['width'] / (dim['width'] * scale_ratio_y)) * overlap
-
-                # Size in x to size in y ratio limit (to prevent over-wide glyphs)
-                xy_ratio_max = sym_attr['params'].get('xy-ratio')
-                if (xy_ratio_max):
-                    xy_ratio = dim['width'] * scale_ratio_x / (dim['height'] * scale_ratio_y)
-                    if xy_ratio > xy_ratio_max:
-                        scale_ratio_x = scale_ratio_x * xy_ratio_max / xy_ratio
-
                 self.sourceFont[currentSourceFontGlyph].transform(psMat.scale(scale_ratio_x, scale_ratio_y))
 
             # We pasted and scaled now we want to align/move

--- a/font-patcher
+++ b/font-patcher
@@ -676,6 +676,7 @@ class font_patcher:
     def setup_patch_set(self):
         """ Creates list of dicts to with instructions on copying glyphs from each symbol font into self.sourceFont """
         # Supported params: overlap | careful
+        # Overlap value is used horizontally but vertically limited to 0.01
         # Powerline dividers
         SYM_ATTR_POWERLINE = {
             'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
@@ -1118,7 +1119,8 @@ class font_patcher:
             overlap = sym_attr['params'].get('overlap')
             if overlap:
                 scale_ratio_x *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_x)) * overlap
-                scale_ratio_y *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_y)) * overlap
+                y_overlap = min(0.01, overlap) # never aggressive vertical overlap
+                scale_ratio_y *= 1.0 + (self.font_dim['width'] / (sym_dim['width'] * scale_ratio_y)) * y_overlap
 
             # Size in x to size in y ratio limit (to prevent over-wide glyphs)
             xy_ratio_max = sym_attr['params'].get('xy-ratio')

--- a/font-patcher
+++ b/font-patcher
@@ -739,8 +739,8 @@ class font_patcher:
             0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
 
             # Top and bottom trapezoid
-            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}}
+            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
+            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}}
         }
 
         SYM_ATTR_DEFAULT = {

--- a/font-patcher
+++ b/font-patcher
@@ -693,22 +693,22 @@ class font_patcher:
             0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
 
             # Bottom Triangles
-            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
+            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Top Triangles
-            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
+            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Flames
-            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
-            0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
-            0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
+            0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
+            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
+            0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Small squares
             0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
@@ -719,8 +719,8 @@ class font_patcher:
             0xe0c7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Waveform
-            0xe0c8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
-            0xe0ca: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
+            0xe0c8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
+            0xe0ca: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
 
             # Hexagons
             0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
@@ -977,8 +977,8 @@ class font_patcher:
             return (1.0, 1.0)
 
         # For monospaced fonts all chars need to be maximum 'one' space wide
-        # other fonts allows double width glyphs (for 'pa', 'x' scale target is still one space)
-        if self.args.single or stretch != 'pa':
+        # other fonts allows double width glyphs for 'pa' or if requested with '2'
+        if self.args.single or (stretch != 'pa' and '2' not in stretch):
             relative_width = 1.0
         else:
             relative_width = 2.0
@@ -1168,6 +1168,8 @@ class font_patcher:
                 elif sym_attr['align'] == 'r':
                     # Right align
                     x_align_distance += self.font_dim['width'] - sym_dim['width']
+                    if not self.args.single and '2' in sym_attr['stretch']:
+                        x_align_distance += self.font_dim['width']
 
             if overlap:
                 overlap_width = self.font_dim['width'] * overlap


### PR DESCRIPTION
#### Description

For non-single fonts (i.e. with no `--mono`) added symbol glyphs will be scaled down to be maximum 2 'slots' wide.

Usually the added Glyphs are about 1.6.. 1.8 the width of the normal 'Letters' we have in the target fonts. But there are tiny/tall fonts, where the added glyphs just look out of place.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

The first commit refactor the code with no effective change in result. This is needed in preparation to the actual intended change that would look rather complicated otherwise.

The actual change in the 2nd commit allows downscaling added glyphs in non`-mono` fonts, but still observes the `ScaleGlyph` data.

#### How should this be manually tested?

Fonts patched with `--mono` should come out unchanged.
Fonts patched without `--mono` but higher EM value (i.e. where the added symbols are smaller than 2 times the normal advance width) should come out unchanged.
Fonts patched without `--mono` but small EM shall have symbol glyphs not wider than two normal advance widths.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #718
* #747
* #888

#### Screenshots (if appropriate or helpful)
