### PR TITLE
font-patcher: Fix unexpected 'Book' SubFamily

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -302,6 +302,9 @@ class FontnameParser:
         sfnt_list = []
         TO_DEL = ['Family', 'SubFamily', 'Fullname', 'Postscriptname', 'Preferred Family',
                 'Preferred Styles', 'Compatible Full', 'WWS Family', 'WWS Subfamily']
+        # Remove these entries in all languages and add (at least the vital ones) some
+        # back, but only as 'English (US)'. This makes sure we do not leave contradicting
+        # names over different languages.
         for l, k, v in list(font.sfnt_names):
             if not k in TO_DEL:
                 sfnt_list += [( l, k, v )]

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.4.0"
+script_version = "3.4.1"
 
 version = "2.3.0-RC"
 projectName = "Nerd Fonts"
@@ -512,12 +512,15 @@ class font_patcher:
             subFamily = fallbackStyle
 
         # some fonts have inaccurate 'SubFamily', if it is Regular let us trust the filename more:
-        if subFamily == "Regular":
+        if subFamily == "Regular" and len(fallbackStyle):
             subFamily = fallbackStyle
 
         # This is meant to cover the case where the SubFamily is "Italic" and the filename is *-BoldItalic.
         if  len(subFamily) < len(fallbackStyle):
             subFamily = fallbackStyle
+
+        if len(subFamily) == 0:
+            subFamily = "Regular"
 
         if self.args.windows:
             maxFamilyLength = 31


### PR DESCRIPTION
**[why]**
Sometimes we set an empty string as SubFamily name. That ends up as 'Book' which is unexpected.

**[how]**
The translation from empty to "Book" is done by Fontforge, at least with version 20220308.

Make sure we always have a SubFamily, and if we don't that must be a 'Regular'.

**[note]**
This was only a problem with the old naming engine. `--makegroups` got this right always.

Fixes: #1046

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?
https://github.com/ryanoasis/nerd-fonts/pull/780#issuecomment-1381067808
#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
