### PR TITLE
Fix Noto too wide

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -654,6 +654,8 @@ class font_patcher:
         #
         # 0x00-0x17f is the Latin Extended-A range
         for glyph in range(0x00, 0x17f):
+            if glyph in range(0x7F, 0xBF):
+                continue # ignore special characters like '1/4' etc
             try:
                 (_, _, xmax, _) = self.sourceFont[glyph].boundingBox()
             except TypeError:


### PR DESCRIPTION
#### Description

**[why]**
The 'monospace' width is determined by examining all the 'normal' glyphs
and taking the widest one.

'Normal' means `0x00`-`0x17f`: the Latin Extended-A range.

Unfortunately Noto has the '1/2', '1/4', '3/4' that are all wider then the
normal (i.e. letter) glyphs.

**[how]**
Exclude a small sub-range from the 'find the widest glyph' that contain
no glyphs one would call 'letter'.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Fix `Noto * Nerd Font Mono` variants.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #610

#### Screenshots (if appropriate or helpful)
