### PR TITLE
font-patcher: Make Nerd Fonts Monospaced Again

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -678,7 +678,7 @@ class font_patcher:
         # Supported params: overlap | careful
         # Powerline dividers
         SYM_ATTR_POWERLINE = {
-            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': ''},
+            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
 
             # Arrow tips
             0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
@@ -711,23 +711,23 @@ class font_patcher:
             0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
 
             # Small squares
-            0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': ''},
-            0xe0c5: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': ''},
+            0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0c5: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Bigger squares
-            0xe0c6: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': ''},
-            0xe0c7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': ''},
+            0xe0c6: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0c7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Waveform
             0xe0c8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01}},
 
             # Hexagons
-            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': ''},
-            0xe0cd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': ''},
+            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0cd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Legos
-            0xe0ce: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': ''},
-            0xe0cf: {'align': 'c', 'valign': 'c', 'stretch': 'xy', 'params': ''},
+            0xe0ce: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0cf: {'align': 'c', 'valign': 'c', 'stretch': 'xy', 'params': {}},
             0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
 
             # Top and bottom trapezoid
@@ -737,22 +737,22 @@ class font_patcher:
 
         SYM_ATTR_DEFAULT = {
             # 'pa' == preserve aspect ratio
-            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': ''}
+            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}}
         }
 
         SYM_ATTR_FONTA = {
             # 'pa' == preserve aspect ratio
-            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': ''},
+            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
 
             # Don't center these arrows vertically
-            0xf0dc: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': ''},
-            0xf0dd: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': ''},
-            0xf0de: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': ''}
+            0xf0dc: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}},
+            0xf0dd: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}},
+            0xf0de: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}}
         }
 
         CUSTOM_ATTR = {
             # 'pa' == preserve aspect ratio
-            'default': {'align': 'c', 'valign': '', 'stretch': '', 'params': ''}
+            'default': {'align': 'c', 'valign': '', 'stretch': '', 'params': {}}
         }
 
         # Most glyphs we want to maximize during the scale.  However, there are some
@@ -1017,13 +1017,10 @@ class font_patcher:
                 # Currently stretching vertically for both monospace and double-width
                 scale_ratio_y = self.font_dim['height'] / sym_dim['height']
 
-            if 'overlap' in sym_attr['params']:
-                overlap = sym_attr['params']['overlap']
-            else:
-                overlap = 0
+            overlap = sym_attr['params'].get('overlap')
 
             if scale_ratio_x != 1 or scale_ratio_y != 1:
-                if overlap != 0:
+                if overlap:
                     scale_ratio_x *= 1 + overlap
                     scale_ratio_y *= 1 + overlap
                 self.sourceFont[currentSourceFontGlyph].transform(psMat.scale(scale_ratio_x, scale_ratio_y))
@@ -1049,7 +1046,7 @@ class font_patcher:
                     # Right align
                     x_align_distance += self.font_dim['width'] - sym_dim['width']
 
-            if overlap != 0:
+            if overlap:
                 overlap_width = self.font_dim['width'] * overlap
                 if sym_attr['align'] == 'l':
                     x_align_distance -= overlap_width
@@ -1077,7 +1074,7 @@ class font_patcher:
             # Check if the inserted glyph is scaled correctly for monospace
             if self.args.single:
                 (xmin, _, xmax, _) = self.sourceFont[currentSourceFontGlyph].boundingBox()
-                if int(xmax - xmin) > self.font_dim['width'] * (1 + overlap):
+                if int(xmax - xmin) > self.font_dim['width'] * (1 + (overlap or 0)):
                     print("\n  Warning: Scaled glyph U+{:X} wider than one monospace width ({} / {} (overlap {}))".format(
                         currentSourceFontGlyph, int(xmax - xmin), self.font_dim['width'], overlap))
 

--- a/font-patcher
+++ b/font-patcher
@@ -1054,15 +1054,16 @@ class font_patcher:
             align_matrix = psMat.translate(x_align_distance, y_align_distance)
             self.sourceFont[currentSourceFontGlyph].transform(align_matrix)
 
+            # Ensure after horizontal adjustments and centering that the glyph
+            # does not overlap the bearings (edges)
+            self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
+
             # Needed for setting 'advance width' on each glyph so they do not overlap,
             # also ensures the font is considered monospaced on Windows by setting the
             # same width for all character glyphs. This needs to be done for all glyphs,
             # even the ones that are empty and didn't go through the scaling operations.
+            # It should come after setting the glyph bearings
             self.set_glyph_width_mono(self.sourceFont[currentSourceFontGlyph])
