### PR TITLE
font-patcher: Preserve existing bitmaps

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -271,7 +271,11 @@ class font_patcher:
                 fontname = sourceFont.cidfontname
             outfile = os.path.normpath(os.path.join(self.args.outputdir, fontname + self.args.extension))
             # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
-            sourceFont.generate(outfile, flags=(str('opentype'), str('PfEd-comments')))
+            bitmaps = str()
+            if len(self.sourceFont.bitmapSizes):
+                print("Preserving bitmaps {}".format(self.sourceFont.bitmapSizes))
+                bitmaps = str('otf') # otf/ttf, both is bf_ttf
+            sourceFont.generate(outfile, bitmap_type=bitmaps, flags=(str('opentype'), str('PfEd-comments')))
             message = "\nGenerated: {} in '{}'".format(self.sourceFont.fullname, outfile)
 
         # Adjust flags that can not be changed via fontforge


### PR DESCRIPTION
**[why]**
Bitmaps existing in a font are discarded. The font-patcher script just cares about outline fonts.

**[how]**
If the sourcefont has bitmaps, do save them into the patched font. Note that this does not generate bitmaps for the patched-in glyphs (icons).

**[note]**
Fonts probably affected in src/unpatched-fonts:
```
    bitmap (11,) (gohufont-11)
    bitmap (14,) (gohufont-14)
    bitmap (11,) (gohufont-uni-11)
    bitmap (14,) (gohufont-uni-14)
    bitmap (7, 9, 10, 12, 14, 18, 24) (ProFontIIx)
    bitmap (12, 14, 16, 18, 20, 22, 24, 28, 32) (TerminusTTF-Bold Italic-4.40.1)
    bitmap (12, 14, 16, 18, 20, 22, 24, 28, 32) (TerminusTTF-Bold-4.40.1)
    bitmap (12, 14, 16, 18, 20, 22, 24, 28, 32) (TerminusTTF-Italic-4.40.1)
    bitmap (12, 14, 16, 18, 20, 22, 24, 28, 32) (TerminusTTF-4.40.1)
```

Fixes: #86

Reported-by: DoctorKnowsBetter

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Save the bitmaps existing in the source font into the patched font.

#### How should this be manually tested?

Take patched font and look for distortions as detailed in linked Issues.

#### Any background context you can provide?

[Note to self:] TTC support missing

#### What are the relevant tickets (if any)?

* #86 
* #329

#### Screenshots (if appropriate or helpful)
