### PR TITLE
patcher: Fix grave (backtick) zero width

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -126,6 +126,14 @@ class font_patcher:
             symfont.close()
         print("\nDone with Patch Sets, generating font...")
 
+        # The grave accent and fontforge:
+        # If the type is 'auto' fontforge changes it to 'mark' on export.
+        # We can not prevent this. So set it to 'baseglyph' instead, as
+        # that resembles the most common expectations.
+        # This is not needed with fontforge March 2022 Release anymore.
+        if "grave" in self.sourceFont:
+            self.sourceFont["grave"].glyphclass="baseglyph"
+
         # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
         if self.sourceFont.fullname != None:
             self.sourceFont.generate(self.args.outputdir + "/" + self.sourceFont.fullname + self.extension, flags=(str('opentype'), str('PfEd-comments')))


### PR DESCRIPTION
#### Description

**[why]**
In ligature-enabled environments the accent grave will be rendered as
zero width, thus overlapping with the next character (in some source
fonts).

The problem is, that the glyph type in the sourcefonts is set to 'auto',
and fontforge exports these as 'mark' - the patched font will be broken.

**[how]**
There is no way we can get that glyph to be 'auto', but we can force it
to be an ordinary 'baseglyph' instead, and that will be respected on
export.

Maybe I should raise an Issue at fontforge... maybe later.

Fixes: #858
Fixes: #582

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Always set the glyph type of `grave` to 'just a normal glyph'.

#### How should this be manually tested?

Use some patched font in a ligatures enabled environment, e.g. Writer, Word, VisualStudio, ... type in one "`" and the cursor should advance one slot.

#### Any background context you can provide?

https://github.com/adam7/delugia-code/pull/11

The ~~bug~~ peculiar behavior of `fontforge` is fixed:
* `head` (3253fff88) :heavy_check_mark: 
* `20220308` release :heavy_check_mark: 
* `20201107` release :negative_squared_cross_mark: 

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

'Before' screenshots are in Issue #585.
After this the glyph will always be 'one width' wide.

![image](https://user-images.githubusercontent.com/16012374/177755077-731636fd-95f2-431d-b459-0c12a7501a6f.png)
