### PR TITLE
No need --cask params anymore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -258,7 +258,7 @@ All fonts are available via [Homebrew Cask Fonts](https://github.com/Homebrew/ho
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Option 5: Clone the Repo`

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -290,7 +290,7 @@ _注_: **Requires cloning** the repo as of now
 
 ```sh
 brew tap caskroom/fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `选项5: 克隆 Repo`

--- a/readme_es.md
+++ b/readme_es.md
@@ -237,7 +237,7 @@ Todas las fuentes están disponibles en [Homebrew Cask Fonts](https://github.com
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Opción 5: Clonar el repo`

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -315,7 +315,7 @@ Toutes les polices sont disponibles via [Homebrew Fonts](https://github.com/cask
 
 ```sh
 brew tap caskroom/fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Option 5: Cloner le dépôt`

--- a/readme_hi.md
+++ b/readme_hi.md
@@ -252,7 +252,7 @@ _ध्यान दें_:**क्लोनिंग की आवश्यक
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `विकल्प 5: रेपो का क्लोन बनाएं`

--- a/readme_it.md
+++ b/readme_it.md
@@ -238,7 +238,7 @@ Tutti i font sono disponibili via la [Homebrew Cask Fonts](https://github.com/Ho
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Opzione 5: Clonare il Repo`

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -234,7 +234,7 @@ macOS (OS X) では [Homebrew Cask Fonts](https://github.com/Homebrew/homebrew-c
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `その 5: リポジトリをクローンする`

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -235,7 +235,7 @@ macOS (OS X)의 [Homebrew Cask Fonts](https://github.com/Homebrew/homebrew-cask-
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `옵션 5: 저장소 클론`

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -310,7 +310,7 @@ Wszystkie czcionki są dostępne na [Homebrew Fonts](https://github.com/caskroom
 
 ```sh
 brew tap caskroom/fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Opcja 5: Klonowanie Repo`

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -234,7 +234,7 @@ Todos os tipos de letra estão disponíveis através de [Homebrew Cask Fonts](ht
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Opção 5: Dar clone ao repositório`

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -290,7 +290,7 @@ _Замечание_: **Необходимо клонировать** текущ
 
 ```sh
 brew tap caskroom/fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Вариант 5: Клонировать Репозиторий`

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -252,7 +252,7 @@ _註_: **Requires cloning** the repo as of now
 
 ```sh
 brew tap caskroom/fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `選項5: 複製 Repo`

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -235,7 +235,7 @@ _Примітка_: **необхідне клонування** репозито
 
 ```sh
 brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
+brew install font-hack-nerd-font
 ```
 
 ### `Варіант 5: Клонування репозиторію`


### PR DESCRIPTION
#### Description

No need `--cask` param to install cask via brew.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

```sh
brew tap homebrew/cask-fonts
brew install font-hack-nerd-font
```

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
