### PR TITLE
font-patcher: Allow glyphs with altuni for exactEncoding

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.0.4"
+script_version = "3.0.5"
 
 version = "2.2.1"
 projectName = "Nerd Fonts"
@@ -939,6 +939,8 @@ class font_patcher:
         if self.args.quiet is False:
             sys.stdout.write("Adding " + str(max(1, glyphSetLength)) + " Glyphs from " + setName + " Set \n")
 
+        currentSourceFontGlyph = -1 # initialize for the exactEncoding case
+
         for index, sym_glyph in enumerate(symbolFontSelection):
             index = max(1, index)
 
@@ -948,8 +950,17 @@ class font_patcher:
                 sym_attr = attributes['default']
 
             if exactEncoding:
-                # use the exact same hex values for the source font as for the symbol font
-                currentSourceFontGlyph = sym_glyph.encoding
+                # Use the exact same hex values for the source font as for the symbol font.
+                # Problem is we do not know the codepoint of the sym_glyph and because it
+                # came from a selection.byGlyphs there might be skipped over glyphs.
+                # The iteration is still in the order of the selection by codepoint,
+                # so we take the next allowed codepoint of the current glyph
+                possible_codes = [ ]
+                if sym_glyph.unicode > currentSourceFontGlyph:
+                    possible_codes += [ sym_glyph.unicode ]
+                if sym_glyph.altuni:
+                    possible_codes += [ v for v, s, r in sym_glyph.altuni if v > currentSourceFontGlyph ]
+                currentSourceFontGlyph = min(possible_codes)
             else:
                 # use source font defined hex values based on passed in start and end
                 currentSourceFontGlyph = sourceFontList[sourceFontCounter]


### PR DESCRIPTION
#### Description

**[why]**
Some symbol fonts might come with glyphs that have multiple codepoints.

When we want to patch them with `'Exact': true` (i.e. at their 'original'
codepoints) we want to patch them into the codepoint that has been used
in the selection process. That means between `SymStart` and `SymEnd`.

But this is not the case. We patch them in into their 'main' codepoint,
which can be outside the expected range of points.

This came up when patching with FontAwesome V6. It has for example these
glyphs:

Glyph 'music' has a main codepoint `0x1F3B5`, but it is present in the
font also on codepoint `0xF001`.

Glyph 'heard' has a main codepoint `0x1F9E1`, but it is present in the
font also on codepoints `0x2665`, `0x2764`, `0xF004`, `0xF08A`, `0x1F499`, ...

When doing a `'Exact': true` patch (i.e. exactEncoding = true) the
glyphs is patched into the target font at its (the glyph's) main
codepoint, regardless of our patch-codepoint-range.

**[how]**
We examine all codepoints that a glyph occupies in the symbol font. From
all these codepoints we take the nearest to the last glyph be patched
in. Nearest means from the possible codepoints the lowest that come
after the previous used codepoint.

For example the 'heard':

Last patched in codepoint was `0xF003`.
Main codepoint: `0x1F9E1`
Alternate codepoints: `0x2665`, `0x2764`, `0xF004`, `0xF08A`, `0x1F499`, ...
-=> `0xF004`

Later in the patching process we might encounter the same glyph again,
but this time the previous codepoint was `0xF089`, so we need to take
`0xF08A`.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Put symbol glyphs that have additional unicodes (`altuni`) into the expected (i.e. next possible in the range we work on) codepoint slot.

_From Fontforge Python Docu:_
> [glyph.altuni](https://fontforge.org/docs/scripting/python/fontforge.html#fontforge.glyph.altuni)
>
> Returns additional unicode code points for this glyph. For a primary code point, see [glyph.unicode](https://fontforge.org/docs/scripting/python/fontforge.html#fontforge.glyph.unicode) .

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/discussions/727#discussioncomment-2227926

#### Screenshots (if appropriate or helpful)
