### PR TITLE
Fix Iosevka Family names

### DIFF
--- a/src/unpatched-fonts/Iosevka/config.cfg
+++ b/src/unpatched-fonts/Iosevka/config.cfg
@@ -1,1 +1,2 @@
 config_has_powerline=1
+config_patch_flags="--makegroups"


### PR DESCRIPTION
#### Description

**[why]**
The Iosevka font has a lot of different families. A lot users install just all "Iosevka Nerd Font" families, and this can break in a lot different ways.

I will try to collect Issues possibly caused by this in PR #1019.

**[how]**
Just turn the feature on in `font-patcher` (via patch-em-all's config).

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Enable `--makegroups` for Iosevka on release runs.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

For example in Gnome Terminal, this is how all the Iosevka Families are shown at the moment:

![image](https://user-images.githubusercontent.com/16012374/205485931-924c8a5d-8cb8-474b-b057-ff2a4b293c4a.png)

And this is after this PR has been pulled:

![image](https://user-images.githubusercontent.com/16012374/205485974-04a93c6c-9e2f-48d9-a9b3-0c5dc23950aa.png)

Note that the `Nerd Font` part is missing in the 'now' screenshot :-o This not even breaks all the patched Iosevkas, because they mix up all families, but also interfere with parallel installed Iosevka-original :-(