### PR TITLE
docs: fix logo image source path

### DIFF
--- a/readme_cn.md
+++ b/readme_cn.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="images/nerd-fonts-logo.png" alt="Nerd Fonts Logo" />
+  <img src="images/nerd-fonts-logo.svg" alt="Nerd Fonts Logo" />
 </h1>
 
 [![GitHub release][img-version-badge-with-logo]][repo]&nbsp;[![Gitter][img-gitter-badge]][gitter]&nbsp;[![CodeClimate][img-code-climate-badge]][code-climate]&nbsp;[![Code of Conduct][coc-badge]][coc]&nbsp;[![PRs Welcome][prs-badge]][prs]&nbsp;&nbsp;&nbsp;[![Windows Logo][w-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![macOS (OSX) Logo][m-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![Linux Logo][l-top]](#patched-fonts)

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -142,7 +142,7 @@ _如果你..._
 ### [Font Logos][font-logos]
 > Font-logos 是一个包含LOGO和linux流行布局的图标字体。 / ([repo][font-logos])
 
-![image](images/fontforge-glyph-set-font-linux.png)
+![image](images/fontforge-glyph-set-font-logos.png)
 
 ### [Pomicons][gabrielelana-pomicons]
 > 8 个符号 ["Pomodoro Technique"®](https://cirillocompany.de/pages/pomodoro-technique). / ([repo][gabrielelana-pomicons])

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="images/nerd-fonts-logo.png" alt="Nerd Fonts Logo" />
+  <img src="images/nerd-fonts-logo.svg" alt="Nerd Fonts Logo" />
 </h1>
 
 [![GitHub release][img-version-badge-with-logo]][репозиторий]&nbsp;[![Gitter][img-gitter-badge]][gitter]&nbsp;[![CodeClimate][img-code-climate-badge]][code-climate]&nbsp;[![Code of Conduct][coc-badge]][coc]&nbsp;[![PRs Welcome][prs-badge]][prs]&nbsp;&nbsp;&nbsp;[![Windows Logo][w-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![macOS (OSX) Logo][m-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![Linux Logo][l-top]](#patched-fonts)
@@ -142,7 +142,7 @@ _Если Вы..._
 ### [Font Logos][font-logos]
 > Font-logos содержит логотипы популярных дистрибутивов Linux, включая веб-сайты. / ([репозиторий][font-logos])
 
-![image](images/fontforge-glyph-set-font-linux.png)
+![image](images/fontforge-glyph-set-font-logos.png)
 
 ### [Pomicons][gabrielelana-pomicons]
 > 8 значков для ["Метод Помидора"®](https://cirillocompany.de/pages/pomodoro-technique). / ([репозиторий][gabrielelana-pomicons])

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -142,7 +142,7 @@ _如果你..._
 ### [Font Logos][font-logos]
 > Font-logos 是一個包含LOGO和linux流行布局的圖示字體。 / ([repo][font-logos])
 
-![image](images/fontforge-glyph-set-font-linux.png)
+![image](images/fontforge-glyph-set-font-logos.png)
 
 ### [Pomicons][gabrielelana-pomicons]
 > 8 個符號 ["Pomodoro Technique"®](https://cirillocompany.de/pages/pomodoro-technique). / ([repo][gabrielelana-pomicons])

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="images/nerd-fonts-logo.png" alt="Nerd Fonts Logo" />
+  <img src="images/nerd-fonts-logo.svg" alt="Nerd Fonts Logo" />
 </h1>
 
 [![GitHub release][img-version-badge-with-logo]][repo]&nbsp;[![Gitter][img-gitter-badge]][gitter]&nbsp;[![CodeClimate][img-code-climate-badge]][code-climate]&nbsp;[![Code of Conduct][coc-badge]][coc]&nbsp;[![PRs Welcome][prs-badge]][prs]&nbsp;&nbsp;&nbsp;[![Windows Logo][w-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![macOS (OSX) Logo][m-top]](#patched-fonts)&nbsp;&nbsp;&nbsp;[![Linux Logo][l-top]](#patched-fonts)


### PR DESCRIPTION
#### Description

Fix the logo source path in *cn* and *tw* documentation.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Fix the logo source path in *cn* and *tw* documentation.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
