### PR TITLE
font-patcher: Remove CV lookups in Iosevka

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -60,6 +60,7 @@ class font_patcher:
         except Exception:
             sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
         self.setup_font_names()
+        self.remove_too_many_lookups()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)
         self.check_position_conflicts()
@@ -433,6 +434,26 @@ class font_patcher:
         self.sourceFont.sfntRevision = None # Auto-set (refreshed) by fontforge
         self.sourceFont.appendSFNTName(str('English (US)'), str('Version'), "Version " + self.sourceFont.version)
         # print("Version now is {}".format(sourceFont.version))
+
+
+    def remove_too_many_lookups(self):
+        # Iosevka has so many lookup tables that fontforge is unable to save the file
+        lookups = self.sourceFont.gsub_lookups
+        # We identify Iosevka not by name, but by the amount of lookups.
+        # Maybe we want to identify by name?
+        # The number of lookups is not relevant if the save can be done or not,
+        # it depends on the space the tables need.
+        if len(lookups) < 410:
+            return
+        removed = []
+        for l in lookups:
+            # Arbritarily choose to remove CV. SS is too small to help much.
+            hit = re.search('cv[0-9]+', l)
+            if hit:
+                self.sourceFont.removeLookup(l)
+                removed.append(hit.group())
+        if removed:
+            print("Removing lookup: ", ','.join(removed))
 
 
     def remove_ligatures(self):


### PR DESCRIPTION
**[why]**
For some reason `fontforge` is unable to pack all the lookup tables of
Iosevka back into the generated font, although they fit obviously in the
source font.

The lookup tables will become garbled and `fontforge` says something like:

        Attempt to output 67666 into a 16-bit field.
        It will be truncated and the file may not be useful.

As this also happens if we do nothing, just open and generate the font
without touching, there is not much we can do.

**[how]**
The only thing we can do is reduce the number of lookup tables that are
in the font file. This is somewhat brute, but at least we end up with a
usable font, albeit with a little bit less features.

Unfortunately the SS (Style Set) tables are not enough, but the CV
(Character Variants) suffice. So all CV lookups are riped out.

Fixes: #694 

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Remove the CV lookup tables from all Iosevka variants.
Other fonts in the `src/unpatched-fonts/` are not affected/changed.

#### How should this be manually tested?

#### Any background context you can provide?

Fontforge ~~bug~~ unexpected behavior. Even in interactive mode we can not open and directly (unmodified) the Iosevka fonts in opentype format. See #694

#### What are the relevant tickets (if any)?

#694 and possibly #742

Thanks @xsrvmy for the hint in https://github.com/ryanoasis/nerd-fonts/issues/742#issuecomment-1003851925

#### Screenshots (if appropriate or helpful)
