### PR TITLE
Feature: Add -WindowsCompatibleOnly switch parameter to install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -12,12 +12,18 @@
     C:\PS> ./install.ps1 FiraCode, Hack
     Installs all the FiraCode and Hack fonts.
 .EXAMPLE
+    C:\PS> ./install.ps1 CascadiaCode -WindowsCompatibleOnly
+    Filters fonts to include only those labeled as 'Windows Compatible'
+    Can be used in combination with the -FontName and/or -WhatIf parameters
+.EXAMPLE
     C:\PS> ./install.ps1 DejaVuSansMono -WhatIf
     Shows which fonts would be installed without actually installing the fonts.
     Remove the "-WhatIf" to install the fonts.
 #>
 [CmdletBinding(SupportsShouldProcess)]
-param ()
+param (
+    [switch]$WindowsCompatibleOnly
+)
 
 dynamicparam {
     $Attributes = [Collections.ObjectModel.Collection[Attribute]]::new()
@@ -44,8 +50,17 @@ end {
 
     Join-Path $PSScriptRoot patched-fonts | Push-Location
     foreach ($aFontName in $FontName) {
-        Get-ChildItem $aFontName -Filter "*.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
-        Get-ChildItem $aFontName -Filter "*.otf" -Recurse | Foreach-Object {$fontFiles.Add($_)}
+        Get-ChildItem $aFontName -Recurse | Where-Object {
+            $IsValidFileExtension = $_.Extension -match 'ttf|otf'
+
+            if ($WindowsCompatibleOnly) {
+                $IsValidFileExtension -and ($_.BaseName -match 'Windows Compatible')
+            } else {
+                $IsValidFileExtension
+            }
+        } | ForEach-Object {
+            $fontFiles.Add($_)
+        }
     }
     Pop-Location
 


### PR DESCRIPTION
#### Description
Introduces a `-WindowsCompatibleOnly` switch parameter to the existing `install.ps1` PowerShell script to allow a user to specify the installation to only include font files labeled as "Windows Compatible" (as in the font file name contains the explicit string "Windows Compatible").

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Implements `-WindowsCompatibleOnly` parameter for `install.ps1` and includes example within the help comments in same file

#### How should this be manually tested?
On a clean Windows machine (no nerd-fonts installed), invoke `PS> .\install.ps1 FiraCode -WindowsCompatibleOnly` with/without `-WhatIf` parameter

#### What are the relevant tickets (if any)?
Closes #840 