### PR TITLE
Update Hasklig readme

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1102,6 +1102,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "chezbgone",
+      "name": "Jason Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7344128?v=4",
+      "profile": "https://github.com/chezbgone",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github",

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -163,6 +163,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="http://cstrahan.com/"><img src="https://avatars.githubusercontent.com/u/143982?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Charles Strahan</b></sub></a><br /><a href="https://github.com/ryanoasis/nerd-fonts/commits?author=cstrahan" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/chezbgone"><img src="https://avatars.githubusercontent.com/u/7344128?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jason Chen</b></sub></a><br /><a href="https://github.com/ryanoasis/nerd-fonts/commits?author=chezbgone" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/patched-fonts/Hasklig/readme.md
+++ b/patched-fonts/Hasklig/readme.md
@@ -12,7 +12,7 @@ Hasklig solves the problem the way typographers have always solved ill-fitting c
 
 Not only can multi-character glyphs be rendered more vividly, other problematic things in monospaced fonts, such as spacing can be corrected.
 
-[**Download Hasklig Font Family v1.1**](https://github.com/i-tu/Hasklig/releases/download/1.1/Hasklig-1.1.zip)
+[**Download Hasklig Font Family v1.2**](https://github.com/i-tu/Hasklig/releases/download/v1.2/Hasklig-1.2.zip)
 
 #### Hasklig
 ![Hasklig Sample](hasklig_example.png?raw=true)
@@ -21,6 +21,13 @@ Not only can multi-character glyphs be rendered more vividly, other problematic 
 ![Source Code Pro Sample](SourceCodeProSample.png?raw=true)
 
 ### Release notes
++ [v1.2](https://github.com/i-tu/Hasklig/releases/tag/1.2)
+  + Include latest changes from the Source Code Pro repository `master` branch ([adobe-fonts/source-code-pro@`14875b7`](https://github.com/adobe-fonts/source-code-pro/commit/14875b70293e83159ad85c7d9d9081e76403d1e3)).\
+    The Source Code Versions Hasklig v1.2 is based on are:
+    - Roman 2.032
+    - Italic 1.052
+    - Variable _not supported_
+  + Most notably, this update resolves (https://github.com/i-tu/Hasklig/issues/123).
 + [v1.1](https://github.com/i-tu/Hasklig/releases/tag/1.1)
     + New ligatures `->>`, `:::`, `>=>`, `<=<`, `<=>`, `<->`
     + Switched to newer version of calt code by [Nikita Prokopov](https://github.com/tonsky/FiraCode). It "doesn’t apply ligatures to long sequences of chars, e.g. !!!!, >>>>, etc"


### PR DESCRIPTION
The patched Hasklig font was updated to use Hasklig v1.2 in d4d8d9e184a487fd92412ff639b79b0d61908b91, but the readme was not updated. This PR updates the readme with the appropriate information found [here](https://github.com/i-tu/Hasklig/releases/tag/v1.2).