### PR TITLE
Allow running gotta-patch-em-all from any dir

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -20,10 +20,13 @@ type fontforge >/dev/null 2>&1 || {
   exit 1
 }
 
+# Get script directory to set source and target dirs relative to it
+sd="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
 res1=$(date +%s)
-parent_dir="${PWD}/../../"
+parent_dir="${sd}/../../"
 # Set source and target directories
-source_fonts_dir="${PWD}/../../src/unpatched-fonts"
+source_fonts_dir="${sd}/../../src/unpatched-fonts"
 like_pattern=''
 complete_variations_per_family=4
 font_typefaces_count=0


### PR DESCRIPTION
#### Description

The `gotta-patch-em-all-font-patcher!.sh` assumes that it's being run from inside `bin/scripts`, by setting source and target directories according to the output of `pwd`.
That's not super obvious from the outside. When I tried running it, I didn't know and tried running it from the root dir. That didn't cause an error, but instead the script simply didn't find any fonts.

Now it sets the directories relative to the script directory, which allows running it from anywhere.

#### What does this Pull Request (PR) do?

Added one line plus comment to the script, to set the script directory (var `sd`). Then changed the two instances of `${PWD}` to instead use `${sd}`.

#### How should this be manually tested?

Run the script from inside *or* outside `bin/scripts`, see if it works. I'm currently running it from the root dir, and it's working fine so far.