### PR TITLE
fix(jetbrain-mono-font): installation guide

### DIFF
--- a/src/unpatched-fonts/JetBrainsMono/README.md
+++ b/src/unpatched-fonts/JetBrainsMono/README.md
@@ -22,10 +22,10 @@ Select JetBrains Mono in the IDE settings: go to `Preferences/Settings` → `Edi
     ```console
     brew tap homebrew/cask-fonts
     ```
-2. Install it using the `font-jetbrains-mono` cask:
+2. Install it using the `font-jetbrains-mono-nerd-font` cask:
 
    ```console
-   brew install --cask font-jetbrains-mono
+   brew install --cask font-jetbrains-mono-nerd-font
    ```
 
 ### Manual installation


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Fix the JetBrain Mono installation guideline

#### How should this be manually tested?
None

#### Any background context you can provide?
I used the command `brew install --cask font-jetbrains-mono` and the font displayed looks weird as shown [here](#Screenshots)
Then I tried `brew install --cask font-jetbrains-mono-nerd-font` according to [this](https://gist.github.com/davidteren/898f2dcccd42d9f8680ec69a3a5d350e?permalink_comment_id=4047567#gistcomment-4047567) and it works as shown [right here](#Screenshots)

#### What are the relevant tickets (if any)?
None

#### Screenshots (if appropriate or helpful)
| Before | After |
| --- | --- |
| <img width="194" alt="1" src="https://user-images.githubusercontent.com/53143214/179245342-1a221f8e-9e53-4e4a-9da9-9b43771289f2.png"> | ![2](https://user-images.githubusercontent.com/53143214/179245395-1afcb323-6119-4aed-be30-a0c541ff1b25.png) |