### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,15 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 #### 🗹 Requirements
 
-<!-- ⚠️ !!! 
+<!-- ⚠️ !!!
 If you are unsure what you are reporting is an issue or
 it's a general question please go to the gitter chat instead: https://gitter.im/ryanoasis/nerd-fonts
 ⚠️ !!! -->
@@ -13,16 +22,27 @@ it's a general question please go to the gitter chat instead: https://gitter.im/
 - [ ] I have searched the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting) for help
 - [ ] I have searched the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki) for help
 
+
 #### 🎯 Subject of the issue
 
+Experienced behavior:
 <!--- Describe issue here -->
+
+Expected behavior:
+<!--- Please do not forget to explain what you would have expected to see -->
+
+Example symbols:
+<!--- The codepoint of one or more affected symbols, or paste the text containing the issue here (no screenshot) -->
 
 #### 🔧 Your Setup
 
 - _Which font are you using (e.g. `Anonymice Powerline Nerd Font Complete.ttf`)?_
+   - _Please give the full filename_
+   - _Where did you get the file from (download link, self patched, source downloaded from link...)_
 - _Which terminal emulator are you using (e.g. `iterm2`, `urxvt`, `gnome`, `konsole`)?_
 - _Are you using OS X, Linux or Windows? And which specific version or distribution?_
 
 #### ★ Screenshots (Optional)
 
-<!--- Provide screenshots where appropriate -->
+<!--- Provide screenshots where appropriate, they help tremendously -->
+<!--- Try to include the title of terminal windows and possibly settings dialogues -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Requirements**
+
+<!-- ⚠️ !!!
+If you are unsure what you are reporting is an issue or
+it's a general question please go to the gitter chat instead: https://gitter.im/ryanoasis/nerd-fonts
+⚠️ !!! -->
+
+
+<!-- ⚠️ !!! Issues not filled out with the template will be closed straight away and will only be responded to once filled properly ⚠️ !!! -->
+<!--- By posting an issue you acknowledge the following: -->
+
+- [ ] I have searched the [issues](https://github.com/ryanoasis/nerd-fonts/issues) for my request and found nothing related and/or helpful
+- [ ] I have searched the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting) for help
+- [ ] I have searched the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki) for help
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
A lot of issues do not have screenshots and which glyphs are the problem has to be asked and or guessed.

Also change to newer github issue template method.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Change the Issue Template

#### How should this be manually tested?

Can be tested interactively in my fork, installed it there in master [`Finii:master`](https://github.com/Finii/nerd-fonts), so it is in effect.

#### Any background context you can provide?

Frustrated by people that think I know all the icons by heard ;-)

#### What are the relevant tickets (if any)?

Replacement for #763

#### Screenshots (if appropriate or helpful)

After **_Create New Issue_**:

![image](https://user-images.githubusercontent.com/16012374/152940853-d8b8cca7-acb2-4cdf-a1a2-eaaad1628fb3.png)

![image](https://user-images.githubusercontent.com/16012374/152941084-7de9aad5-9038-4cca-b2a8-0d8a79ada9ec.png)
