### PR TITLE
font-patcher: Correct python module missing message

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -11,10 +11,6 @@ projectNameAbbreviation = "NF"
 projectNameSingular = projectName[:-1]
 
 import sys
-try:
-    import psMat
-except ImportError:
-    sys.exit(projectName + ": FontForge module is probably not installed. [See: http://designwithfontforge.com/en-US/Installing_Fontforge.html]")
 import re
 import os
 import argparse
@@ -27,12 +23,13 @@ try:
 except ImportError:
     sys.exit(projectName + ": configparser module is probably not installed. Try `pip install configparser` or equivalent")
 try:
+    import psMat
     import fontforge
 except ImportError:
     sys.exit(
         projectName + (
             ": FontForge module could not be loaded. Try installing fontforge python bindings "
-            "[e.g. on Linux Debian or Ubuntu: `sudo apt install fontforge python-fontforge`]"
+            "[e.g. on Linux Debian or Ubuntu: `sudo apt install fontforge python3-fontforge`]"
         )
     )
 


### PR DESCRIPTION
**[why]**
When the fontforge python bindings are not installed we fail while
importing `psMat`. The message suggests that fontforge itself is not
installed - which is not the real reason. One can use the `libfontforge`
with the `python-fontforge` without having the GUI program `fontforge`.

Furthermore we link to outdated installation instructions.

**[how]**
We already check and report correctly what needs to be done with the
fontforge module import. As both modules are often in the same package
we should probably report the same message. That message holds correct
hints for Debian/Ubuntu. It does not have a link to fontforge, though.

**[note]**
Also update Debian package name.

Fixes: #725

Reported-by: Aniket Teredesai <a@aniketteredesai.com>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![image](https://user-images.githubusercontent.com/16012374/155947677-bc09bfd2-3628-406f-9cb9-29e39775d4e5.png)
