### PR TITLE
Fix wiki links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ it's a general question please go to the gitter chat instead: https://gitter.im/
 
 - [ ] I have searched the [issues](https://github.com/ryanoasis/nerd-fonts/issues) for my issue and found nothing related and/or helpful
 - [ ] I have searched the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting) for help
-- [ ] I have searched the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki) for help
+- [ ] I have searched the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki) for help
 
 
 #### 🎯 Subject of the issue

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,7 +20,7 @@ it's a general question please go to the gitter chat instead: https://gitter.im/
 
 - [ ] I have searched the [issues](https://github.com/ryanoasis/nerd-fonts/issues) for my request and found nothing related and/or helpful
 - [ ] I have searched the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting) for help
-- [ ] I have searched the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki) for help
+- [ ] I have searched the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki) for help
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]


### PR DESCRIPTION
#### Description

The "I have searched the Wiki" links in the issue templates point to the vim-devicons Wiki rather than the nerd-fonts Wiki. I suspect that's not intended 😁 

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [X] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

It changes links in the bug report and feature request templates; there are no other changes.

#### How should this be manually tested?

Create a new issue of each type, and verify that the nerd-fonts Wiki is opened when the Wiki link is clicked.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

n/a

#### Screenshots (if appropriate or helpful)

n/a