### PR TITLE
font-patcher: Cover alternate unicode encodings

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -921,13 +921,11 @@ class font_patcher:
                 # that means it has gone through this function before.
                 # Therefore we skip it to avoid infinite loop.
                 # A unicode value of -1 basically means unused and is also worth skipping.
-                if r[0] in self.essential or r[0] == -1:
-                    continue
-                self.add_glyphrefs_to_essential(r[0])
+                if r[0] not in self.essential and r[0] >= 0:
+                    self.add_glyphrefs_to_essential(r[0])
         for r in self.sourceFont[unicode].references:
-            if self.sourceFont[r[0]].unicode in self.essential or self.sourceFont[r[0]].unicode == -1:
-                continue
-            self.add_glyphrefs_to_essential(self.sourceFont[r[0]].unicode)
+            if self.sourceFont[r[0]].unicode not in self.essential and self.sourceFont[r[0]].unicode >= 0:
+                self.add_glyphrefs_to_essential(self.sourceFont[r[0]].unicode)
 
     def get_essential_references(self):
         """Find glyphs that are needed for the basic glyphs"""

--- a/font-patcher
+++ b/font-patcher
@@ -912,6 +912,23 @@ class font_patcher:
                 self.sourceFont.os2_typoascent += 1
                 self.sourceFont.os2_winascent += 1
 
+    def add_glyphrefs_to_essential(self, unicode):
+        self.essential.add(unicode)
+        # According to fontforge spec, altuni is either None or a tuple of tuples
+        if self.sourceFont[unicode].altuni is not None:
+            for r in self.sourceFont[unicode].altuni:
+                # If alternate unicode already exists in self.essential,
+                # that means it has gone through this function before.
+                # Therefore we skip it to avoid infinite loop.
+                # A unicode value of -1 basically means unused and is also worth skipping.
+                if r[0] in self.essential or r[0] == -1:
+                    continue
+                self.add_glyphrefs_to_essential(r[0])
+        for r in self.sourceFont[unicode].references:
+            if self.sourceFont[r[0]].unicode in self.essential or self.sourceFont[r[0]].unicode == -1:
+                continue
+            self.add_glyphrefs_to_essential(self.sourceFont[r[0]].unicode)
+
     def get_essential_references(self):
         """Find glyphs that are needed for the basic glyphs"""
         # Sometimes basic glyphs are constructed from multiple other glyphs.
@@ -921,8 +938,7 @@ class font_patcher:
         for glyph in range(0x21, 0x17f):
             if not glyph in self.sourceFont:
                 continue
-            for r in self.sourceFont[glyph].references:
-                self.essential.add(self.sourceFont[r[0]].unicode)
+            self.add_glyphrefs_to_essential(glyph)
 
     def get_sourcefont_dimensions(self):
         """ This gets the font dimensions (cell width and height), and makes them equal on all platforms """

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.0"
+script_version = "3.5.1"
 
 version = "2.3.0"
 projectName = "Nerd Fonts"
@@ -915,17 +915,24 @@ class font_patcher:
     def add_glyphrefs_to_essential(self, unicode):
         self.essential.add(unicode)
         # According to fontforge spec, altuni is either None or a tuple of tuples
-        if self.sourceFont[unicode].altuni is not None:
-            for r in self.sourceFont[unicode].altuni:
+        # Those tuples contained in altuni are of the following "format":
+        # (unicode-value, variation-selector, reserved-field)
+        altuni = self.sourceFont[unicode].altuni
+        if altuni is not None:
+            for altcode in [ v for v, s, r in altuni if v >= 0 ]:
                 # If alternate unicode already exists in self.essential,
                 # that means it has gone through this function before.
                 # Therefore we skip it to avoid infinite loop.
                 # A unicode value of -1 basically means unused and is also worth skipping.
-                if r[0] not in self.essential and r[0] >= 0:
-                    self.add_glyphrefs_to_essential(r[0])
-        for r in self.sourceFont[unicode].references:
-            if self.sourceFont[r[0]].unicode not in self.essential and self.sourceFont[r[0]].unicode >= 0:
-                self.add_glyphrefs_to_essential(self.sourceFont[r[0]].unicode)
+                if altcode not in self.essential:
+                    self.add_glyphrefs_to_essential(altcode)
+        # From fontforge documentation:
+        # glyph.references return a tuple of tuples containing, for each reference in foreground,
+        # a glyph name, a transformation matrix, and whether the reference is currently selected.
+        references = self.sourceFont[unicode].references
+        for refcode in [ self.sourceFont[n].unicode for n, m, s in references ]:
+            if refcode not in self.essential and refcode >= 0:
+                self.add_glyphrefs_to_essential(refcode)
 
     def get_essential_references(self):
         """Find glyphs that are needed for the basic glyphs"""


### PR DESCRIPTION
#### Description

**[why]**
As described in [this comment](https://github.com/ryanoasis/nerd-fonts/issues/400#issuecomment-1397371200), issue #400 recently reoccurred with the latest build of Input font, and it turns out the dotless-j part of the small `j` now points to `U+0237`, which in turn has an alternate unicode encoding to `U+F6BE`; overwriting `U+F6BE` effectively overwrites `U+0237`, and in turn, alters the small `j`. This patch aims to fix that.

**[how]**
In addition to references, the patcher also checks for alternate unicode encodings which are returned by the `glyph.altuni` attribute, adds those to the essential set of glyphs, and in turn recursively searches for their references/alternate unicode encodings, making sure to handle circular references if they appear (for example: `U+2010` and `U+2011` in Input Mono).

Fixes: #400 

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Make `font-patcher` also check for alternate unicode encodings in addition to references so they won't be overwritten.

#### How should this be manually tested?

Input Mono so far is the only font I've had this issue with, and this patch successfully prevents `font-patcher` from overwriting or altering those essential glyphs, but should work with most if not all fonts.

#### What are the relevant tickets (if any)?

#400 