### PR TITLE
font-patcher: Fix checksum algo

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -82,9 +82,9 @@ class TableHEADWriter:
         i += 4
         extra = 0
         for j in range(4):
+            extra = extra << 8
             if i + j <= end:
                 extra += ord(self.f.read(1))
-            extra = extra << 8
         checksum = (checksum + extra) & 0xFFFFFFFF
         return checksum
 


### PR DESCRIPTION
**[why]**
For some fonts the calculated checksum(s) was wrong.

**[how]**
Misplaced the multiplier ... the LSB shall not be shifted of course, but the current code shifts as last action: Also the LSB is shifted.

First shift (old) accumulated content, then add new data. In that way the last added data (LSB) is not shifted.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

Noticed only after failed runs on `v2.3.0-RC` because that version number changed the font lengths :eyes: 

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