-
-            # Ensure after horizontal adjustments and centering that the glyph
-            # does not overlap the bearings (edges)
-            self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
 
             # Check if the inserted glyph is scaled correctly for monospace
             if self.args.single:

--- a/font-patcher
+++ b/font-patcher
@@ -1058,7 +1058,8 @@ class font_patcher:
 
             # Ensure after horizontal adjustments and centering that the glyph
             # does not overlap the bearings (edges)
-            self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
+            if not overlap:
+                self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
 
             # Needed for setting 'advance width' on each glyph so they do not overlap,
             # also ensures the font is considered monospaced on Windows by setting the

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.0.3"
+script_version = "3.0.4"
 
 version = "2.2.1"
 projectName = "Nerd Fonts"
@@ -320,6 +320,7 @@ class font_patcher:
         parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
         parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')
         parser.add_argument('--makegroups',                              dest='makegroups',       default=False, action='store_true', help='Use alternative method to name patched fonts (experimental)')
+        parser.add_argument('--variable-width-glyphs',                   dest='nonmono',          default=False, action='store_true', help='Do not adjust advance width (no "overhang")')
 
         # progress bar arguments - https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
         progressbars_group_parser = parser.add_mutually_exclusive_group(required=False)
@@ -379,6 +380,10 @@ class font_patcher:
 
         if self.args.alsowindows:
             self.args.windows = False
+
+        if self.args.nonmono and self.args.single:
+            print("Warniung: Specified contradicting --variable-width-glyphs and --use-single-width-glyph. Ignoring --variable-width-glyphs.")
+            self.args.nonmono = False
 
         # this one also works but it needs to be updated every time a font is added
         # it was a conditional in self.setup_font_names() before, but it was missing
@@ -1065,6 +1070,10 @@ class font_patcher:
             # It should come after setting the glyph bearings
             self.set_glyph_width_mono(self.sourceFont[currentSourceFontGlyph])
 
+            # Re-remove negative bearings for target font with variable advance width
+            if self.args.nonmono:
+                self.remove_glyph_neg_bearings(self.sourceFont[currentSourceFontGlyph])
+
             # Check if the inserted glyph is scaled correctly for monospace
             if self.args.single:
                 (xmin, _, xmax, _) = self.sourceFont[currentSourceFontGlyph].boundingBox()
