### PR TITLE
Handle TTCs gracefully

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -55,6 +55,9 @@ class font_patcher:
             sys.exit("{}: Font file does not exist: {}".format(projectName, self.args.font))
         if not os.access(self.args.font, os.R_OK):
             sys.exit("{}: Can not open font file for reading: {}".format(projectName, self.args.font))
+        if len(fontforge.fontsInFile(self.args.font)) > 1:
+            sys.exit("{}: Font file contains {} fonts, can only handle single font files".format(projectName,
+                len(fontforge.fontsInFile(self.args.font))))
         try:
             self.sourceFont = fontforge.open(self.args.font, 1) # 1 = ("fstypepermitted",))
         except Exception:
@@ -72,6 +75,8 @@ class font_patcher:
             self.extension = os.path.splitext(self.args.font)[1]
         else:
             self.extension = '.' + self.args.extension
+        if re.match("\.ttc$", self.extension, re.IGNORECASE):
+            sys.exit(projectName + ": Can not create True Type Collections")
 
 
     def patch(self):


### PR DESCRIPTION
**[why]**
When a True Type Collection file (`.ttc`) is used as font source this is
not handled and just the first file in the collection is processed and
saved. But the user is not informed.

When the target file format is True Type Collection, **no file at all** is
written.

These are two distinct cases, because you can in fact open a `.ttc` and
save the first font (patched) when specifying a different extension via
`-ext`. Or open a normal font and specify `ttc` as extension i.e. target
file format.

**[how]**
Check if a collection is to be opened. As we currently have no code to
loop through all fonts (and just the first font is processed) a message
is issued and we exit. Typically a user would want all the fonts and
would have to 'explode' the collection into multiple single font files
beforehand.

Prevent the target to be `ttc`, as that is not handled in fontforge at
all. To save TTCs a different API function is to be used. Unfortunately
fontforge does not care and just does nothing.

`font.generateTtc()` would have to be used with `ttc` extensions...

Anyhow. As the looping through all fonts is missing anyhow, and I feel
the usefulness is very slim, we just prevent silent failures with this
commit.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

* Normal patching should not be changed.
* try `fontforge --script font-patcher [...] -ext ttc` _(shall fail with meaningful message)_
* try `fontforge --script font-patcher somefont.tcc` _(shall fail with meaningful message)_
* try `fontforge --script font-patcher somefont.tcc -ext ttf` _(WOULD work for the first embedded font, now prevented)_

#### Any background context you can provide?

https://github.com/ryanoasis/nerd-fonts/discussions/735

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/issues/175
https://github.com/ryanoasis/nerd-fonts/pull/664 (!!!?)
https://github.com/powerline/fontpatcher/pull/6

We could also wield [#6](https://github.com/powerline/fontpatcher/pull/6) ... in a next step ;) If you think its needed. The change today would be much smaller than back then I guess. But there are so many PRs waiting ;)

#### Screenshots (if appropriate or helpful)
