### PR TITLE
font-patcher: Allow to specify custom symbolfont with absolute path

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -107,7 +107,7 @@ class font_patcher:
                     if symfont:
                         symfont.close()
                         symfont = None
-                    symfont = fontforge.open(self.args.glyphdir + patch['Filename'])
+                    symfont = fontforge.open(os.path.join(self.args.glyphdir, patch['Filename']))
 
                     # Match the symbol font size to the source font size
                     symfont.em = self.sourceFont.em


### PR DESCRIPTION
**[why]**
When one wants to use a custom symbol font and specifies it with an
absolute path, the `glyphdir` is still prepended.

That means that the argument to `--custom` is always used as relative
path (to `--glyphdir`), even when it starts with `/`. That is somehow
unexpected or at least inconvenient.

Example:
`fontforge font-patcher --custom ~/Downloads/fa6.otf Inconsolata-Regular.otf`

`fa6.otf` is searched for in `./src/glyphs/home/username/Downloads`

**[how]**
Use Python function that handles joining path fragments.

> If a component is an absolute path, all previous
> components are thrown away.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Allow (respect) absolute paths specified with `--custom`. No change for relative paths.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
