### PR TITLE
Feature/testability

### DIFF
--- a/.github/workflows/casks.yml
+++ b/.github/workflows/casks.yml
@@ -35,7 +35,7 @@ jobs:
           cd bin/scripts
           ./generate-casks.sh --setversion ${{ steps.releasetag.outputs.tag }}
       - name: Upload casks as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: casks
           path: casks
@@ -67,7 +67,7 @@ jobs:
           git reset --hard upstream/master
           git push --force origin HEAD:nerdfonts
       - name: Retrieve new casks
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: casks
           path: casks

--- a/.github/workflows/font-patcher.yml
+++ b/.github/workflows/font-patcher.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         FontForgeRelease: [
+          { name: "FontForge January 2023 Release", version: "20230101", archiveType: "tar.xz" },
           { name: "FontForge March 2022 Release", version: "20220308", archiveType: "tar.xz" },
           { name: "FontForge 20th Anniversary Edition", version: "20201107", archiveType: "tar.xz" },
           { name: "FontForge 2020 March Release", version: "20200314", archiveType: "tar.xz" },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           cd -- "$GITHUB_WORKSPACE/bin/scripts"
           fontforge --script `pwd`/../../font-patcher --version
-          ./gotta-patch-em-all-font-patcher\!.sh "/${{ matrix.font }}"
+          ./gotta-patch-em-all-font-patcher\!.sh -j "/${{ matrix.font }}"
 
       - name: Archive font package zip files
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
           sudo apt update -y -q
           sudo apt install software-properties-common -y -q
           sudo apt install python3-fontforge -y -q
+          sudo apt install fuse -y -q
 
       # Ubuntu 20.04 has only fontforge release 2020, but there are some vital bugfixes in the 2022 release
       # This can be replaced with the ordinary apt package when Ubuntu updates, probably with 22.10?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,18 @@ jobs:
         run: |
           [[ "${{ steps.rel_can.outputs.val }}" == "true" || "${{ steps.rel_pre_existing.outputs.exists }}" == "false" ]] && echo "val=true" || echo "val=false" >> $GITHUB_OUTPUT
 
+      - name: Determine release timestamp
+        id: timestamp
+        run: |
+          echo "val=$(date +%s)" >> $GITHUB_OUTPUT
+
       - name: Show outputs
         run: |
           echo "rel_version: ${{ steps.rel_ver.outputs.val }}"
           echo "rel_candidate: ${{ steps.rel_can.outputs.val }}"
           echo "rel_pre_existing: ${{ steps.rel_pre_existing.outputs.exists }}"
           echo "rel_upload: ${{ steps.upload.outputs.val }}"
+          echo "rel_timestamp: ${{ steps.timestamp.outputs.val }} ($(date -R --date=@${{ steps.timestamp.outputs.val }}))"
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -93,6 +99,7 @@ jobs:
       rel_candidate: ${{ steps.rel_can.outputs.val }}
       rel_pre_existing: ${{ steps.rel_pre_existing.outputs.exists }}
       rel_upload: ${{ steps.upload.outputs.val }}
+      rel_timestamp: ${{ steps.timestamp.outputs.val }}
 
   # Workflow to build and install dependencies
   build:
@@ -106,6 +113,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_VERSION: ${{ needs.setup-fonts-matrix.outputs.rel_version }}
       RELEASE_CANDIDATE: ${{ needs.setup-fonts-matrix.outputs.rel_candidate }}
+      SOURCE_DATE_EPOCH: ${{ needs.setup-fonts-matrix.outputs.rel_timestamp }}
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         # If the tag exists it is obviously a re-release
 
         # This would need a complete checkout, that we want to avoid
-        # uses: mukunku/tag-exists-action@v1.0.0
+        # uses: mukunku/tag-exists-action@v1.2.0
         #   with:
         #     tag: "v${{ steps.rel_ver.outputs.val }}"
         #   env:
@@ -219,7 +219,7 @@ jobs:
           ./archive-fonts.sh "${{ matrix.font }}"
 
       - name: Upload zip file archive for release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v0.1.15
         if: needs.setup-fonts-matrix.outputs.rel_upload == 'true'
         with:
           draft: true
@@ -228,7 +228,7 @@ jobs:
           files: archives/*
 
       - name: Upload patched fonts as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: patched-fonts
           # adding multiple paths (i.e. LICENSE) is a workaround to get a least common ancestor
@@ -261,7 +261,7 @@ jobs:
           ./archive-font-patcher.sh
 
       - name: Upload font-patcher archive for release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v0.1.15
         if: needs.setup-fonts-matrix.outputs.rel_upload == 'true'
         with:
           draft: true
@@ -282,7 +282,7 @@ jobs:
 
       - name: Download patched fonts from build
         id: download-patched-fonts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: patched-fonts
           path: .
@@ -381,7 +381,7 @@ jobs:
           clean: false
 
       - name: Adjust release tag to include previous commit
-        uses: EndBug/latest-tag@v1.5.0
+        uses: EndBug/latest-tag@v1.5.1
         if: needs.setup-fonts-matrix.outputs.rel_upload == 'true'
         with:
           ref: "v${{ needs.setup-fonts-matrix.outputs.rel_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,13 @@ jobs:
       - name: Determine candidate status
         id: rel_can
         run: |
-          [[ "${{ steps.rel_ver.outputs.val }}" == *"-RC"* ]] && echo "val=true" || echo "val=false" >> $GITHUB_OUTPUT
+          if [[ "${{ steps.rel_ver.outputs.val }}" == *"-RC"* ]]; then
+            CAN="val=true"
+          else
+            CAN="val=false"
+          fi
+          echo "${CAN}"
+          echo "${CAN}" >> $GITHUB_OUTPUT
 
       - name: Determine new release or re-release
         # If the tag exists it is obviously a re-release
@@ -68,9 +74,10 @@ jobs:
         #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: rel_pre_existing
         run: |
-          curl -v "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/tags" | jq '.[].name' | grep '^"v${{ steps.rel_ver.outputs.val }}"$' \
-            && echo "exists=true" || echo "exists=false" >> $GITHUB_OUTPUT
-          echo "Tag exists: ${{ steps.rel_pre_existing.outputs.exists }}"
+          RPE=$(curl -v "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/tags" | jq '.[].name' | grep '^"v${{ steps.rel_ver.outputs.val }}"$' \
+            && echo "exists=true" || echo "exists=false")
+          echo "${RPE}" >> $GITHUB_OUTPUT
+          echo "Tag exists: ${RPE}"
 
       - name: Upload release only on first trigger for release and always on release candidate
         id: upload
@@ -78,7 +85,13 @@ jobs:
         # * This is a new (previously untagged) release
         # * This is a release candidate
         run: |
-          [[ "${{ steps.rel_can.outputs.val }}" == "true" || "${{ steps.rel_pre_existing.outputs.exists }}" == "false" ]] && echo "val=true" || echo "val=false" >> $GITHUB_OUTPUT
+          if [[ "${{ steps.rel_can.outputs.val }}" == "true" || "${{ steps.rel_pre_existing.outputs.exists }}" == "false" ]]; then
+            UP="val=true"
+          else
+            UP="val=false"
+          fi
+          echo "${UP}"
+          echo "${UP}" >> $GITHUB_OUTPUT
 
       - name: Determine release timestamp
         id: timestamp

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 temp-glyph-source-fonts/*
 temp/*
 patched-fonts/Input*
+check-fonts/*
 unpatched-sample-fonts/Input*
 casks/*
 archives/*

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -38,7 +38,7 @@ res1=$(date +%s)
 parent_dir="${sd}/../../"
 # Set source and target directories
 source_fonts_dir="${sd}/../../src/unpatched-fonts"
-like_pattern=''
+like_pattern='.*\.\(otf\|ttf\|sfd\)'
 complete_variations_per_family=4
 font_typefaces_count=0
 font_families_count=0

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 2.3.0-RC
-# Script Version: 1.1.1
+# Script Version: 1.2.0
 
 # used for debugging
 # set -x
@@ -60,7 +60,6 @@ while getopts ":h-:" option; do
           info_only=$2
           echo "${LINE_PREFIX} 'Info Only' option given, only generating font info (not patching)"
           ;;
-          ;;
         *)
           echo >&2 "Option '${OPTARG}' unknown"
           exit 1;;
@@ -99,6 +98,17 @@ done < <(find "$source_fonts_dir" -iregex ${like_pattern} -type f -print0)
 
 # print total number of source fonts found
 echo "$LINE_PREFIX Total source fonts found: ${#source_fonts[*]}"
+
+# Use one date-time for ALL fonts and for creation and modification date in the font file
+if [ -z "${SOURCE_DATE_EPOCH}" ]
+then
+  export SOURCE_DATE_EPOCH=$(date +%s)
+fi
+release_timestamp=$(date -R --date=@${SOURCE_DATE_EPOCH} 2>/dev/null) || {
+  echo >&2 "$LINE_PREFIX Invalid release timestamp SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
+  exit 2
+}
+echo "$LINE_PREFIX Release timestamp is ${release_timestamp}"
 
 function patch_font {
   local f=$1; shift

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.3.0"
+script_version = "3.3.1"
 
 version = "2.3.0-RC"
 projectName = "Nerd Fonts"
@@ -331,7 +331,7 @@ class font_patcher:
                 sanitize_filename(self.args.outputdir, True),
                 sanitize_filename(sourceFont.familyname) + ".ttc"))
             sourceFonts[0].generateTtc(outfile, sourceFonts[1:], flags=gen_flags, layer=layer)
-            message = "\nGenerated: {} fonts in '{}'".format(len(sourceFonts), outfile)
+            message = "   Generated {} fonts\n   \===> '{}'".format(len(sourceFonts), outfile)
         else:
             fontname = sourceFont.fullname
             if not fontname:
@@ -341,36 +341,41 @@ class font_patcher:
                 sanitize_filename(fontname) + self.args.extension))
             bitmaps = str()
             if len(self.sourceFont.bitmapSizes):
-                print("Preserving bitmaps {}".format(self.sourceFont.bitmapSizes))
+                if not self.args.quiet:
+                    print("Preserving bitmaps {}".format(self.sourceFont.bitmapSizes))
                 bitmaps = str('otf') # otf/ttf, both is bf_ttf
             sourceFont.generate(outfile, bitmap_type=bitmaps, flags=gen_flags)
-            message = "\nGenerated: {} in '{}'".format(self.sourceFont.fullname, outfile)
+            message = "   {}\n   \===> '{}'".format(self.sourceFont.fullname, outfile)
 
         # Adjust flags that can not be changed via fontforge
-        try:
-            source_font = TableHEADWriter(self.args.font)
-            dest_font = TableHEADWriter(outfile)
-            for idx in range(source_font.num_fonts):
-                print("{}: Tweaking {}/{}".format(projectName, idx + 1, source_font.num_fonts))
-                source_font.find_head_table(idx)
-                dest_font.find_head_table(idx)
-                if source_font.flags & 0x08 == 0 and dest_font.flags & 0x08 != 0:
-                    print("Changing flags from 0x{:X} to 0x{:X}".format(dest_font.flags, dest_font.flags & ~0x08))
-                    dest_font.putshort(dest_font.flags & ~0x08, 'flags') # clear 'ppem_to_int'
-                if source_font.lowppem != dest_font.lowppem:
-                    print("Changing lowestRecPPEM from {} to {}".format(dest_font.lowppem, source_font.lowppem))
-                    dest_font.putshort(source_font.lowppem, 'lowestRecPPEM')
-                if dest_font.modified:
-                    dest_font.reset_table_checksum()
-                    dest_font.reset_full_checksum()
-        except Exception as error:
-            print("Can not handle font flags ({})".format(repr(error)))
-        finally:
+        if re.search('\\.[ot]tf$', self.args.font, re.IGNORECASE) and re.search('\\.[ot]tf$', outfile, re.IGNORECASE):
             try:
-                source_font.close()
-                dest_font.close()
-            except:
-                pass
+                source_font = TableHEADWriter(self.args.font)
+                dest_font = TableHEADWriter(outfile)
+                for idx in range(source_font.num_fonts):
+                    if not self.args.quiet:
+                        print("{}: Tweaking {}/{}".format(projectName, idx + 1, source_font.num_fonts))
+                    source_font.find_head_table(idx)
+                    dest_font.find_head_table(idx)
+                    if source_font.flags & 0x08 == 0 and dest_font.flags & 0x08 != 0:
+                        if not self.args.quiet:
+                            print("Changing flags from 0x{:X} to 0x{:X}".format(dest_font.flags, dest_font.flags & ~0x08))
+                        dest_font.putshort(dest_font.flags & ~0x08, 'flags') # clear 'ppem_to_int'
+                    if source_font.lowppem != dest_font.lowppem:
+                        if not self.args.quiet:
+                            print("Changing lowestRecPPEM from {} to {}".format(dest_font.lowppem, source_font.lowppem))
+                        dest_font.putshort(source_font.lowppem, 'lowestRecPPEM')
+                    if dest_font.modified:
+                        dest_font.reset_table_checksum()
+                        dest_font.reset_full_checksum()
+            except Exception as error:
+                print("Can not handle font flags ({})".format(repr(error)))
+            finally:
+                try:
+                    source_font.close()
+                    dest_font.close()
+                except:
+                    pass
         print(message)
 
         if self.args.postprocess:
@@ -641,8 +646,6 @@ class font_patcher:
                         print("Failed to remove subtable:", subtable)
         elif self.args.removeligatures:
             print("Unable to read configfile, unable to remove ligatures")
-        else:
-            print("No configfile given, skipping configfile related actions")
 
 
     def assert_monospace(self):
@@ -1564,7 +1567,8 @@ def main():
     sourceFonts = []
     all_fonts = fontforge.fontsInFile(args.font)
     for i, subfont in enumerate(all_fonts):
-        print("\n{}: Processing {} ({}/{})".format(projectName, subfont, i + 1, len(all_fonts)))
+        if len(all_fonts) > 1:
+          print("\n{}: Processing {} ({}/{})".format(projectName, subfont, i + 1, len(all_fonts)))
         try:
             sourceFonts.append(fontforge.open("{}({})".format(args.font, subfont), 1)) # 1 = ("fstypepermitted",))
         except Exception:
@@ -1573,7 +1577,7 @@ def main():
 
         patcher.patch(sourceFonts[-1])
 
-    print("\nDone with Patch Sets, generating font...\n")
+    print("Done with Patch Sets, generating font...")
     for f in sourceFonts:
         patcher.setup_font_names(f)
     patcher.generate(sourceFonts)

--- a/font-patcher
+++ b/font-patcher
@@ -315,6 +315,11 @@ class font_patcher:
 
     def generate(self, sourceFonts):
         sourceFont = sourceFonts[0]
+        # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
+        if int(fontforge.version()) >= 20201107:
+            gen_flags = (str('opentype'), str('PfEd-comments'), str('no-FFTM-table'))
+        else:
+            gen_flags = (str('opentype'), str('PfEd-comments'))
         if len(sourceFonts) > 1:
             layer = None
             # use first non-background layer
@@ -325,8 +330,7 @@ class font_patcher:
             outfile = os.path.normpath(os.path.join(
                 sanitize_filename(self.args.outputdir, True),
                 sanitize_filename(sourceFont.familyname) + ".ttc"))
-            # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
-            sourceFonts[0].generateTtc(outfile, sourceFonts[1:], flags=(str('opentype'), str('PfEd-comments')), layer=layer)
+            sourceFonts[0].generateTtc(outfile, sourceFonts[1:], flags=gen_flags, layer=layer)
             message = "\nGenerated: {} fonts in '{}'".format(len(sourceFonts), outfile)
         else:
             fontname = sourceFont.fullname
@@ -335,12 +339,11 @@ class font_patcher:
             outfile = os.path.normpath(os.path.join(
                 sanitize_filename(self.args.outputdir, True),
                 sanitize_filename(fontname) + self.args.extension))
-            # the `PfEd-comments` flag is required for Fontforge to save '.comment' and '.fontlog'.
             bitmaps = str()
             if len(self.sourceFont.bitmapSizes):
                 print("Preserving bitmaps {}".format(self.sourceFont.bitmapSizes))
                 bitmaps = str('otf') # otf/ttf, both is bf_ttf
-            sourceFont.generate(outfile, bitmap_type=bitmaps, flags=(str('opentype'), str('PfEd-comments')))
+            sourceFont.generate(outfile, bitmap_type=bitmaps, flags=gen_flags)
             message = "\nGenerated: {} in '{}'".format(self.sourceFont.fullname, outfile)
 
         # Adjust flags that can not be changed via fontforge


### PR DESCRIPTION
#### Description

This PR has multiple improvements in the direction of testing `font-patcher` changes:

* Set creation/modification date in all fonts consistently
* Add options to `gotta-patch-em-all`
  * Option `--verbose` to get usual output, normal output is now less verbose
  * Option `--keeptime` to keep font's timestamp when doing a re-patch
  * Option `--checkfont` creates fonts in different directory for easier diffing via fontforge
* Reactivate parallel processing in `gotta-patch-em-all`
* Add newest **Fontforge January 2023 Release** to tests :tada: 
* Lots of CI related fixes

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

Do some `gotta-patch-em-all` runs.
The timestamp feature for releases can only be tested by running the release workflow -> https://github.com/Finii/nerd-fonts/actions/runs/3854035186

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
