### PR TITLE
cheat-sheet: Add tooltip to copy hex code

### DIFF
--- a/bin/scripts/generate-css.sh
+++ b/bin/scripts/generate-css.sh
@@ -85,7 +85,7 @@ for var in "${!i@}"; do
     printf "\\n"
     printf "    <div class=\"nf nf-%s center\"></div>" "$glyph_name"
     printf "\\n"
-    printf "    <div class=\"class-name\">nf-%s</div><div class=\"codepoint\">%s</div>" "$glyph_name" "$glyph_code"
+    printf "    <div class=\"class-name\">nf-%s</div><div title=\"Copy Hex Code to Clipboard\" class=\"codepoint\">%s</div>" "$glyph_name" "$glyph_code"
     printf "\\n"
     printf "  </div>"
     printf "\\n"


### PR DESCRIPTION
#### Description

This changes the design of the Cheat Sheet, to allow handling the > `FFFF` code points more comfortably for the users.

See
* #1059

This PR also consists of these commits to branch `gh-pages`:

* bae34d36a `cheat-sheet: Copy UTF16 instead of raw hex code`
* 6e361d40c `cheat-sheet: Allow click to copy on hex value`
* 8914909ad  `Regenerate Cheat Sheet`


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

Go to the cheat sheet and try to copy the UTF16 and hex values (use `-md-` icons for UTF16).

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
