### PR TITLE
font-patcher: Fix scaleGlyph related rounding error

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1161,7 +1161,7 @@ class font_patcher:
         except:
             pass
 
-    def prepareScaleGlyph(self, scaleGlyph, symbolFont):
+    def prepareScaleGlyph(self, scaleGlyph, symbolFont, destGlyph):
         """ Prepare raw ScaleGlyph data for use """
         # The GlyphData is a dict with these (possible) entries:
         # 'GlyphsToScale': List of ((lists of glyph codes) or (ranges of glyph codes)) that shall be scaled
@@ -1196,13 +1196,14 @@ class font_patcher:
         else:
             scaleGlyph['scales'] = []
             for group in scaleGlyph['GlyphsToScale']:
-                sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ])
+                sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
                 scaleGlyph['scales'].append(self.get_scale_factor(sym_dim))
 
     def get_glyph_scale(self, unicode_value, scaleGlyph, symbolFont):
         """ Determines whether or not to use scaled glyphs for glyphs in passed glyph_list """
+        # Potentially destorys the contents of self.sourceFont[unicode_value]
         if not 'scales' in scaleGlyph:
-            self.prepareScaleGlyph(scaleGlyph, symbolFont)
+            self.prepareScaleGlyph(scaleGlyph, symbolFont, self.sourceFont[unicode_value])
         for glyph_list, scale in zip(scaleGlyph['GlyphsToScale'], scaleGlyph['scales']):
             if unicode_value in glyph_list:
                 return scale
@@ -1224,13 +1225,22 @@ def make_sure_path_exists(path):
         if exception.errno != errno.EEXIST:
             raise
 
-def get_multiglyph_boundingBox(glyphs):
-    """ Returns dict of the dimensions of multiple glyphs combined """
+def get_multiglyph_boundingBox(glyphs, destGlyph = None):
+    """ Returns dict of the dimensions of multiple glyphs combined(, as if they are copied into destGlyph) """
+    # If destGlyph is given the glyph(s) are first copied over into that
+    # glyph and measured in that font (to avoid rounding errors)
+    # Leaves the destGlyph in unknown state!
     bbox = [ None, None, None, None ]
     for glyph in glyphs:
         if glyph is None:
             # Glyph has been in defining range but is not in the actual font
             continue
+        if destGlyph:
+            glyph.font.selection.select(glyph)
+            glyph.font.copy()
+            destGlyph.font.selection.select(destGlyph)
+            destGlyph.font.paste()
+            glyph = destGlyph
         gbb = glyph.boundingBox()
         bbox[0] = gbb[0] if bbox[0] is None or bbox[0] > gbb[0] else bbox[0]
         bbox[1] = gbb[1] if bbox[1] is None or bbox[1] > gbb[1] else bbox[1]


### PR DESCRIPTION
**[why]**
Sometimes the patched-in symbols are slightly too big, which shows up in Nerd Font Mono fonts where the destination size is specified exactly.

That issues a warning like:
```
  Warning: Scaled glyph U+F077 wider than one monospace width
```

**[how]**
For the `scaleGlyph` groups we need to combine the bounding boxes of several symbol glyphs to determine the 'combined' scale we need. Unfortunately when the concrete glyph is finally copied over its size can change minimally.

So we need to measure the glyphs in the `scaleGroup` _after_ they have been copied to the to-be-patched font. This is a bit complicated, because we need to know some glyph slot we can use for that.

**[note]**
See also commit
  e805b879  `font-patcher: Resolve rounding error when rescaling`

Fixes: #917

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
