### PR TITLE
feat: use standard Docker build Actions, enable builds for ARM architecture

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,7 +27,6 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           images: nerdfonts/patcher
 
         # QEMU allows us to build container images for multiple architectures (amd64, ARM etc...)
@@ -50,6 +49,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags:  ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -19,10 +19,37 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'ryanoasis' }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Build image
-        run: docker build -t nerdfonts/patcher .
-      - name: Push image
-        run: |
-          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PAT }}
-          docker push nerdfonts/patcher
+      - name: Checkout
+        uses: actions/checkout@v3
+
+        # Docker Meta provides automatic, standard tagging
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: nerdfonts/patcher
+
+        # QEMU allows us to build container images for multiple architectures (amd64, ARM etc...)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+        # Docker Buildx provides Buildkit support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags:  ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#### Description

Refactor docker-release (aka build and push) workflow to use the standard Docker Github Actions.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

This adds the following features:

- Builds for both AMD64 and ARM64 (other architectures can be enabled if required).
- Automatic tagging and labelling (including 'latest').

#### How should this be manually tested?

- I don't have access to _your_ Docker hub credentials so wasn't able to test I could publish as your user, just check it does successfully publish with your creds the first time (but it should be fine!).

#### Any background context you can provide?

I went to run the nerd-fonts patcher and found the provided container image was only built for  AMD64, many modern computers are ARM64 hence this PR.

https://github.com/marketplace/actions/build-and-push-docker-images

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
