### PR TITLE
font-patcher: Correct mono scaling of thin glyphs

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -638,10 +638,7 @@ class font_patcher:
 
         # We want to preserve x/y aspect ratio, so find biggest scale factor that allows symbol to fit
         scale_ratio_x = self.font_dim['width'] / sym_dim['width']
-
-        # font_dim['height'] represents total line height, keep our symbols sized based upon font's em
-        # NOTE: is this comment correct? font_dim['height'] isn't used here
-        scale_ratio_y = self.sourceFont.em / sym_dim['height']
+        scale_ratio_y = self.font_dim['height'] / sym_dim['height']
         if scale_ratio_x > scale_ratio_y:
             scale_ratio = scale_ratio_y
         else:


### PR DESCRIPTION
**[why]**
Some glyphs that are tall and thin, are too big in the resulting patched
font, i.e. are higher than our 'line'.

At least for `--mono` fonts. The non-mono fonts do not rescale the
inserted glyphs at all, so there is no definition of 'too tall/wide'.

[how]
We want all glyphs to fit into the box defined by `*_dim['height']` and
`*_dim['widths']`, as it also defines our powerline-glyph scaling and
horizontal and vertical advance widths.

So we need to take that value (instead of EM) for the scaling
calculation. The history of the use of EM here is a bit obscure.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Base mono-patched font glyph size on `height` and `width` and not `EM` and `width`.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

### More in the comments below.