@@ -1115,6 +1124,10 @@ class font_patcher:
         self.font_dim.width is set with self.get_sourcefont_dimensions().
         """
         try:
+            # Fontforge handles the width change like this:
+            # - Keep existing left_side_bearing
+            # - Set width
+            # - Calculate and set new right_side_bearing
             glyph.width = self.font_dim['width']
         except:
             pass

--- a/readme.md
+++ b/readme.md
@@ -373,7 +373,7 @@ Full options:
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -416,6 +416,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -384,7 +384,7 @@ The list is not complete, but you can [search for a complete list here](https://
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -427,6 +427,8 @@ optional arguments:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        显示每个Glyph Set的完成度进度条
   --no-progressbars     不显示每个Glyph Set的完成度进度条
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_es.md
+++ b/readme_es.md
@@ -332,7 +332,7 @@ Parcha la fuente de tu preferencia para usar los [VimDevIcons ➶][vim-devicons]
 uso: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                   [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                   [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                  [--glyphdir [GLYPHDIR]] [--makegroups]
+                  [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                   [--progressbars | --no-progressbars] [--also-windows]
                   [--fontawesome] [--fontawesomeextension] [--fontlinux]
                   [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -375,6 +375,8 @@ argumentos opcionales:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
   --no-progressbars     No muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -410,7 +410,7 @@ Générer la police de votre choix pour l'utiliser avec [VimDevIcons ➶][vim-de
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -453,6 +453,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_hi.md
+++ b/readme_hi.md
@@ -365,7 +365,7 @@ The list is not complete, but you can [search for a complete list here](https://
     प्रयोग: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -408,6 +408,8 @@ The list is not complete, but you can [search for a complete list here](https://
       --glyphdir [GLYPHDIR]
                             Path to glyphs to be used for patching
       --makegroups          Use alternative method to name patched fonts (experimental)
+      --variable-width-glyphs
+                            Do not adjust advance width (no "overhang")
       --progressbars        प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार दिखाएं
       --no-progressbars     प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार न दिखाएं
       --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_it.md
+++ b/readme_it.md
@@ -333,7 +333,7 @@ Modificare il font di tua scelta per utilizzare i [VimDevIcons ➶][vim-devicons
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -376,6 +376,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -328,7 +328,7 @@ The list is not complete, but you can [search for a complete list here](https://
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -371,6 +371,8 @@ optional arguments:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        グリフセットごとに進捗を百分率で表示します。
   --no-progressbars     グリフセットごとの進捗を表示しません。
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -329,7 +329,7 @@ The list is not complete, but you can [search for a complete list here](https://
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -372,6 +372,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -405,7 +405,7 @@ Patchowanie wybranych przez ciebie fontów z wykorzystaniem [VimDevIcons ➶][vi
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -448,6 +448,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -329,7 +329,7 @@ Modificar o tipo de letra à tua escolha com [VimDevIcons ➶][vim-devicons]:
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -372,6 +372,8 @@ argumentos opcionais:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Mostrar barras de progresso de conclusão percentual por Glyph Set
   --no-progressbars     Não mostrar barras de progresso de conclusão percentual por Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -384,7 +384,7 @@ The list is not complete, but you can [search for a complete list here](https://
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -427,6 +427,8 @@ options:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        Show percentage completion progress bars per Glyph Set
   --no-progressbars     Don't show percentage completion progress bars per Glyph Set
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -384,7 +384,7 @@ The list is not complete, but you can [search for a complete list here](https://
 usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                     [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                     [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                     [--progressbars | --no-progressbars] [--also-windows]
                     [--fontawesome] [--fontawesomeextension] [--fontlinux]
                     [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -427,6 +427,8 @@ optional arguments:
   --glyphdir [GLYPHDIR]
                         Path to glyphs to be used for patching
   --makegroups          Use alternative method to name patched fonts (experimental)
+  --variable-width-glyphs
+                        Do not adjust advance width (no "overhang")
   --progressbars        顯示每個Glyph Set的完成度進度條
   --no-progressbars     不顯示每個Glyph Set的完成度進度條
   --also-windows        Create two fonts, the normal and the --windows version

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -326,7 +326,7 @@ The list is not complete, but you can [search for a complete list here](https://
     usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
                         [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
                         [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                        [--glyphdir [GLYPHDIR]] [--makegroups]
+                        [--glyphdir [GLYPHDIR]] [--makegroups] [--variable-width-glyphs]
                         [--progressbars | --no-progressbars] [--also-windows]
                         [--fontawesome] [--fontawesomeextension] [--fontlinux]
                         [--octicons] [--codicons] [--powersymbols] [--pomicons]
@@ -369,6 +369,8 @@ The list is not complete, but you can [search for a complete list here](https://
       --glyphdir [GLYPHDIR]
                             Path to glyphs to be used for patching
       --makegroups          Use alternative method to name patched fonts (experimental)
+      --variable-width-glyphs
+                            Do not adjust advance width (no "overhang")
       --progressbars        Показати прогресбар виконання обробки кожного гліфу
       --no-progressbars     Не показувати прогресбар виконання обробки кожного гліфу
       --also-windows        Create two fonts, the normal and the --windows version

--- a/src/unpatched-fonts/NerdFontsSymbolsOnly/config.cfg
+++ b/src/unpatched-fonts/NerdFontsSymbolsOnly/config.cfg
@@ -1,1 +1,1 @@
-config_patch_flags="--ext ttf"
+config_patch_flags="--ext ttf --variable-width-glyphs"


### PR DESCRIPTION
This reverts commit 59c45ba4eff539d2a83a7d7004f056b9860d3253.

In the following **_The Commit_** means the commit that this PR want to revert (remove).

**[why]**
_The Commit_ breaks the non-mono Nerd Fonts for a lot of people.
The issue which is the reason for _This Commit_ was not very good documented and investigation can not be
seen.

From _The Commit_'s TITLE it should have affected the 2048-em Symbols font only, but in fact all patched fonts were changed.
Maybe that was intended, maybe not.

**[how]**
This will make the advance width again equal for all glyphs.
This enables the use of the non-mono variant in more terminals.
For wider symbols a space is now (again) needed after the symbol.
That is expected by a lot applications.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Make Non-Mono Nerd Fonts monospaced but allow added symbols to extend over the allotted space to the right (negative right side bearings).

#### How should this be manually tested?

#### Any background context you can provide?

The behavior has been changed with _The Commit_ 59c45ba4e that has been written to fix this issue (at Arch) https://bugs.archlinux.org/task/66212.

Most of the fonts in `patched-fonts/` were not updated after that change, so the problems with that change became not obvious until recently.

If it is a problem or not depends also on the used terminal application. Some scale individual glyphs (like Windows Terminal), some just write them out.

**_What has been the problem and why is the solution a problem_**

A User complained that in their use case (which is not described in detail, but can be in a non-terminal program that shows a status bar somewhere) the added wide symbols overlap with immediately following ordinary letters.

This is the case because obviously the program that shows the symbols and letters follows the _advance width_, which is the same for every symbol in a monospaced font. The bigger symbols extrude to the right more than the cursor will more, so this is expected.
This is the reason why applications that use the symbols typically add a blank after the symbol itself, to preserve monospace grid and prevent overlap. For example vim-devicons adds an `ArtifactFix` (i.e. blank `' '`) when appropriate. Other programs like '`ls` with filetype symbols' also add a blank space directly after a symbol that is to be displayed.

After _That Commit_ the fonts are not monospaced anymore and terminal emulators do one of
* reject the font outright (not monospaced = not usable)
* rescale the too-big glyphs (effectively leaves the user with a badly rescaled version of `Nerd Font Mono`)
* work in proportional mode (and thereby destroy the vertical alignment of tables that have different symbols with different widths on each line)

The original problem poster should maybe have changed that application to include the customary blank after symbols.
But then it looks like at least some problem commenter use the font in proportional mode like this
![before_update](https://user-images.githubusercontent.com/16012374/149503912-1b8d0b79-d85f-48ce-a55c-37c31171a1e0.png)
The numbers-and-letter part of the font in this example is proportional, and so the poster (rightfully?) expects proportional symbols. I assume the symbols are not patched in but come from the Symbols-Only font (as described in _The Commit_ message 59c45ba4ef.

Lets define some nomenclature:

1. `Nerd Font Mono`: strictly monospaced font (i.e. all symbols fit into one 'space' (symbols scaled way down)
1. `Nerd Font Classic`: monospaced font (all 'letters' monospaced, symbols have monospace advance, but extend to right)
1. `Nerd Font Proportional`: monospaced letters, but proportional symbols (no negative bearings)

Nerd Fonts contained up to 59c45ba4 the fonts **1** and **2**. Afterward the font-patch result is **1** and **3**. This PR reverts / changes it back to **1** and **2**. Typical use cases of Nerd Fonts expect the overwide symbols of **2** and handle them appropriately. Also **2** is useful in more terminal applications. People who want non-tiny symbols (i.e. not **1**) need **2** or a proportional-font-allowed terminal to use **3**.
Possibly the font **3** would also be nice to have (or at least allow users to self patch it with a command line option).

#### What are the relevant tickets (if any)?

* #746
* #731 
* #520 
* #754 

The problem comes up in various guises, and the list is not complete.

#### Screenshots (if appropriate or helpful)

#### Font **1** example

Symbols scaled down to fit into one advance width (i.e. 1200 here), strictly monospaced, all glyphs have 1200 advance width.
Font taken from this repo, MASTER, `patched-fonts/CascadiaCode/Regular/complete/Caskaydia\ Cove\ Regular\ Nerd\ Font\ Complete\ Mono.otf`

![image](https://user-images.githubusercontent.com/16012374/149506653-83dd1e0b-b557-4cbe-ba02-0c8024aaaa35.png)

#### Font **2** example

Symbols not scaled but changed advance width (i.e. 1200), monospaced, all glyphs have 1200 advance width, symbols have negative right bearing (extrude out to the right).
Font created from this repo, MASTER, `fontforge patched-fonts/CascadiaCode/Regular/complete/Caskaydia\ Cove\ Regular\ Nerd\ Font\ Complete.otf patched-fonts/CascadiaCode/Regular/complete/Caskaydia\ Cove\ Regular\ Nerd\ Font\ Complete\ Mono.otf`

![image](https://user-images.githubusercontent.com/16012374/149508274-f8889b6a-7f08-47ca-83f0-887c65849036.png)

#### Font **3** example

Symbols not scaled with original advance width (i.e. 2048 here), not strictly monospaced, all textual glyphs have 1200 advance width, symbols have any advance width.
Font taken from this repo, MASTER, `patched-fonts/CascadiaCode/Regular/complete/Caskaydia\ Cove\ Regular\ Nerd\ Font\ Complete.otf`

![image](https://user-images.githubusercontent.com/16012374/149507551-2b7aab02-571a-4a2c-91c5-68e4639a5f3a.png)

_Edit: Make more clear what **The Commit** means and highlight the term as special_