### PR TITLE
doc: Correct example patch call through fontforge [skip ci]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -344,7 +344,7 @@ Patching the font of your own choosing for use with the [VimDevIcons ➶][vim-de
 * Alternative usage: Execute the patcher with the FontForge binary using the script flag:
 
   ```
-  ./fontforge -script font-patcher PATH_TO_FONT
+  fontforge -script font-patcher PATH_TO_FONT
   ```
 
 * Patching fonts using the AppImage:


### PR DESCRIPTION
**[why]**
The readme states that one should call `fontforge` with `./fortforge`.
That means that no PATH is used, and will usually fail, because the user
is in our repo and not in the directory where the fontforge binary
resides in. And even if ... then the `font-patcher` script would be
somewhere else. That makes no sense.

**[how]**
Drop the `./` prefix of the `fontforge` call.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Fix `readme.md` with a sane `fontforge -script font-patcher` call.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/issues/268#issuecomment-1111035933

#### Screenshots (if appropriate or helpful)
