### PR TITLE
Fix Failing Docker Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.title="Nerd Fonts Patcher" \
       org.opencontainers.image.source="https://github.com/ryanoasis/nerd-fonts" \
       org.opencontainers.image.licenses="MIT"
 
-RUN apk update && apk upgrade && apk add --no-cache fontforge --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+RUN apk update && apk upgrade && apk add --no-cache fontforge --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
     apk add --no-cache py3-pip && \
     pip install configparser
 


### PR DESCRIPTION
#### Description

The Alpine Linux package repository no longer contains the `fontforge` package for x86 and ARM architectures in the `edge/testing` branch, as can be verified here:

[https://pkgs.alpinelinux.org/packages?name=fontforge&branch=edge&repo=&arch=&maintainer=](https://pkgs.alpinelinux.org/packages?name=fontforge&branch=edge&repo=&arch=&maintainer=)

This commit updates the `nerdfonts/patcher` [Dockerfile](https://github.com/ryanoasis/nerd-fonts/blob/master/Dockerfile) to install the `fontforge` package from the `edge/community` branch to resolve the failing Docker builds.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Modifies the [Dockerfile](https://github.com/ryanoasis/nerd-fonts/blob/master/Dockerfile) so that the `RUN` command reads:

```dockerfile
RUN apk update && apk upgrade && apk add --no-cache fontforge --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
    apk add --no-cache py3-pip && \
    pip install configparser
```

#### How should this be manually tested?

1. Clone the `fix/docker-build` branch of the [frankhinek/nerd-fonts](https://github.com/frankhinek/nerd-fonts) repo:

    ```console
    git clone -b fix/docker-build --depth 1 https://github.com/frankhinek/nerd-fonts.git
    ```

    or manually patch the `Dockerfile` as specified above.

2. Build the Docker container image:

    ```console
    docker build -t nerdfonts/patcher .
    ```

#### Any background context you can provide?

The [nerdfonts/patcher](https://hub.docker.com/r/nerdfonts/patcher) container image published to Docker Hub hasn't been updated for 8 months, so it would be great if, after the Docker Builds are succeeding, a new image can be pushed to Docker Hub.