### PR TITLE
Bugfix vertical lines in powerline prompts

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -691,33 +691,33 @@ class font_patcher:
             'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
 
             # Arrow tips
-            0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
+            0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
             0xe0b1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
-            0xe0b2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
+            0xe0b2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
             0xe0b3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
 
             # Rounded arcs
-            0xe0b4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.59}},
+            0xe0b4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.59}},
             0xe0b5: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
-            0xe0b6: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.01, 'xy-ratio': 0.59}},
+            0xe0b6: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.59}},
             0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
 
             # Bottom Triangles
-            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Top Triangles
-            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
+            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Flames
-            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
+            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
+            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
             0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Small squares
@@ -742,8 +742,8 @@ class font_patcher:
             0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
 
             # Top and bottom trapezoid
-            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
-            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}}
+            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
+            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}}
         }
 
         SYM_ATTR_DEFAULT = {

--- a/font-patcher
+++ b/font-patcher
@@ -691,33 +691,33 @@ class font_patcher:
             'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
 
             # Arrow tips
-            0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
+            0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.7}},
             0xe0b1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
-            0xe0b2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
+            0xe0b2: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.7}},
             0xe0b3: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.7}},
 
             # Rounded arcs
-            0xe0b4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.59}},
+            0xe0b4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.59}},
             0xe0b5: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
-            0xe0b6: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.59}},
+            0xe0b6: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.59}},
             0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
 
             # Bottom Triangles
-            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Top Triangles
-            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Flames
-            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0c1: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.03}},
+            0xe0c2: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.04}},
             0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Small squares
@@ -742,8 +742,8 @@ class font_patcher:
             0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
 
             # Top and bottom trapezoid
-            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}},
-            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.03, 'xy-ratio': 0.7}}
+            0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.7}},
+            0xe0d4: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.04, 'xy-ratio': 0.7}}
         }
 
         SYM_ATTR_DEFAULT = {


### PR DESCRIPTION
#### Description

First part of solution:

**[why]**
For some powerline symbols we add a certain amount of overlap into the
previous or next character to cover up a small gap between the symbols
that otherwise can show up as ugly thin (usually colored) line.

But after we carefully design that glyph with a bit overlap (over-sized
and having negative bearings) we remove all bearings. That breaks of
course the glyph and no actual overlap on the left side happens.

**[how]**
Just do not remove negative bearings on overlap-enabled glyphs. As they
are rescaled in both directions anyhow all bearings are wanted and must
be kept.

Second part of solution:

**[why]**
With the previous commit the gap between powerline glyphs became much    
better, but a faint line is still visible for LCD antialiasing (on my    
machine).    
    
Having seen how big the overlap is for Cascadia Code the overlap here    
can be increase maybe a bit.    
    
**[how]**
Increase the overlap to 3 % (from mostly 2 %) for the glyphs that have a    
'full colored edge' on one side.    
    
Fixes: #29  

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Increase the `overlap` for some glyphs slightly and correct the needed negative left side bearings for glyphs that should have had an overlap on the left side but had not.

#### How should this be manually tested?

#### Any background context you can provide?

The issue comes up relatively often, I think. I was never bothered by the lines, so I dod not really follow that. Maybe I'm wrong. I have real list of Issues that are related.

#### What are the relevant tickets (if any)?

#29

Also see #779 for `params` future as dict.

#### Screenshots (if appropriate or helpful)

@MIvanchev used `LiterationMono Nerd Font Mono` and neovim-Qt, so I use that here as examples.
Note: Hinting full, Subpixel antialiasing, X11

**Current behavior (before the PR):**

![overlap0](https://user-images.githubusercontent.com/16012374/152815182-fff412cb-e16a-49b3-bd8b-4c4993bfbcf2.png)
![image](https://user-images.githubusercontent.com/16012374/152815382-92e1dfc4-f4c4-4c8c-a127-12dc1f7ef262.png)

**After fixing the code:** (first part)

![overlap1](https://user-images.githubusercontent.com/16012374/152815704-a5409830-68d2-4bdf-868b-a38822d278cb.png)
![image](https://user-images.githubusercontent.com/16012374/152815883-d3a9719a-2f60-41e7-b6d9-d1acb38d3a7f.png)
_Note more pronounced line for round things, as that has only 1%, the other have 2% overlap_

**After increasing the overlap:** (second part)

![overlap2](https://user-images.githubusercontent.com/16012374/152816078-b72e1584-c75e-4b3c-b277-456872bc0a3a.png)
![image](https://user-images.githubusercontent.com/16012374/152816150-702c9f29-9d85-48bf-a719-1b5157b3c9ee.png)

_I guess 3% is enough, it is still very very faintly visible. Can be increased if users still complain_
