### PR TITLE
CI: Add Lilex to release

### DIFF
--- a/bin/scripts/lib/fonts.json
+++ b/bin/scripts/lib/fonts.json
@@ -249,6 +249,14 @@
       "description": "`0` and `O` very similar, very short tight descenders"
     },
     {
+      "unpatchedName": "Lilex",
+      "patchedName": "Lilex",
+      "folderName": "Lilex",
+      "imagePreviewFont": "Lilex Nerd Font",
+      "linkPreviewFont": "lilex",
+      "description": "Modern with ligatures"
+    },
+    {
       "unpatchedName": "Meslo",
       "patchedName": "Meslo",
       "folderName": "Meslo",


### PR DESCRIPTION
[why]
Lilex is missing from the 2.2.0 RC and is not automagically patched.

[how]
Add Lilex to the font metadata database :->

[note]
Lilex's licence has no RFN given.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Add Lilex to the Ci processes.

#### How should this be manually tested?

Run the CI

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#474 

#### Screenshots (if appropriate or helpful)
