### PR TITLE
font-patcher: Ensure PostScript font name does not contain spaces

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -343,8 +343,9 @@ class font_patcher:
                 familyname += " Mono"
 
         # Don't truncate the subfamily to keep fontname unique.  MacOS treats fonts with
-        # the same name as the same font, even if subFamily is different.
-        fontname += '-' + subFamily
+        # the same name as the same font, even if subFamily is different. Make sure to
+        # keep the resulting fontname (PostScript name) valid by removing spaces.
+        fontname += '-' + subFamily.replace(' ', '')
 
         # rename font
         #


### PR DESCRIPTION
When pulling the subfamily out of the sfnt_names SubFamily property,
we will get a subfamily with possible spaces, e.g. 'Bold Italic'.

When constructing the final unique font name (PostScript name), we
need to remove those spaces, to make the font name valid, otherwise
the font will fail validation with a warning when installing.

Fixes #413

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
