### PR TITLE
font-patcher: Do not overwrite glyphs that are needed for basic glyphs

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.0.3"
+script_version = "3.0.4"
 
 version = "2.2.1"
 projectName = "Nerd Fonts"
@@ -167,6 +167,7 @@ class font_patcher:
         self.font_dim = None  # class 'dict'
         self.onlybitmaps = 0
         self.extension = ""
+        self.essential = set()
         self.setup_arguments()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
         if not os.path.isfile(self.args.font):
@@ -181,6 +182,7 @@ class font_patcher:
         except Exception:
             sys.exit(projectName + ": Can not open font, try to open with fontforge interactively to get more information")
         self.setup_version()
+        self.get_essential_references()
         self.setup_name_backup()
         self.remove_ligatures()
         make_sure_path_exists(self.args.outputdir)
@@ -835,6 +837,17 @@ class font_patcher:
         self.sourceFont.hhea_linegap = 0
         self.sourceFont.os2_typolinegap = 0
 
+    def get_essential_references(self):
+        """Find glyphs that are needed for the basic glyphs"""
+        # Sometimes basic glyphs are constructed from multiple other glyphs.
+        # Find out which other glyphs are also needed to keep the basic
+        # glyphs intact.
+        # 0x00-0x17f is the Latin Extended-A range
+        for glyph in range(0x21, 0x17f):
+            if not glyph in self.sourceFont:
+                continue
+            for (r, _) in self.sourceFont[glyph].references:
+                self.essential.add(self.sourceFont[r].unicode)
 
     def get_sourcefont_dimensions(self):
         # Initial font dimensions
@@ -952,10 +965,11 @@ class font_patcher:
                     sys.stdout.flush()
 
             # check if a glyph already exists in this location
-            if careful or 'careful' in sym_attr['params']:
+            if careful or 'careful' in sym_attr['params'] or currentSourceFontGlyph in self.essential:
                 if currentSourceFontGlyph in self.sourceFont:
                     if self.args.quiet is False:
-                        print("  Found existing Glyph at {:X}. Skipping...".format(currentSourceFontGlyph))
+                        careful_type = 'essential' if currentSourceFontGlyph in self.essential else 'existing'
+                        print("  Found {} Glyph at {:X}. Skipping...".format(careful_type, currentSourceFontGlyph))
                     # We don't want to touch anything so move to next Glyph
                     continue
             else:


### PR DESCRIPTION
**[why]**
Sometimes the basic glyphs (`[a-zA-Z]` etc) are constructed in the font
from other glyphs via references. To keep those basic glyphs intact we
must not touch the referenced glyphs.

**[how]**
Crate a list of all glyphs referenced by the basic glyphs.
When patching in some new symbol - if that codepoint is in the list do
not overwrite it. Overwriting would break a basic glyph.

The user does not get the glyph that we would have patched in, but that
can not be helped if we want to keep the basic glyphs intact and not
'redesign' the complete font.

Fixes: #400

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Do not overwrite codepoints that are needed (by reference) by glyphs in the basic latin range.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![image](https://user-images.githubusercontent.com/16012374/188574412-08a1cb02-143a-4132-a8e5-f9bb310af57e.png)

Font: `Input Mono`
The ordinary small `j` is a combination of the dotless-small-`j` and a single dot. We must not touch any of the two, or the basic glyph small-`j` is broken.

```
$ fontforge font-patcher --complete ~/Downloads/Input-Font/Input_Fonts/InputMono/InputMono/InputMono-Regular.ttf
[...]
The glyph named ring is mapped to U+F7EA.
  But its name indicates it should be mapped to U+02DA.
Adding 2119 Glyphs from Material Set 
╢████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟ 21%  Found essential Glyph at F6BE. Skipping...
╢████████████████████████████████████████╟ 100%
The following table(s) in the font have been ignored by FontForge
  Ignoring 'webf'
[...]
```

`F6BE` is not patched after this PR.