### PR TITLE
Release master fontpatcher

### DIFF
--- a/.github/workflows/release_master_fontpatcher-zip.yaml
+++ b/.github/workflows/release_master_fontpatcher-zip.yaml
@@ -3,6 +3,7 @@ name: Release font patcher from master
 on:
   create:
   push:
+    branches: master
     paths:
       - font-patcher
       - src/glyphs/**

--- a/.github/workflows/release_master_fontpatcher-zip.yaml
+++ b/.github/workflows/release_master_fontpatcher-zip.yaml
@@ -3,7 +3,7 @@ name: Release font patcher from master
 on:
   create:
   push:
-    branches: master
+    #branches: master
     paths:
       - font-patcher
       - src/glyphs/**
@@ -17,26 +17,41 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+    outputs:
+      changed: ${{ steps.updated-or-not.outputs.updated }}
     steps:
-    
+    - name: install zipcmp
+      run: sudo apt-get install -y zipcmp
     - name: Grab the script and its dependencies from the repo
       uses: snow-actions/sparse-checkout@v1.2.0
       with:
         patterns: |
+          FontPatcher.zip
           font-patcher
           src/glyphs
           src/archive-font-patcher-readme.md
           bin/scripts/archive-font-patcher.sh
           bin/scripts/name_parser
-          
     - run: chmod +x 
         font-patcher
         bin/scripts/archive-font-patcher.sh
         bin/scripts/name_parser        
     - run: bin/scripts/archive-font-patcher.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: FontPatcher.zip
+        path: archives/FontPatcher.zip
+    - id: updated-or-not
+      run: |
+        if zipcmp archives/FontPatcher.zip ./FontPatcher.zip ; then
+          echo "updated=false" | tee -a $GITHUB_OUTPUT
+        else
+          echo "updated=true" | tee -a $GITHUB_OUTPUT
+        fi
     - run: cp archives/FontPatcher.zip . -f
     - uses: EndBug/add-and-commit@v9
+      if: steps.updated-or-not.outputs.updated == 'true'
+      #needs to be quoted
       with:
         fetch: false
         add: "FontPatcher.zip"

--- a/.github/workflows/release_master_fontpatcher-zip.yaml
+++ b/.github/workflows/release_master_fontpatcher-zip.yaml
@@ -3,6 +3,13 @@ name: Release font patcher from master
 on:
   create:
   push:
+    paths:
+      - font-patcher
+      - src/glyphs/**
+      - src/archive-font-patcher-readme.me
+      - bin/scripts/archive-font-patcher.sh
+      - bin/scripts/name_parser
+      - .github/workflows/release_master_fontpatcher-zip.yaml
   workflow_dispatch:
   
 
@@ -11,29 +18,27 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-#    - uses: actions/checkout@v3
-     
-        
+    
     - name: Grab the script and its dependencies from the repo
-      run: |
-        #!/bin/sh
-        git clone \
-          --depth 1 \
-          --single-branch \
-          --quiet --progress \
-          --no-checkout \
-          https://oauth2:${{  secrets.GITHUB_TOKEN  }}@github.com/${GITHUB_REPOSITORY}
-        cd nerd-fonts && git checkout HEAD src font-patcher
-        
-    - run: rm -fR nerd-fonts/src/unpatched-fonts
-    
-    - run: zip -r fontpatcher.zip nerd-fonts/*
-    
-    - run: git config user.name "Github Actions" && git config user.email "actions@github.com"
-      working-directory: nerd-fonts
-    
-    - working-directory: nerd-fonts
-      run: cp -f ../fontpatcher.zip . && git add fontpatcher.zip && git commit -m"Update fontpatcher.zip"
-
-    - uses: mxschmitt/action-tmate@v3
-
+      uses: snow-actions/sparse-checkout@v1.2.0
+      with:
+        patterns: |
+          font-patcher
+          src/glyphs
+          src/archive-font-patcher-readme.md
+          bin/scripts/archive-font-patcher.sh
+          bin/scripts/name_parser
+          
+    - run: chmod +x 
+        font-patcher
+        bin/scripts/archive-font-patcher.sh
+        bin/scripts/name_parser        
+    - run: bin/scripts/archive-font-patcher.sh
+    - run: cp archives/FontPatcher.zip . -f
+    - uses: EndBug/add-and-commit@v9
+      with:
+        fetch: false
+        add: "FontPatcher.zip"
+        message: "[ci] update FontPatcher.zip"
+        committer_name: GitHub Actions
+        committer_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/release_master_fontpatcher-zip.yaml
+++ b/.github/workflows/release_master_fontpatcher-zip.yaml
@@ -1,0 +1,39 @@
+name: Release font patcher from master
+
+on:
+  create:
+  push:
+  workflow_dispatch:
+  
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+#    - uses: actions/checkout@v3
+     
+        
+    - name: Grab the script and its dependencies from the repo
+      run: |
+        #!/bin/sh
+        git clone \
+          --depth 1 \
+          --single-branch \
+          --quiet --progress \
+          --no-checkout \
+          https://oauth2:${{  secrets.GITHUB_TOKEN  }}@github.com/${GITHUB_REPOSITORY}
+        cd nerd-fonts && git checkout HEAD src font-patcher
+        
+    - run: rm -fR nerd-fonts/src/unpatched-fonts
+    
+    - run: zip -r fontpatcher.zip nerd-fonts/*
+    
+    - run: git config user.name "Github Actions" && git config user.email "actions@github.com"
+      working-directory: nerd-fonts
+    
+    - working-directory: nerd-fonts
+      run: cp -f ../fontpatcher.zip . && git add fontpatcher.zip && git commit -m"Update fontpatcher.zip"
+
+    - uses: mxschmitt/action-tmate@v3
+

--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -1,60 +1,54 @@
-name: Create FontPatcher.zip from master
+name: Create FontPatcher.zip
 
 on:
-  create:
   push:
-    #branches: master
+    branches: master
     paths:
       - font-patcher
       - src/glyphs/**
       - src/archive-font-patcher-readme.me
       - bin/scripts/archive-font-patcher.sh
-      - bin/scripts/name_parser
-      - .github/workflows/release_master_fontpatcher-zip.yaml
+      - bin/scripts/name_parser/Fontname*.py
   workflow_dispatch:
-  
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.updated-or-not.outputs.updated }}
     steps:
-    - name: install zipcmp
-      run: sudo apt-get install -y zipcmp
-    - name: Grab the script and its dependencies from the repo
-      uses: snow-actions/sparse-checkout@v1.2.0
-      with:
-        patterns: |
-          FontPatcher.zip
-          font-patcher
-          src/glyphs
-          src/archive-font-patcher-readme.md
-          bin/scripts/archive-font-patcher.sh
-          bin/scripts/name_parser
-    - run: chmod +x 
-        font-patcher
-        bin/scripts/archive-font-patcher.sh
-        bin/scripts/name_parser        
-    - run: bin/scripts/archive-font-patcher.sh
-    - uses: actions/upload-artifact@v2
-      with:
-        name: FontPatcher.zip
-        path: archives/FontPatcher.zip
-    - id: updated-or-not
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch dependencies
+      run: sudo apt install -y -q zipcmp
+
+    - name: Create archive
       run: |
-        if zipcmp archives/FontPatcher.zip ./FontPatcher.zip ; then
-          echo "updated=false" | tee -a $GITHUB_OUTPUT
-        else
-          echo "updated=true" | tee -a $GITHUB_OUTPUT
-        fi
-    - run: cp archives/FontPatcher.zip . -f
-    - uses: EndBug/add-and-commit@v9
-      if: steps.updated-or-not.outputs.updated == 'true'
-      #needs to be quoted
+        chmod u+x font-patcher bin/scripts/archive-font-patcher.sh
+        cd bin/scripts
+        ./archive-font-patcher.sh
+
+    - name: Upload archive as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: archives/FontPatcher.zip
+        retention-days: 1
+
+    - name: Check if archive contents changed
+      id: updated-or-not
+      run: |
+        (zipcmp archives/FontPatcher.zip ./FontPatcher.zip; \
+         echo "updated=$?" >> $GITHUB_OUTPUT) || true
+
+    - name: Prepare commit
+      if: steps.updated-or-not.outputs.updated != 0
+      run: cp -f archives/FontPatcher.zip .
+
+    - name: Commit new archive
+      uses: EndBug/add-and-commit@v9
+      if: steps.updated-or-not.outputs.updated != 0
       with:
         fetch: false
         add: "FontPatcher.zip"
-        message: "[ci] update FontPatcher.zip"
+        message: "[ci] Update FontPatcher.zip"
         committer_name: GitHub Actions
         committer_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -1,4 +1,4 @@
-name: Release font patcher from master
+name: Create FontPatcher.zip from master
 
 on:
   create:

--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         chmod u+x font-patcher bin/scripts/archive-font-patcher.sh
         cd bin/scripts
-        ./archive-font-patcher.sh
+        ./archive-font-patcher.sh intermediate
 
     - name: Upload archive as artifact
       uses: actions/upload-artifact@v3

--- a/bin/scripts/archive-font-patcher.sh
+++ b/bin/scripts/archive-font-patcher.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 2.3.3
-# Script Version: 1.0.0
+# Script Version: 1.1.0
 # Archives the font patcher script and the required source files
+# If some (any) argument is given this is though of as intermediate version
 # used for debugging
 # set -x
 
@@ -16,14 +17,19 @@ mkdir -p "$outputdir"
 touch "$outputdir/readme.md"
 mini_readme="$outputdir/readme.md"
 cat "$parent_dir/src/archive-font-patcher-readme.md" >> "$mini_readme"
+if [ $# -ge 1 ]; then
+  echo "Intemediate version, adding git version"
+  echo -e "\n## Version\n" >> "$mini_readme"
+  echo "This archive is created from $(git describe --tags --dirty)" >> "$mini_readme"
+fi
 
 # clear out the directory zips
 find "${outputdir:?}" -name "FontPatcher.zip" -type f -delete
 
 cd -- "$scripts_root_dir/../../" || exit 1
-find "src/glyphs" | zip -9 "$outputdir/FontPatcher" -@ 
+find "src/glyphs" | zip -9 "$outputdir/FontPatcher" -@
 find "bin/scripts/name_parser" -name "Fontname*.py" | zip -9 "$outputdir/FontPatcher" -@
-find "font-patcher" | zip -9 "$outputdir/FontPatcher" -@ 
+find "font-patcher" | zip -9 "$outputdir/FontPatcher" -@
 
 # add mini readme file
 zip -9 "$outputdir/FontPatcher" -rj "$mini_readme" -q


### PR DESCRIPTION
#### Description

Fixes https://github.com/ryanoasis/nerd-fonts/issues/1040

@all-contributors please add @b- for infra

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] Verified the license of any newly added font, glyph, or glyph set _(N/A)_

#### What does this Pull Request (PR) do?

 - Adds a Github Actions workflow to release _just_ an updated fontpatcher.zip from master, upon push of font-patcher or its dependencies or glyphs to master 

#### How should this be manually tested?
 - make sure the freshly cooked font-patcher.zip contains all required dependencies (but not anything else), and functions as expected.

#### Any background context you can provide?

https://github.com/ryanoasis/nerd-fonts/pull/1041

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/issues/1040

#### Screenshots (if appropriate or helpful)
