### PR TITLE
Bugfix Symbol Only Mono fonts

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -840,6 +840,20 @@ class font_patcher:
             self.font_dim['ymin'] = self.sourceFont.os2_typodescent
             self.font_dim['ymax'] = self.sourceFont.os2_typoascent
 
+        # Calculate font height
+        self.font_dim['height'] = -self.font_dim['ymin'] + self.font_dim['ymax']
+        if self.font_dim['height'] == 0:
+            # This can only happen if the input font is empty
+            # Assume we are using our prepared templates
+            self.font_dim = {
+                'xmin'  : 0,
+                'ymin'  : -self.sourceFont.descent,
+                'xmax'  : self.sourceFont.em,
+                'ymax'  : self.sourceFont.ascent,
+                'width' : self.sourceFont.em,
+                'height': self.sourceFont.descent + self.sourceFont.ascent,
+            }
+
         # Line gap add extra space on the bottom of the line which
         # doesn't allow the powerline glyphs to fill the entire line.
         # Put half of the gap into the 'cell', each top and bottom
@@ -853,6 +867,7 @@ class font_patcher:
             gap_bottom = gap - gap_top
             self.font_dim['ymin'] -= gap_bottom
             self.font_dim['ymax'] += gap_top
+            self.font_dim['height'] = -self.font_dim['ymin'] + self.font_dim['ymax']
             self.sourceFont.os2_typoascent = self.sourceFont.os2_typoascent + gap_top
             self.sourceFont.os2_typodescent = self.sourceFont.os2_typodescent - gap_bottom
             # TODO Check what to do with win and hhea values
@@ -874,20 +889,6 @@ class font_patcher:
             if xmax > self.font_dim['xmax']:
                 self.font_dim['xmax'] = xmax
                 # print("New MAXWIDTH-B {} {} {}".format(glyph, self.sourceFont[glyph].width, xmax))
-
-        # Calculate font height
-        self.font_dim['height'] = -self.font_dim['ymin'] + self.font_dim['ymax']
-        if self.font_dim['height'] == 0:
-            # This can only happen if the input font is empty
-            # Assume we are using our prepared templates
-            self.font_dim = {
-                'xmin'  : 0,
-                'ymin'  : -self.sourceFont.descent,
-                'xmax'  : self.sourceFont.em,
-                'ymax'  : self.sourceFont.ascent,
-                'width' : self.sourceFont.em,
-                'height': self.sourceFont.descent + self.sourceFont.ascent,
-            }
 
 
     def get_scale_factor(self, sym_dim):

--- a/font-patcher
+++ b/font-patcher
@@ -876,7 +876,7 @@ class font_patcher:
                 # print("New MAXWIDTH-B {} {} {}".format(glyph, self.sourceFont[glyph].width, xmax))
 
         # Calculate font height
-        self.font_dim['height'] = abs(self.font_dim['ymin']) + self.font_dim['ymax']
+        self.font_dim['height'] = -self.font_dim['ymin'] + self.font_dim['ymax']
         if self.font_dim['height'] == 0:
             # This can only happen if the input font is empty
             # Assume we are using our prepared templates
@@ -886,7 +886,7 @@ class font_patcher:
                 'xmax'  : self.sourceFont.em,
                 'ymax'  : self.sourceFont.ascent,
                 'width' : self.sourceFont.em,
-                'height': abs(self.sourceFont.descent) + self.sourceFont.ascent,
+                'height': self.sourceFont.descent + self.sourceFont.ascent,
             }
 
 

--- a/src/unpatched-fonts/NerdFontsSymbolsOnly/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd
+++ b/src/unpatched-fonts/NerdFontsSymbolsOnly/NerdFontsSymbols 1000 EM Nerd Font Complete Blank.sfd
@@ -24,14 +24,14 @@ ModificationTime: 1646316690
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
-LineGap: 90
+LineGap: 0
 VLineGap: 0
 Panose: 2 0 5 9 0 0 0 0 0 0
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
 OS2TypoDOffset: 1
-OS2TypoLinegap: 90
+OS2TypoLinegap: 0
 OS2WinAscent: 0
 OS2WinAOffset: 1
 OS2WinDescent: 0

--- a/src/unpatched-fonts/NerdFontsSymbolsOnly/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd
+++ b/src/unpatched-fonts/NerdFontsSymbolsOnly/NerdFontsSymbols 2048 EM Nerd Font Complete Blank.sfd
@@ -24,14 +24,14 @@ ModificationTime: 1646316690
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
-LineGap: 184
+LineGap: 0
 VLineGap: 0
 Panose: 2 0 5 9 0 0 0 0 0 0
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
 OS2TypoDOffset: 1
-OS2TypoLinegap: 184
+OS2TypoLinegap: 0
 OS2WinAscent: 0
 OS2WinAOffset: 1
 OS2WinDescent: 0


### PR DESCRIPTION
#### Description

Fix empty `Symbols Only Nerd Font Mono` fonts.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/master/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

* Make the empty-input-font detection more robust (such that the empty font may have linegap defined)
* Remote the linegap from out symbols only font templates

#### How should this be manually tested?

Create a symbols only `Mono` variant and look at the glyphs. Are they existing and scaled ok?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
