### PR TITLE
font-patcher: Use git version tag for font version

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1588,6 +1588,34 @@ def check_fontforge_min_version():
         sys.stderr.write("{}: Please use at least version: {}\n".format(projectName, minimumVersion))
         sys.exit(1)
 
+def check_version_with_git(version):
+    """ Upgraded the version to the current git tag version (starting with 'v') """
+    git = subprocess.run("git describe --tags",
+            cwd=os.path.dirname(__file__),
+            shell=True,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        ).stdout.decode('utf-8')
+    if len(git) == 0:
+        return False
+    tag = git.strip()
+    if len(tag) == 0 or not tag.startswith('v'):
+        return False
+    tag = tag[1:]
+    r = re.search('(.*?)(-[0-9]+)-g[0-9a-fA-F]+$', tag)
+    if r:
+        tag = r.group(1)
+        patchlevel = r.group(2)
+    else:
+        patchlevel = ""
+    # Inspired by Phaxmohdem's versiontuple https://stackoverflow.com/a/28568003
+
+    versiontuple = lambda v: tuple( p.zfill(8) for p in v.split(".") )
+    if versiontuple(tag) > versiontuple(version):
+        return tag + patchlevel
+    if versiontuple(tag) == versiontuple(version) and len(patchlevel) > 0:
+        return tag + patchlevel
+    return False
+
 def setup_arguments():
     parser = argparse.ArgumentParser(
         description=(
@@ -1716,7 +1744,12 @@ def setup_arguments():
 
 
 def main():
-    print("{} Patcher v{} ({}) executing".format(projectName, version, script_version))
+    global version
+    git_version = check_version_with_git(version)
+    print("{} Patcher v{} ({}) (ff {}) executing".format(
+        projectName, git_version if git_version else version, script_version, fontforge.version()))
+    if git_version:
+        version = git_version
     check_fontforge_min_version()
     args = setup_arguments()
     patcher = font_patcher(args)


### PR DESCRIPTION
**[why]**
When changes are made to the `font-patcher` and fonts are patched with that version we can not see which patcher has been used in the fonts afterwards.

Would be good to have the usual version-patchversion number in the fonts in these cases (i.e. `v2.3.3-7` for 7 commits after `2.3.3`).

I did this manually before, but it is always a hassle.

[how]
If the `font-patcher` is run directly from a git repo and git is installed we try to get the latest tag version including patch number.

If and only if that is successful and that version is 'newer' than the version encoded in the `font-patcher` script the git version is trusted more.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
