### PR TITLE
font-patcher: Fix some Nerd Font Mono too wide

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -944,19 +944,29 @@ class font_patcher:
         # Ignore the y-values, os2_winXXXXX values set above are used for line height
         #
         # 0x00-0x17f is the Latin Extended-A range
+        warned = self.args.quiet or self.args.nonmono # Do not warn if quiet or proportional target
         for glyph in range(0x21, 0x17f):
-            if glyph in range(0x7F, 0xBF) or glyph in range(0x132, 0x134):
-                continue # ignore special characters like '1/4' etc and 'IJ' 'ij'
+            if glyph in range(0x7F, 0xBF) or glyph in [
+                    0x132, 0x134, # IJ, ij (in Overpass Mono)
+                    0x022, 0x027, 0x060, # Single and double quotes in Inconsolata LGC
+                    0x0D0, 0x10F, 0x110, 0x111, 0x127, 0x13E, 0x140, 0x165, # Eth and others with stroke or caron in RobotoMono
+                    ]:
+                continue # ignore special characters like '1/4' etc and some specifics
             try:
                 (_, _, xmax, _) = self.sourceFont[glyph].boundingBox()
             except TypeError:
                 continue
+            # print("WIDTH {:X} {} ({} {})".format(glyph, self.sourceFont[glyph].width, self.font_dim['width'], xmax))
             if self.font_dim['width'] < self.sourceFont[glyph].width:
                 self.font_dim['width'] = self.sourceFont[glyph].width
-                # print("New MAXWIDTH-A {} {} {}".format(glyph, self.sourceFont[glyph].width, xmax))
+                if not warned and glyph > 0x7a: # NOT 'basic' glyph, which includes a-zA-Z
+                    print("Extended glyphs wider than basic glyphs")
+                    warned = True
+                # print("New MAXWIDTH-A {} {} -> {} {}".format(glyph, self.sourceFont[glyph].width, self.font_dim['width'], xmax))
             if xmax > self.font_dim['xmax']:
                 self.font_dim['xmax'] = xmax
-                # print("New MAXWIDTH-B {} {} {}".format(glyph, self.sourceFont[glyph].width, xmax))
+                # print("New MAXWIDTH-B {} {} -> {} {}".format(glyph, self.sourceFont[glyph].width, self.font_dim['width'], xmax))
+        # print("FINAL", self.font_dim)
 
 
     def get_scale_factor(self, sym_dim):

--- a/font-patcher
+++ b/font-patcher
@@ -945,8 +945,8 @@ class font_patcher:
         #
         # 0x00-0x17f is the Latin Extended-A range
         for glyph in range(0x21, 0x17f):
-            if glyph in range(0x7F, 0xBF):
-                continue # ignore special characters like '1/4' etc
+            if glyph in range(0x7F, 0xBF) or glyph in range(0x132, 0x134):
+                continue # ignore special characters like '1/4' etc and 'IJ' 'ij'
             try:
                 (_, _, xmax, _) = self.sourceFont[glyph].boundingBox()
             except TypeError:


### PR DESCRIPTION
**[why]**
The 'monospace' width is determined by examining all the 'normal' glyphs and taking the widest one.

'Normal' means `0x00`-`0x17f`: the Latin Extended-A range.

Unfortunately Overpass (Mono) has wide-as-two-letters `IJ` and `ij` ligatures.

**[how]**
Exclude a small sub-range from the 'find the widest glyph' that contain these ligatures. Yes they will kind of break, but what can we do if we want to create a strictly monospaced font?

[note]
Related commit
  fbe07b8ab  Fix Noto too wide

Related: #1043

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Exclude IJ and ij ligatures from the width calculation (for NFM), as they are too wide in the supposed to be `monospaced` font `Overpass Mono`.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
