### PR TITLE
Bugfix/hasklug ligature

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -667,11 +667,11 @@ class font_patcher:
                 ligature_subtables = json.loads(self.config.get("Subtables", "ligatures"))
                 for subtable in ligature_subtables:
                     print("Removing subtable:", subtable)
-                try:
-                    self.sourceFont.removeLookupSubtable(subtable)
-                    print("Successfully removed subtable:", subtable)
-                except Exception:
-                    print("Failed to remove subtable:", subtable)
+                    try:
+                        self.sourceFont.removeLookupSubtable(subtable)
+                        print("Successfully removed subtable:", subtable)
+                    except Exception:
+                        print("Failed to remove subtable:", subtable)
         elif self.args.removeligatures:
             print("Unable to read configfile, unable to remove ligatures")
         else:

--- a/src/unpatched-fonts/Hasklig/config.json
+++ b/src/unpatched-fonts/Hasklig/config.json
@@ -24,4 +24,5 @@
 		"Single Substitution lookup 106 subtable",
 		"Single Substitution lookup 107 subtable",
 		"Single Substitution lookup 109 subtable",
-		"Single Substitution lookup 110 subtable" ]
+		"Single Substitution lookup 110 subtable",
+		"Single Substitution lookup 111 subtable" ]


### PR DESCRIPTION
#### Description

Fix double bar (`||`) ligature removal in `Hasklug Nerd Font Mono`.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

Install Mono font. Open `writer`, select that font, type bar bar (`|` `|`). Two bars?

#### Any background context you can provide?

#934

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
