### PR TITLE
Faster ci

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -142,10 +142,8 @@ function patch_font {
   }
   # Use absolute path to allow fontforge being an AppImage (used in CI)
   PWD=`pwd`
-  fontforge -quiet -script $PWD/font-patcher "$f" -q $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
-  fontforge -quiet -script $PWD/font-patcher "$f" -q -s ${font_config} $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
-  fontforge -quiet -script $PWD/font-patcher "$f" -q -w $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
-  fontforge -quiet -script $PWD/font-patcher "$f" -q -s ${font_config} -w $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
+  fontforge -quiet -script $PWD/font-patcher "$f" -q --also-windows $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
+  fontforge -quiet -script $PWD/font-patcher "$f" -q -s ${font_config} --also-windows $powerline $post_process --complete --no-progressbars --outputdir "${patched_font_dir}complete/" $config_patch_flags 2>/dev/null
   # wait for this group of background processes to finish to avoid forking too many processes
   # that can add up quickly with the number of combinations
   #wait

--- a/font-patcher
+++ b/font-patcher
@@ -180,7 +180,7 @@ class font_patcher:
             self.sourceFont = fontforge.open(self.args.font, 1) # 1 = ("fstypepermitted",))
         except Exception:
             sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
-        self.setup_font_names()
+        self.setup_version()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)
         self.check_position_conflicts()
@@ -242,7 +242,6 @@ class font_patcher:
 
         if symfont:
             symfont.close()
-        print("\nDone with Patch Sets, generating font...")
 
         # The grave accent and fontforge:
         # If the type is 'auto' fontforge changes it to 'mark' on export.
@@ -252,6 +251,8 @@ class font_patcher:
         if "grave" in self.sourceFont:
             self.sourceFont["grave"].glyphclass="baseglyph"
 
+
+    def generate(self):
         # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
         if self.sourceFont.fullname != None:
             outfile = self.args.outputdir + "/" + self.sourceFont.fullname + self.extension
@@ -614,6 +615,9 @@ class font_patcher:
         self.sourceFont.comment = projectInfo
         self.sourceFont.fontlog = projectInfo
 
+
+    def setup_version(self):
+        """ Add the Nerd Font version to the original version """
         # print("Version was {}".format(sourceFont.version))
         if self.sourceFont.version != None:
             self.sourceFont.version += ";" + projectName + " " + version
@@ -1225,6 +1229,9 @@ def main():
     check_fontforge_min_version()
     patcher = font_patcher()
     patcher.patch()
+    print("\nDone with Patch Sets, generating font...\n")
+    patcher.setup_font_names()
+    patcher.generate()
 
 
 if __name__ == "__main__":

--- a/font-patcher
+++ b/font-patcher
@@ -256,11 +256,11 @@ class font_patcher:
         if self.sourceFont.fullname != None:
             outfile = self.args.outputdir + "/" + self.sourceFont.fullname + self.extension
             self.sourceFont.generate(outfile, flags=(str('opentype'), str('PfEd-comments')))
-            message = "\nGenerated: {} in '{}'".format(self.sourceFont.fontname, outfile)
+            message = "\nGenerated: {} in '{}'".format(self.sourceFont.fullname, outfile)
         else:
             outfile = self.args.outputdir + "/" + self.sourceFont.cidfontname + self.extension
             self.sourceFont.generate(outfile, flags=(str('opentype'), str('PfEd-comments')))
-            message = "\nGenerated: {} in '{}'".format(self.sourceFont.fullname, outfile)
+            message = "\nGenerated: {} in '{}'".format(self.sourceFont.fontname, outfile)
 
         # Adjust flags that can not be changed via fontforge
         try:

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.0.2"
+script_version = "3.0.3"
 
 version = "2.2.1"
 projectName = "Nerd Fonts"
@@ -181,6 +181,7 @@ class font_patcher:
         except Exception:
             sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
         self.setup_version()
+        self.setup_name_backup()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)
         self.check_position_conflicts()
@@ -325,6 +326,7 @@ class font_patcher:
         progressbars_group_parser.add_argument('--progressbars',         dest='progressbars',     action='store_true',                help='Show percentage completion progress bars per Glyph Set')
         progressbars_group_parser.add_argument('--no-progressbars',      dest='progressbars',     action='store_false',               help='Don\'t show percentage completion progress bars per Glyph Set')
         parser.set_defaults(progressbars=True)
+        parser.add_argument('--also-windows',                            dest='alsowindows',      default=False, action='store_true', help='Create two fonts, the normal and the --windows version')
 
         # symbol fonts to include arguments
         sym_font_group = parser.add_argument_group('Symbol Fonts')
@@ -375,6 +377,9 @@ class font_patcher:
                     font_complete = False
             self.args.complete = font_complete
 
+        if self.args.alsowindows:
+            self.args.windows = False
+
         # this one also works but it needs to be updated every time a font is added
         # it was a conditional in self.setup_font_names() before, but it was missing
         # a symbol font, so it would name the font complete without being so sometimes.
