### PR TITLE
Bugfix/ci release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           cd -- "$GITHUB_WORKSPACE/bin/scripts"
           fontforge --script ../../font-patcher --version
-          ./gotta-patch-em-all-font-patcher\!.sh "${{ matrix.font }}"
+          ./gotta-patch-em-all-font-patcher\!.sh "/${{ matrix.font }}"
 
       - name: Generate fontconfig and casks
         run: |

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -308,3 +308,8 @@ printf "# The total number of font families patched was \\t\\t'%s'\\n" "$font_fa
 printf "# The total number of 'complete' patched fonts created was \\t'%s'\\n" "$complete_variation_count"
 printf "# The total number of 'variation' patched fonts created was \\t'%s'\\n" "$total_variation_count"
 printf "# The total number of patched fonts created was \\t\\t'%s'\\n" "$total_count"
+
+if [ "$total_count" -lt 1 ]; then
+  # Probably unwanted... alert user
+  exit 1
+fi

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -5,6 +5,16 @@
 # used for debugging
 # set -x
 
+# The optional first argument to this script is a filter for the fonts to patch.
+# All font files that start with that filter (and are ttf or otf files) will
+# be processed only.
+#   Example ./gotta-patch-em-all-font-patcher\!.sh "iosevka"
+#   Process all font files that start with "iosevka"
+# If the argument starts with a '/' all font files in a directory that matches
+# the filter are processed only.
+#   Example ./gotta-patch-em-all-font-patcher\!.sh "/iosevka"
+#   Process all font files that are in directories that start with "iosevka"
+
 # for executing script to rebuild JUST the readmes:
 # ./gotta-patch-em-all-font-patcher\!.sh "" info
 # to test this script with a single font (pattern):
@@ -37,9 +47,15 @@ patched_parent_dir="patched-fonts"
 max_parallel_process=64
 
 if [ $# -eq 1 ] || [ "$1" != "" ]
+then
+  if [[ "${1:0:1}" == "/" ]]
   then
-    like_pattern=$1
-    echo "$LINE_PREFIX Parameter given, limiting search and patch to pattern '$like_pattern' given"
+    like_pattern="-ipath \"*$1*/*.[o,t]tf\""
+    echo "$LINE_PREFIX Parameter given, limiting search and patch to pathname pattern '$1' given"
+  else
+    like_pattern="-iname \"$1*.[o,t]tf\""
+    echo "$LINE_PREFIX Parameter given, limiting search and patch to filename pattern '$1' given"
+  fi
 fi
 
 # simple second param option to allow to regenerate font info without re-patching
@@ -54,7 +70,7 @@ fi
 source_fonts=()
 while IFS= read -d $'\0' -r file ; do
   source_fonts=("${source_fonts[@]}" "$file")
-done < <(find "$source_fonts_dir" -iname "$like_pattern*.[o,t]tf" -type f -print0)
+done < <(find "$source_fonts_dir" ${like_pattern} -type f -print0)
 
 # print total number of source fonts found
 echo "$LINE_PREFIX Total source fonts found: ${#source_fonts[*]}"


### PR DESCRIPTION
#### Description

Fix release CI pipeline that does not patch all fonts.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Allow the release script to also patch fonts where the directory name of the font in `src/` is not the same as the (beginning of the ) font file name.

#### How should this be manually tested?

Let the CI run and examine the job. All sub-jobs from the matrix have to succeed and that means now that they patch at least one font file. Afterwards examine that all fonts in `patched-fonts/` have been rebuild.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#824

Please also consider related #786 

#### Screenshots (if appropriate or helpful)
