### PR TITLE
patch-em-all: Purge destination dirs if possible

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -62,12 +62,18 @@ echo "$LINE_PREFIX Total source fonts found: ${#source_fonts[*]}"
 function patch_font {
   local f=$1; shift
   local i=$1; shift
+  local purge=$1; shift
   # take everything before the last slash (/) to start building the full path
   local patched_font_dir="${f%/*}/"
   # find replace unpatched parent dir with patched parent dir:
   local patched_font_dir="${patched_font_dir/$unpatched_parent_dir/$patched_parent_dir}"
 
   [[ -d "$patched_font_dir" ]] || mkdir -p "$patched_font_dir"
+  if [ -n ${purge} -a -d "${patched_font_dir}complete" ]
+  then
+    echo "Purging patched font dir ${patched_font_dir}complete"
+    rm ${patched_font_dir}complete/*.[to]tf
+  fi
 
   config_parent_dir=$( cd "$( dirname "$f" )" && cd ".." && pwd)
   config_dir=$( cd "$( dirname "$f" )" && pwd)
@@ -258,7 +264,24 @@ then
   # Iterate through source fonts
   for i in "${!source_fonts[@]}"
   do
-    patch_font "${source_fonts[$i]}" "$i" 2>/dev/null &
+    purge_destination=""
+    current_source_dir=$(dirname ${source_fonts[$i]})
+    if [ "${current_source_dir}" != "${last_source_dir}" ]
+    then
+      # If we are going to patch ALL font files from a certain source directory
+      # the destination directory is purged (all font files therein deleted)
+      # to follow font naming changed. We can not do this if we patch only
+      # some of the source font files in that directory.
+      last_source_dir=${current_source_dir}
+      num_to_patch=$(find "${current_source_dir}" -iname "${like_pattern}*.[o,t]tf" -type f | wc -l)
+      num_existing=$(find "${current_source_dir}" -iname "*.[o,t]tf" -type f | wc -l)
+      if [ ${num_to_patch} -eq ${num_existing} ]
+      then
+        purge_destination="TRUE"
+      fi
+    fi
+    patch_font "${source_fonts[$i]}" "$i" "$purge_destination" 2>/dev/null
+
 
     # un-comment to test this script (patch 1 font)
     #break


### PR DESCRIPTION
**[why]**
When the file names of the source files change which happened for example
with these commits:
```
  ac432eb20 Updated Inconsolata source to latest upstream version of 2.001 (WIP #289)
  9c5ad2c78 Updated Inconsolata source to latest upstream version of 2.001 (WIP #289)
```
or the patched font files naming changes because of any other reason (*):

The patched-font directory will contain the new files along with the
unchanged old ones (because they where not overwritten).

Typically when manually updating the patched-fonts this is not a
problem, as the maintainer can clean this up by hand (if it is noticed).
But with a github action we might want to have that automatized.

To not deter the usability of the script for end-users or for patching
single fonts of a collection we do NOT want to purge 'all old files'
because we can not know if they are really old or not.

**[how]**
For each directory that we process from the source fonts we check if all
font files therein match our search criterion (pattern, $2). If we are
going to patch _all_ files that are in that source directory we delete all
font files in the destination directory; expecting that all files will
be recreated.
If we do _not_ patch _all_ files, we can do nothing, because we can not
decide if the existing files originate from one of the
not-to-be-processed source font files or are zombies.

Fixes: #786

(*) For example when the font naming changes because
- The FontnameParser is used where `Nerd Font` moves forward before the style in the font name
- We will finally create font files without blanks in them, but conventional `Name-Weight.ttf`

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Remove font files from `patched-fonts` that are not created on the most recent complete patch run.

#### How should this be manually tested?

Inconsolata has some orphan font files, run the patched `patch-em-all` and see those vanish.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#786

#### Screenshots (if appropriate or helpful)