@@ -395,7 +400,17 @@ class font_patcher:
         # ])
 
 
+    def setup_name_backup(self):
+        """ Store the original font names to be able to rename the font multiple times """
+        self.original_fontname = self.sourceFont.fontname
+        self.original_fullname = self.sourceFont.fullname
+        self.original_familyname = self.sourceFont.familyname
+
+
     def setup_font_names(self):
+        self.sourceFont.fontname = self.original_fontname
+        self.sourceFont.fullname = self.original_fullname
+        self.sourceFont.familyname = self.original_familyname
         verboseAdditionalFontNameSuffix = " " + projectNameSingular
         if self.args.windows:  # attempt to shorten here on the additional name BEFORE trimming later
             additionalFontNameSuffix = " " + projectNameAbbreviation
@@ -1232,6 +1247,11 @@ def main():
     print("\nDone with Patch Sets, generating font...\n")
     patcher.setup_font_names()
     patcher.generate()
+    # This mainly helps to improve CI runtime
+    if patcher.args.alsowindows:
+        patcher.args.windows = True
+        patcher.setup_font_names()
+        patcher.generate()
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -370,27 +370,27 @@ Patching the font of your own choosing for use with the [VimDevIcons ➶][vim-de
 Full options:
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -401,12 +401,33 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Change font file type to create (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
   --fontawesomeextension
                         Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
   --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
   --powerline           Add Powerline Glyphs
@@ -415,20 +436,6 @@ optional arguments:
                         Add Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Add Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
-  --postprocess [POSTPROCESS]
-                        Specify a Script for Post Processing
-  --removeligs, --removeligatures
-                        Removes ligatures specified in JSON configuration file
-  --configfile [CONFIGFILE]
-                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Change font file type to create (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        The directory to output the patched font file to
 ```
 
 #### Examples

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -381,19 +381,20 @@ The list is not complete, but you can [search for a complete list here](https://
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--custom [CUSTOM]]
-                    [--postprocess [POSTPROCESS]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 1.2.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -411,26 +412,38 @@ optional arguments:
                         不生成 verbose output
   -w, --windows         将内部字体名称限制在31个字符内 (为了 Windows 兼容性)
   -c, --complete        加入所有可用的字体
+  --careful             如果发现了已经存在的字形，不要对它进行复写
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     指定一个自定义图标字体，所有新字形都会在不缩放的情况下被拷贝。
+  -ext [EXTENSION], --extension [EXTENSION]
+                        更改字体文件的文件格式去创建新文件 (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        将修补后的字体文件输出到特定目录
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        显示每个Glyph Set的完成度进度条
+  --no-progressbars     不显示每个Glyph Set的完成度进度条
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         加入 Font Awesome Glyphs字体 (http://fontawesome.io/)
   --fontawesomeextension
                         加入 Font Awesome 补充字体 (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux           加入 Font Linux 字体 (https://github.com/Lukas-W/font-linux)
   --octicons            加入 Octicons 字体 (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        加入 IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            加入 Pomicon 字体 (https://github.com/gabrielelana/pomicons)
   --powerline           加入 Powerline 字体
   --powerlineextra      加入 Powerline 字体 (https://github.com/ryanoasis/powerline-extra-symbols)
-  --custom [CUSTOM]     指定一个自定义图标字体，所有新字形都会在不缩放的情况下被拷贝。
   --postprocess [POSTPROCESS]
                         指定一个针对后续进程的脚本
-  --progressbars        显示每个Glyph Set的完成度进度条
-  --no-progressbars     不显示每个Glyph Set的完成度进度条
-  --careful             如果发现了已经存在的字形，不要对它进行复写
-  -ext [EXTENSION], --extension [EXTENSION]
-                        更改字体文件的文件格式去创建新文件 (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        将修补后的字体文件输出到特定目录
-
 ```
 
 #### 例子

--- a/readme_es.md
+++ b/readme_es.md
@@ -329,20 +329,20 @@ Parcha la fuente de tu preferencia para usar los [VimDevIcons ➶][vim-devicons]
 
 
 ```
-uso: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
-                    font
+uso: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                  [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                  [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                  [--glyphdir [GLYPHDIR]] [--makegroups]
+                  [--progressbars | --no-progressbars] [--also-windows]
+                  [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                  [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                  [--powerline] [--powerlineextra] [--material] [--weather]
+                  font
 
 Parchador de fuentes Nerd Fonts: parcha una fuente dada con glifos relacionados con la programación y el desarrollo
 
 * Sitio web: https://www.nerdfonts.com
-* Versión: 2.0.0
+* Versión: 2.2.1
 * Sitio de Desarrollo: https://github.com/ryanoasis/nerd-fonts
 * Registro de Cambios: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -360,12 +360,33 @@ argumentos opcionales:
                         No generar salida verbal
   -w, --windows         Limitar el nombre interno de la fuente a 31 caracteres (para compatibilidad con Windows)
   -c, --complete        Añade todos los glifos disponibles
+  --careful             No sobreescribe los glifos que ya existen si son detectados
+  --removeligs, --removeligatures
+                        Remueve ligaturas especificadas en el archivo de configuración JSON
+  --postprocess [POSTPROCESS]
+                        Especifica un Script para Post Procesamiento
+  --configfile [CONFIGFILE]
+                        Especifica una ruta de archivo para un archivo de configuración JSON (mira el ejemplo en: src/config.sample.json)
+  --custom [CUSTOM]     Especifica una fuente de símbolos personalizados. Todos los glifos nuevos serán copiados, sin aplicar escala.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Cambia el tipo de archivo de fuente a crear (ej., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        El directorio donde se generará el archivo de fuente parchado
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
+  --no-progressbars     No muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Añade los glifos de Font Awesome (http://fontawesome.io/)
   --fontawesomeextension
                         Añade los glifos de Font Awesome Extension (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Añade los glifos de Font Linux y otros glifos de Código Libre (https://github.com/Lukas-W/font-logos)
   --octicons            Añade los glifos de Octicons (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Añade los glifos de IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Añade los glifos de Pomicon (https://github.com/gabrielelana/pomicons)
   --powerline           Añade los glifos de Powerline
@@ -374,20 +395,6 @@ argumentos opcionales:
                         Añade los glifos de Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Añade los glifos de Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Especifica una fuente de símbolos personalizados. Todos los glifos nuevos serán copiados, sin aplicar escala.
-  --postprocess [POSTPROCESS]
-                        Especifica un Script para Post Procesamiento
-  --removeligs, --removeligatures
-                        Remueve ligaturas especificadas en el archivo de configuración JSON
-  --configfile [CONFIGFILE]
-                        Especifica una ruta de archivo para un archivo de configuración JSON (mira el ejemplo en: src/config.sample.json)
-  --progressbars        Muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
-  --no-progressbars     No muestra barras de progreso con porcentajes de completitud por cada Conjunto de Glifos
-  --careful             No sobreescribe los glifos que ya existen si son detectados
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Cambia el tipo de archivo de fuente a crear (ej., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        El directorio donde se generará el archivo de fuente parchado
 ```
 
 #### Ejemplos

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -407,27 +407,27 @@ Générer la police de votre choix pour l'utiliser avec [VimDevIcons ➶][vim-de
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -438,12 +438,33 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Change font file type to create (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
   --fontawesomeextension
                         Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
   --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
   --powerline           Add Powerline Glyphs
@@ -452,20 +473,6 @@ optional arguments:
                         Add Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Add Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
-  --postprocess [POSTPROCESS]
-                        Specify a Script for Post Processing
-  --removeligs, --removeligatures
-                        Removes ligatures specificed in JSON configuration file
-  --configfile [CONFIGFILE]
-                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Change font file type to create (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        The directory to output the patched font file to
 ```
 
 #### Exemples

--- a/readme_hi.md
+++ b/readme_hi.md
@@ -362,20 +362,20 @@ The list is not complete, but you can [search for a complete list here](https://
 
 पूर्ण विकल्प:
 
-    प्रयोग: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                        [--fontawesomeextension] [--fontlinux] [--octicons]
-                        [--powersymbols] [--pomicons] [--powerline]
-                        [--powerlineextra] [--material] [--weather]
-                        [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                        [--removeligs] [--configfile [CONFIGFILE]]
-                        [--progressbars | --no-progressbars] [--careful]
-                        [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+    प्रयोग: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                         font
     
     Nerd Fonts Font Patcher: किसी दिए गए फ़ॉन्ट को प्रोग्रामिंग और विकास संबंधी ग्लिफ़ के साथ पैच करता है
     
     * वेबसाइट: https://www.nerdfonts.com
-    * संस्करण: 2.0.0
+    * संस्करण: 2.2.1
     * विकास वेबसाइट: https://github.com/ryanoasis/nerd-fonts
     * बदलाव का लॉग: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
     
@@ -393,12 +393,33 @@ The list is not complete, but you can [search for a complete list here](https://
                             वर्बोज़ आउटपुट उत्पन्न न करें
       -w, --windows         आंतरिक फ़ॉन्ट नाम को 31 वर्णों तक सीमित करें (Windows संगतता के लिए)
       -c, --complete        सभी उपलब्ध ग्लिफ़ जोड़ें
+      --careful             पता चलने पर मौजूदा ग्लिफ़ को अधिलेखित न करें
+      --removeligs, --removeligatures
+                            JSON कॉन्फ़िगरेशन फ़ाइल में निर्दिष्ट संयुक्ताक्षर को हटाता है
+      --postprocess [POSTPROCESS]
+                            पोस्ट प्रोसेसिंग के लिए एक स्क्रिप्ट निर्दिष्ट करें
+      --configfile [CONFIGFILE]
+                            JSON कॉन्फ़िगरेशन फ़ाइल के लिए फ़ाइल पथ निर्दिष्ट करें (see sample: src/config.sample.json)
+      --custom [CUSTOM]     एक कस्टम प्रतीक फ़ॉन्ट निर्दिष्ट करें। सभी नए ग्लिफ़ की प्रतिलिपि बनाई जाएगी, जिसमें कोई स्केलिंग लागू नहीं होगी।
+      -ext [EXTENSION], --extension [EXTENSION]
+                            बनाने के लिए फ़ॉन्ट फ़ाइल प्रकार बदलें (e.g., ttf, otf)
+      -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                            पैच की गई फ़ॉन्ट फ़ाइल को आउटपुट करने के लिए निर्देशिका
+      --glyphdir [GLYPHDIR]
+                            Path to glyphs to be used for patching
+      --makegroups          Use alternative method to name patched fonts (experimental)
+      --progressbars        प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार दिखाएं
+      --no-progressbars     प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार न दिखाएं
+      --also-windows        Create two fonts, the normal and the --windows version
+
+    Symbol Fonts:
       --fontawesome         फ़ॉन्ट विस्मयकारी ग्लिफ़ जोड़ें (http://fontawesome.io/)
       --fontawesomeextension
                             फ़ॉन्ट विस्मयकारी एक्सटेंशन ग्लिफ़ जोड़ें (https://andrelzgava.github.io/font-awesome-extension/)
       --fontlinux, --fontlogos
                             फ़ॉन्ट लिनक्स और अन्य ओपन सोर्स ग्लिफ़ जोड़ें (https://github.com/Lukas-W/font-logos)
       --octicons            ऑक्टिकॉन ग्लिफ़ जोड़ें (https://octicons.github.com)
+      --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
       --powersymbols        आईईसी पावर सिंबल जोड़ें (https://unicodepowersymbol.com/)
       --pomicons            पोमिकॉन ग्लिफ़्स जोड़ें (https://github.com/gabrielelana/pomicons)
       --powerline           पावरलाइन ग्लिफ़ जोड़ें
@@ -407,20 +428,6 @@ The list is not complete, but you can [search for a complete list here](https://
                             सामग्री डिजाइन चिह्न जोड़ें (https://github.com/templarian/MaterialDesign)
       --weather, --weathericons
                             मौसम चिह्न जोड़ें (https://github.com/erikflowers/weather-icons)
-      --custom [CUSTOM]     एक कस्टम प्रतीक फ़ॉन्ट निर्दिष्ट करें। सभी नए ग्लिफ़ की प्रतिलिपि बनाई जाएगी, जिसमें कोई स्केलिंग लागू नहीं होगी।
-      --postprocess [POSTPROCESS]
-                            पोस्ट प्रोसेसिंग के लिए एक स्क्रिप्ट निर्दिष्ट करें
-      --removeligs, --removeligatures
-                            JSON कॉन्फ़िगरेशन फ़ाइल में निर्दिष्ट संयुक्ताक्षर को हटाता है
-      --configfile [CONFIGFILE]
-                            JSON कॉन्फ़िगरेशन फ़ाइल के लिए फ़ाइल पथ निर्दिष्ट करें (see sample: src/config.sample.json)
-      --progressbars        प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार दिखाएं
-      --no-progressbars     प्रति ग्लिफ़ सेट प्रतिशत पूर्णता प्रगति बार न दिखाएं
-      --careful             पता चलने पर मौजूदा ग्लिफ़ को अधिलेखित न करें
-      -ext [EXTENSION], --extension [EXTENSION]
-                            बनाने के लिए फ़ॉन्ट फ़ाइल प्रकार बदलें (e.g., ttf, otf)
-      -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                            पैच की गई फ़ॉन्ट फ़ाइल को आउटपुट करने के लिए निर्देशिका
 
 #### उदाहरण
 

--- a/readme_it.md
+++ b/readme_it.md
@@ -330,27 +330,27 @@ Modificare il font di tua scelta per utilizzare i [VimDevIcons ➶][vim-devicons
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -361,12 +361,33 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Change font file type to create (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
   --fontawesomeextension
                         Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
   --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
   --powerline           Add Powerline Glyphs
@@ -375,20 +396,6 @@ optional arguments:
                         Add Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Add Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
-  --postprocess [POSTPROCESS]
-                        Specify a Script for Post Processing
-  --removeligs, --removeligatures
-                        Removes ligatures specified in JSON configuration file
-  --configfile [CONFIGFILE]
-                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Change font file type to create (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        The directory to output the patched font file to
 ```
 
 #### Esempi

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -325,20 +325,20 @@ The list is not complete, but you can [search for a complete list here](https://
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -356,12 +356,33 @@ optional arguments:
                         デバッグメッセージを表示しません。
   -w, --windows         内部で利用するフォント名を 31 文字に制限します (Windows の互換性のためのオプションです)。
   -c, --complete        全ての利用可能なグリフを追加します。
+  --careful             既に存在するグリフがあれば、それを上書きしないようにします。
+  --removeligs, --removeligatures
+                        設定ファイルの JSON で指定されたリガチャを除きます。
+  --postprocess [POSTPROCESS]
+                        あと処理を行うためのスクリプトを指定します。
+  --configfile [CONFIGFILE]
+                        設定ファイルの JSON を指定します (src/config.sample.json の例を見てください)。
+  --custom [CUSTOM]     カスタムのシンボルフォントを指定します。全てのグリフがコピーされますが、大きさは変更されません。
+  -ext [EXTENSION], --extension [EXTENSION]
+                        作成するフォントのファイルタイプを変更します (例: ttf, otf)。
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        パッチを当てたファイルを保存するディレクトリ。
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        グリフセットごとに進捗を百分率で表示します。
+  --no-progressbars     グリフセットごとの進捗を表示しません。
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Font Awesome のグリフを追加します (http://fontawesome.io/)。
   --fontawesomeextension
                         Font Awesome Extension のグリフを追加します (https://andrelzgava.github.io/font-awesome-extension/)。
   --fontlinux, --fontlogos
                         Font Linux とその他のオープンソースのグリフを追加します (https://github.com/Lukas-W/font-logos)。
   --octicons            Octicons Glyphs のグリフを追加します (https://octicons.github.com)。
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        IEC Power Symbols のグリフを追加します (https://unicodepowersymbol.com/)。
   --pomicons            Pomicon のグリフを追加します (https://github.com/gabrielelana/pomicons)。
   --powerline           Powerline グリフを追加します。
@@ -370,20 +391,6 @@ optional arguments:
                         Material Design Icons のグリフを追加します (https://github.com/templarian/MaterialDesign)。
   --weather, --weathericons
                         Weather Icons のグリフを追加します (https://github.com/erikflowers/weather-icons)。
-  --custom [CUSTOM]     カスタムのシンボルフォントを指定します。全てのグリフがコピーされますが、大きさは変更されません。
-  --postprocess [POSTPROCESS]
-                        あと処理を行うためのスクリプトを指定します。
-  --removeligs, --removeligatures
-                        設定ファイルの JSON で指定されたリガチャを除きます。
-  --configfile [CONFIGFILE]
-                        設定ファイルの JSON を指定します (src/config.sample.json の例を見てください)。
-  --progressbars        グリフセットごとに進捗を百分率で表示します。
-  --no-progressbars     グリフセットごとの進捗を表示しません。
-  --careful             既に存在するグリフがあれば、それを上書きしないようにします。
-  -ext [EXTENSION], --extension [EXTENSION]
-                        作成するフォントのファイルタイプを変更します (例: ttf, otf)。
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        パッチを当てたファイルを保存するディレクトリ。
 ```
 
 #### Examples

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -326,27 +326,27 @@ The list is not complete, but you can [search for a complete list here](https://
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -357,12 +357,33 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Change font file type to create (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
   --fontawesomeextension
                         Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
   --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
   --powerline           Add Powerline Glyphs
@@ -371,20 +392,6 @@ optional arguments:
                         Add Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Add Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
-  --postprocess [POSTPROCESS]
-                        Specify a Script for Post Processing
-  --removeligs, --removeligatures
-                        Removes ligatures specified in JSON configuration file
-  --configfile [CONFIGFILE]
-                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Change font file type to create (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        The directory to output the patched font file to
 ```
 
 #### 예시

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -402,27 +402,27 @@ Patchowanie wybranych przez ciebie fontów z wykorzystaniem [VimDevIcons ➶][vi
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 2.0.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -433,12 +433,33 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        Specify a Script for Post Processing
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Change font file type to create (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
   --fontawesomeextension
                         Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux, --fontlogos
                         Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
   --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
   --powerline           Add Powerline Glyphs
@@ -447,20 +468,6 @@ optional arguments:
                         Add Material Design Icons (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Add Weather Icons (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
-  --postprocess [POSTPROCESS]
-                        Specify a Script for Post Processing
-  --removeligs, --removeligatures
-                        Removes ligatures specificed in JSON configuration file
-  --configfile [CONFIGFILE]
-                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Change font file type to create (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        The directory to output the patched font file to
 ```
 
 #### Przykłady

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -326,20 +326,20 @@ Modificar o tipo de letra à tua escolha com [VimDevIcons ➶][vim-devicons]:
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--material] [--weather]
-                    [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                    [--removeligs] [--configfile [CONFIGFILE]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Modificador de Fontes Nerd Fonts: modifica uma determinada fonte com glifos relacionados à programação e ao desenvolvimento
 
 * Website: https://www.nerdfonts.com
-* Versão: 2.0.0
+* Versão: 2.2.1
 * Website do desenvolvimento: https://github.com/ryanoasis/nerd-fonts
 * Histórico de alterações: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -357,6 +357,26 @@ argumentos opcionais:
                         Não gerar saída de detalhe
   -w, --windows         Limitar o nome da fonte interna a 31 caracteres (para compatibilidade com o Windows)
   -c, --complete        Aderir todos os glifos disponíveis
+  --careful             Não substituir os glifos existentes se detectados
+  --removeligs, --removeligatures
+                        Remove as ligaduras especificadas no ficheiro de configuração JSON
+  --postprocess [POSTPROCESS]
+                        Especificar um executador para pós-processador
+  --configfile [CONFIGFILE]
+                        Especificar um caminho para o arquivo de configuração JSON (vê a amostra: src/config.sample.json)
+  --custom [CUSTOM]     Especificar um tipo de letra de símbolos personalizada. Todos os novos glifos serão copiados, sem escala aplicada.
+  -ext [EXTENSION], --extension [EXTENSION]
+                        Alterar o tipo de ficheiro de fonte para criar (por exemplo, ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        O diretório para enviar o ficheiro de tipo de letra modificado para
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Mostrar barras de progresso de conclusão percentual por Glyph Set
+  --no-progressbars     Não mostrar barras de progresso de conclusão percentual por Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         Aderir os glifos do Font Awesome (http://fontawesome.io/)
   --fontawesomeextension
                         Aderir os glifos do Font Awesome Extension (https://andrelzgava.github.io/font-awesome-extension/)
@@ -371,20 +391,6 @@ argumentos opcionais:
                         Aderir os ícones do Material Design (https://github.com/templarian/MaterialDesign)
   --weather, --weathericons
                         Aderir os ícones do Weather (https://github.com/erikflowers/weather-icons)
-  --custom [CUSTOM]     Especificar um tipo de letra de símbolos personalizada. Todos os novos glifos serão copiados, sem escala aplicada.
-  --postprocess [POSTPROCESS]
-                        Especificar um executador para pós-processador
-  --removeligs, --removeligatures
-                        Remove as ligaduras especificadas no ficheiro de configuração JSON
-  --configfile [CONFIGFILE]
-                        Especificar um caminho para o arquivo de configuração JSON (vê a amostra: src/config.sample.json)
-  --progressbars        Mostrar barras de progresso de conclusão percentual por Glyph Set
-  --no-progressbars     Não mostrar barras de progresso de conclusão percentual por Glyph Set
-  --careful             Não substituir os glifos existentes se detectados
-  -ext [EXTENSION], --extension [EXTENSION]
-                        Alterar o tipo de ficheiro de fonte para criar (por exemplo, ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        O diretório para enviar o ficheiro de tipo de letra modificado para
 ```
 
 #### Exemplos

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -381,26 +381,27 @@ The list is not complete, but you can [search for a complete list here](https://
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--custom [CUSTOM]]
-                    [--postprocess [POSTPROCESS]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 1.2.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
 positional arguments:
   font                  The path to the font to patch (e.g., Inconsolata.otf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --mono, --use-single-width-glyphs
@@ -411,26 +412,41 @@ optional arguments:
                         Do not generate verbose output
   -w, --windows         Limit the internal font name to 31 characters (for Windows compatibility)
   -c, --complete        Add all available Glyphs
-  --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
-  --fontawesomeextension
-                        Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
-  --fontlinux           Add Font Linux Glyphs (https://github.com/Lukas-W/font-linux)
-  --octicons            Add Octicons Glyphs (https://octicons.github.com)
-  --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
-  --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
-  --powerline           Add Powerline Glyphs
-  --powerlineextra      Add Powerline Glyphs (https://github.com/ryanoasis/powerline-extra-symbols)
-  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
+  --careful             Do not overwrite existing glyphs if detected
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
   --postprocess [POSTPROCESS]
                         Specify a Script for Post Processing
-  --progressbars        Show percentage completion progress bars per Glyph Set
-  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
-  --careful             Do not overwrite existing glyphs if detected
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.
   -ext [EXTENSION], --extension [EXTENSION]
                         Change font file type to create (e.g., ttf, otf)
   -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
                         The directory to output the patched font file to
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        Show percentage completion progress bars per Glyph Set
+  --no-progressbars     Don't show percentage completion progress bars per Glyph Set
+  --also-windows        Create two fonts, the normal and the --windows version
 
+Symbol Fonts:
+  --fontawesome         Add Font Awesome Glyphs (http://fontawesome.io/)
+  --fontawesomeextension
+                        Add Font Awesome Extension Glyphs (https://andrelzgava.github.io/font-awesome-extension/)
+  --fontlinux, --fontlogos
+                        Add Font Linux and other open source Glyphs (https://github.com/Lukas-W/font-logos)
+  --octicons            Add Octicons Glyphs (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
+  --powersymbols        Add IEC Power Symbols (https://unicodepowersymbol.com/)
+  --pomicons            Add Pomicon Glyphs (https://github.com/gabrielelana/pomicons)
+  --powerline           Add Powerline Glyphs
+  --powerlineextra      Add Powerline Glyphs (https://github.com/ryanoasis/powerline-extra-symbols)
+  --material, --materialdesignicons, --mdi
+                        Add Material Design Icons (https://github.com/templarian/MaterialDesign)
+  --weather, --weathericons
+                        Add Weather Icons (https://github.com/erikflowers/weather-icons)
 ```
 
 #### Примеры

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -381,19 +381,20 @@ The list is not complete, but you can [search for a complete list here](https://
 
 
 ```
-usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                    [--fontawesomeextension] [--fontlinux] [--octicons]
-                    [--powersymbols] [--pomicons] [--powerline]
-                    [--powerlineextra] [--custom [CUSTOM]]
-                    [--postprocess [POSTPROCESS]]
-                    [--progressbars | --no-progressbars] [--careful]
-                    [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                    [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                    [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                    [--glyphdir [GLYPHDIR]] [--makegroups]
+                    [--progressbars | --no-progressbars] [--also-windows]
+                    [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                    [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                    [--powerline] [--powerlineextra] [--material] [--weather]
                     font
 
 Nerd Fonts Font Patcher: patches a given font with programming and development related glyphs
 
 * Website: https://www.nerdfonts.com
-* Version: 1.2.0
+* Version: 2.2.1
 * Development Website: https://github.com/ryanoasis/nerd-fonts
 * Changelog: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -411,26 +412,36 @@ optional arguments:
                         不生成 verbose output
   -w, --windows         將內部字體名稱限制在31個符號內 (為了 Windows 相容性)
   -c, --complete        加入所有可用的字體
+  --careful             如果發現了已經存在的字形，不要對它進行覆寫
+  --removeligs, --removeligatures
+                        Removes ligatures specificed in JSON configuration file
+  --postprocess [POSTPROCESS]
+                        指定一個針對後續處理程式的腳本
+  --configfile [CONFIGFILE]
+                        Specify a file path for JSON configuration file (see sample: src/config.sample.json)
+  --custom [CUSTOM]     指定一個自訂圖示字體，所有新字形都會在不縮放的情況下被複製。
+  -ext [EXTENSION], --extension [EXTENSION]
+                        更改字體文件的文件格式去創建新文件 (e.g., ttf, otf)
+  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                        將修補後的字體文件輸出到特定目錄
+  --glyphdir [GLYPHDIR]
+                        Path to glyphs to be used for patching
+  --makegroups          Use alternative method to name patched fonts (experimental)
+  --progressbars        顯示每個Glyph Set的完成度進度條
+  --no-progressbars     不顯示每個Glyph Set的完成度進度條
+  --also-windows        Create two fonts, the normal and the --windows version
+
+Symbol Fonts:
   --fontawesome         加入 Font Awesome Glyphs字體 (http://fontawesome.io/)
   --fontawesomeextension
                         加入 Font Awesome 補充字體 (https://andrelzgava.github.io/font-awesome-extension/)
   --fontlinux           加入 Font Linux 字體 (https://github.com/Lukas-W/font-linux)
   --octicons            加入 Octicons 字體 (https://octicons.github.com)
+  --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
   --powersymbols        加入 IEC Power Symbols (https://unicodepowersymbol.com/)
   --pomicons            加入 Pomicon 字體 (https://github.com/gabrielelana/pomicons)
   --powerline           加入 Powerline 字體
   --powerlineextra      加入 Powerline 字體 (https://github.com/ryanoasis/powerline-extra-symbols)
-  --custom [CUSTOM]     指定一個自訂圖示字體，所有新字形都會在不縮放的情況下被複製。
-  --postprocess [POSTPROCESS]
-                        指定一個針對後續處理程式的腳本
-  --progressbars        顯示每個Glyph Set的完成度進度條
-  --no-progressbars     不顯示每個Glyph Set的完成度進度條
-  --careful             如果發現了已經存在的字形，不要對它進行覆寫
-  -ext [EXTENSION], --extension [EXTENSION]
-                        更改字體文件的文件格式去創建新文件 (e.g., ttf, otf)
-  -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                        將修補後的字體文件輸出到特定目錄
-
 ```
 
 #### 例子

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -323,20 +323,20 @@ The list is not complete, but you can [search for a complete list here](https://
 ```
     ./fontforge -script font-patcher ШЛЯХ_ДО_ШРИФТА
 
-    usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--fontawesome]
-                        [--fontawesomeextension] [--fontlinux] [--octicons]
-                        [--powersymbols] [--pomicons] [--powerline]
-                        [--powerlineextra] [--material] [--weather]
-                        [--custom [CUSTOM]] [--postprocess [POSTPROCESS]]
-                        [--removeligs] [--configfile [CONFIGFILE]]
-                        [--progressbars | --no-progressbars] [--careful]
-                        [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+    usage: font-patcher [-h] [-v] [-s] [-l] [-q] [-w] [-c] [--careful] [--removeligs]
+                        [--postprocess [POSTPROCESS]] [--configfile [CONFIGFILE]]
+                        [--custom [CUSTOM]] [-ext [EXTENSION]] [-out [OUTPUTDIR]]
+                        [--glyphdir [GLYPHDIR]] [--makegroups]
+                        [--progressbars | --no-progressbars] [--also-windows]
+                        [--fontawesome] [--fontawesomeextension] [--fontlinux]
+                        [--octicons] [--codicons] [--powersymbols] [--pomicons]
+                        [--powerline] [--powerlineextra] [--material] [--weather]
                         font
 
     Nerd Fonts Font Patcher: виправляє заданий шрифт програмістами та гліфами, пов'язаними з розробкою
 
     * Веб-сайт: https://www.nerdfonts.com
-    * Версія: 2.0.0
+    * Версія: 2.2.1
     * Веб-сайт для розробки: https://github.com/ryanoasis/nerd-fonts
     * Журнал змін: https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md
 
@@ -354,12 +354,33 @@ The list is not complete, but you can [search for a complete list here](https://
                             Не генерувати звіт
       -w, --windows         Обмежте внутрішнє ім'я шрифту до 31 символу (для сумісності з Windows)
       -c, --complete        Додайте всі доступні гліфи
+      --careful             Не перезаписує наявні гліфи, якщо вони виявлені
+      --removeligs, --removeligatures
+                            Видаляє лігатури, вказані у файлі конфігурації JSON
+      --postprocess [POSTPROCESS]
+                            Вкажіть скрипт для постобробки
+      --configfile [CONFIGFILE]
+                            Вкажіть шлях до файлу конфігурації JSON (див. зразок: src/config.sample.json)
+      --custom [CUSTOM]     Вкажіть спеціальний шрифт символу. Усі нові гліфи будуть скопійовані без масштабування
+      -ext [EXTENSION], --extension [EXTENSION]
+                            Змініть тип файлу шрифту для створення (наприклад, ttf, otf)
+      -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
+                            Каталог для виводу виправленого файлу шрифту
+      --glyphdir [GLYPHDIR]
+                            Path to glyphs to be used for patching
+      --makegroups          Use alternative method to name patched fonts (experimental)
+      --progressbars        Показати прогресбар виконання обробки кожного гліфу
+      --no-progressbars     Не показувати прогресбар виконання обробки кожного гліфу
+      --also-windows        Create two fonts, the normal and the --windows version
+
+    Symbol Fonts:
       --fontawesome         Додайте Font Awesome гліфи (http://fontawesome.io/)
       --fontawesomeextension
                             Додайте Font Awesome Extension гліфи (https://andrelzgava.github.io/font-awesome-extension/)
       --fontlinux, --fontlogos
                             Додайте Font Linux та інші open source гліфи (https://github.com/Lukas-W/font-logos)
       --octicons            Додайте Octicons гліфи (https://octicons.github.com)
+      --codicons            Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)
       --powersymbols        Додайте IEC Power Symbols (https://unicodepowersymbol.com/)
       --pomicons            Додайте Pomicon гліфи (https://github.com/gabrielelana/pomicons)
       --powerline           Додайте Powerline гліфи
@@ -368,20 +389,6 @@ The list is not complete, but you can [search for a complete list here](https://
                             Додайте Material Design іконки (https://github.com/templarian/MaterialDesign)
       --weather, --weathericons
                             Додайте Weather іконки (https://github.com/erikflowers/weather-icons)
-      --custom [CUSTOM]     Вкажіть спеціальний шрифт символу. Усі нові гліфи будуть скопійовані без масштабування
-      --postprocess [POSTPROCESS]
-                            Вкажіть скрипт для постобробки
-      --removeligs, --removeligatures
-                            Видаляє лігатури, вказані у файлі конфігурації JSON
-      --configfile [CONFIGFILE]
-                            Вкажіть шлях до файлу конфігурації JSON (див. зразок: src/config.sample.json)
-      --progressbars        Показати прогресбар виконання обробки кожного гліфу
-      --no-progressbars     Не показувати прогресбар виконання обробки кожного гліфу
-      --careful             Не перезаписує наявні гліфи, якщо вони виявлені
-      -ext [EXTENSION], --extension [EXTENSION]
-                            Змініть тип файлу шрифту для створення (наприклад, ttf, otf)
-      -out [OUTPUTDIR], --outputdir [OUTPUTDIR]
-                            Каталог для виводу виправленого файлу шрифту
 ```
 #### Приклади
 


### PR DESCRIPTION
#### Description

Make CI faster (by almost factor of 2)

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

At the moment the `font-patcher` is run 4 times for each source-font file.
But in fact that are two pairs of identical patch runs just with different font naming (shorter names for windows).

We can reuse the patched font held into `fontforge` and export it twice with different naming.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

#### Note
This also updates the readme translations, as best as I could.