### PR TITLE
Update Arch package links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ The following Sankey flow diagram shows the current glyph sets included:
   * [**5 - Clone Repo**](#option-5-clone-the-repo)
   * [**6 - Ad Hoc Curl Download**](#option-6-ad-hoc-curl-download)
   * [**7 - Chocolatey or Scoop (Windows)**](#option-7-unofficial-chocolatey-or-scoop-repositories)
-  * [**8 - Arch User Repository (AUR) (Arch Linux)**](#option-8-unofficial-arch-user-repository-aur)
+  * [**8 - Arch Linux Repository (Community, AUR)**](#option-8-arch-community-repository)
   * [**9 - Patch Your Own Font**](#option-9-patch-your-own-font)
 
 [**Features**](#features)
@@ -82,7 +82,7 @@ _If you..._
   * `Option 5.` want **complete control** then see [cloning the repo](#option-5-clone-the-repo)
   * `Option 6.` want to use the **`curl` command** or use in **scripts** see [Ad Hoc Curl Download](#option-6-ad-hoc-curl-download)
   * `Option 7`. are on **Windows** and want to use **Chocolatey** or **Scoop** see [Unofficial Chocolatey or Scoop Repositories](#option-7-unofficial-chocolatey-or-scoop-repositories)
-  * `Option 8.` are on **Arch Linux** and want to use **AUR packages** see [Unofficial Arch User Repositories](#option-8-unofficial-arch-user-repository-aur)
+  * `Option 8.` are on **Arch Linux** and want to use **Community packages** see [Arch Community Repositories](#option-8-arch-community-repository)
   * `Option 9.` want to patch your own font see the [Font Patcher](#option-9-patch-your-own-font)
 
 ## Features
@@ -316,30 +316,12 @@ scoop bucket add nerd-fonts
 scoop install Hack-NF
 ```
 
-### `Option 8: Unofficial Arch User Repository (AUR)`
+### `Option 8: Arch Community Repository`
 
-> Option for **Arch Linux** and wanting to use **AUR packages**.
+> Option for **Arch Linux** and wanting to use **Community packages**.
 
-The following fonts are available via [AUR packages](https://aur.archlinux.org/) on Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Option 9: Patch Your Own Font`
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -38,7 +38,7 @@
   * [**4 - Homebrew Fonts (macOS (OS X))**](#option-4-homebrew-fonts)
   * [**5 - 克隆 Repo**](#option-5-clone-the-repo)
   * [**6 - Ad Hoc Curl 下载**](#option-6-ad-hoc-curl-download)
-  * [**7 - Arch User Repository (AUR) (Arch Linux)**](#option-7-unofficial-arch-user-repository-aur)
+  * [**8 - Arch Linux Repository (Community, AUR)**](#option-7-arch-community-repository)
   * [**8 - 你自己的字体补丁**](#option-8-patch-your-own-font)
 
 [**特征**](#features)
@@ -76,7 +76,7 @@ _如果你..._
   * `选项 4.` 是**macOS**的使用者，并且想要使用**Homebrew**，请见 [Homebrew Fonts](#option-4-homebrew-fonts)
   * `选项 5.` 想要 **完全控制**，请见 [克隆这个 repo](#option-5-clone-the-repo)
   * `选项 6.` 想要使用 **`curl` command** 或者使用 **scripts**，请见 [Ad Hoc Curl 下载](#option-6-ad-hoc-curl-download)
-  * `选项 7.` 是**Arch Linux**的使用者，并且想要使用**AUR packages**，请见 [Unofficial Arch User Repositories](#option-7-unofficial-arch-user-repository-aur)
+  * `选项 7.` 是**Arch Linux**的使用者，并且想要使用**Community packages**，请见 [Arch Community Repositories](#option-7-arch-community-repository)
   * `选项 8.` 想要打包你自定义的字体，请见 [字体补丁](#option-8-patch-your-own-font)
 
 ## 特征
@@ -323,30 +323,12 @@ _注:_ deprecated alternative paths: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `选项7: 非官方 Arch User Repository (AUR)`
+### `选项7: 非官方 Arch Community Repository`
 
-> 适用于 **Arch Linux** 下使用 **AUR packages**的情况
+> 适用于 **Arch Linux** 下使用 **Community packages**的情况
 
-下列字体可以在Arch Linux通过 [AUR packages](https://aur.archlinux.org/) 下载：
-
-* [Nerd Fonts Complete (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete (single-width)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `选项8: 打包你的个人字体`
 

--- a/readme_es.md
+++ b/readme_es.md
@@ -42,7 +42,7 @@ El siguiente diagrama Sankey muestra los conjuntos de glifos incluidos en la act
   * [**4 - Fuentes Homebrew (macOS (OS X))**](#option-4-homebrew-fonts)
   * [**5 - Clonar el Repo**](#option-5-clone-the-repo)
   * [**6 - Descarga Ad Hoc con Curl**](#option-6-ad-hoc-curl-download)
-  * [**7 - Repositorio de Usuario de Arch (AUR) (Arch Linux)**](#option-7-unofficial-arch-user-repository-aur)
+  * [**7 - Repositorio de Community de Arch (Arch Linux)**](#option-7--arch-community-repository)
   * [**8 - Parcha tu Propia Fuente**](#option-8-patch-your-own-font)
 
 [**Características**](#features)
@@ -80,7 +80,7 @@ _Si tu..._
   * `Opción 4.` estas en **macOS** y quieres usar el **Homebrew**, ve a [Fuentes Homebrew](#option-4-homebrew-fonts)
   * `Opción 5.` quieres **control completo**, entonces ve a [clonar el repo](#option-5-clone-the-repo)
   * `Opción 6.` quieres usar el **comando `curl`** o usar en **scripts**, ve a [Descarga Ad Hoc con Curl](#option-6-ad-hoc-curl-download)
-  * `Opción 7.` estas en **Arch Linux** y quieres usar **paquetes AUR**, ve a [Repositorios de Usuarios AUR No Oficiales](#option-7-unofficial-arch-user-repository-aur)
+  * `Opción 7.` estas en **Arch Linux** y quieres usar **paquetes Community**, ve a [Repositorios de Community](#option-7-arch-community-repository)
   * `Opción 8.` quieres parchar tu propia fuente, ve a [Parchador de Fuentes](#option-8-patch-your-own-font)
 
 ## Características
@@ -270,30 +270,12 @@ Nota:_ Rutas alternativas deprecadas: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Opción 7: Repositorio de Usuarios de Arch (AUR) No Oficial`
+### `Opción 7: Repositorio de Community de Arch`
 
-> Es la opción para usuarios de **Arch Linux** que quieren usar **paquetes AUR**.
+> Es la opción para usuarios de **Arch Linux** que quieren usar **paquetes Community**.
 
-las siguientes fuentes están disponibles como [paquetes AUR](https://aur.archlinux.org/) en Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Opción 8: Parchar tu Propia Fuente`
 

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -44,8 +44,8 @@ Le diagramme de Sankey suivant montre les ensembles de glyphes actuels inclus :
   * [**3 - Install Script**](#option-3-install-script)
   * [**4 - Homebrew Fonts (macOS (OS X))**](#option-4-homebrew-fonts)
   * [**5 - Cloner le dépôt**](#option-5-clone-the-repo)
-  * [**6 - Téléchargement Ad Hoc avec Curl*](#option-6-ad-hoc-curl-download)
-  * [**7 - Non-officiel Arch User dépôt (AUR)**](#option-7-unofficial-arch-user-repository-aur)
+  * [**6 - Téléchargement Ad Hoc avec Curl**](#option-6-ad-hoc-curl-download)
+  * [**7 - Arch Community dépôt**](#option-7-arch-community-repository)
   * [**8 - Générer votre propre police**](#option-8-patch-your-own-font)
 
 [**Fonctionnalités**](#features)
@@ -83,7 +83,7 @@ _Si vous..._
   * `Option 4.` vous êtes sur **macOS** et que vous voulez utiliser **Homebrew**, voir [Homebrew Fonts](#option-4-homebrew-fonts)
   * `Option 5.` voulez un **contrôle total**, voir [cloner le dépôt](#option-5-clone-the-repo)
   * `Option 6.` voulez utiliser la **commande `curl`** ou pour l'utiliser via des **scripts**, voir [Téléchargement Ad Hoc avec Curl](#option-6-ad-hoc-curl-download)
-  * `Option 7.` êtes sur **Arch Linux** et que vous voulez utiliser les **AUR packages**, voir [Dépôts non-officiel Arch User](#option-7-unofficial-arch-user-repository-aur)
+  * `Option 7.` êtes sur **Arch Linux** et que vous voulez utiliser les **Community packages**, voir [Dépôts Arch Community](#option-7-arch-community-repository)
   * `Option 8.` générer votre propre police [Générateur de police](#option-8-patch-your-own-font)
 
 ## Fonctionnalités
@@ -348,30 +348,12 @@ _Note:_ chemins alternatifs dépréciés: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Option 7: Dépôts non-officiel Arch User (AUR)`
+### `Option 7: Dépôts Arch Community`
 
 > L'option pour **Arch Linux** et voulant utiliser les **AUR packages**.
 
-Les polices suivantes sont disponibles via [AUR packages](https://aur.archlinux.org/) sur Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Option 8: Générer votre propre police`
 

--- a/readme_it.md
+++ b/readme_it.md
@@ -42,7 +42,7 @@ Il seguente diagramma di flusso Sankey mostra gli attuali set di glifi inclusi:
   * [**4 - Homebrew Fonts (macOS (OS X))**](#opzione-4-homebrew-fonts)
   * [**5 - Clonare il Repo**](#opzione-5-clonare-il-repo)
   * [**6 - Download Ad Hoc con Curl**](#opzione-6-download-ad-hoc-con-curl)
-  * [**7 - Arch User Repository (AUR) (Arch Linux)**](#opzione-7-arch-user-repositories-non-ufficiali-aur)
+  * [**7 - Arch Community Repository(Arch Linux)**](#opzione-7-arch-community-repositories)
   * [**8 - Modifica il tuo Font**](#opzione-8-modifica-il-tuo-font)
 
 [**Caratteristiche**](#caratteristiche)
@@ -80,7 +80,7 @@ _Se tu..._
   * `Opzione 4.` sei su **macOS** e preferisci usare **Homebrew**, guarda come fare con [Homebrew Fonts](#option-4-homebrew-fonts)
   * `Opzione 5.` vuoi il **controllo completo**, guarda come [clonare il repo](#option-5-clone-the-repo)
   * `Opzione 6.` vuoi usare il **comando `curl`** o utilizzarlo nei tuoi **script**, guarda le istruzioni per [Ad Hoc Curl Download](#option-6-ad-hoc-curl-download)
-  * `Opzione 7.` sei su **Arch Linux** e preferisci usare i **pacchetti AUR**, guarda come fare con gli [Arch User Repositories Non Ufficiali](#option-7-unofficial-arch-user-repository-aur)
+  * `Opzione 7.` sei su **Arch Linux** e preferisci usare i **pacchetti Community**, guarda come fare con gli [Arch Community Repositories](#opzione-7-arch-community-repositories)
   * `Opzione 8.` vuoi modificare un font in tuoi possesso, guarda come usare il [Font Patcher](#option-8-patch-your-own-font)
 
 ## Caratteristiche
@@ -271,30 +271,10 @@ _Nota:_ path alternativo deprecato: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Opzione 7: Arch User Repositories Non Ufficiali (AUR)`
+### `Opzione 7: Arch Community Repositories`
 
-> Opzione per gli utilizzatori di **Arch Linux** che vogliono usare i **pacchetti AUR**.
-
-I seguenti font sono disponibili attraverso i [pacchetti AUR](https://aur.archlinux.org/) su Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Opzione 8: Modifica il tuo Font`
 

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -42,7 +42,7 @@
   * [**4 - Homebrew Fonts (macOS (OS X) 用)**](#その-4-homebrew-fonts)
   * [**5 - リポジトリのクローン**](#その-5-リポジトリをクローンする)
   * [**6 - Curl で直接ダウンロード**](#その-6-curl-で直接ダウンロード)
-  * [**7 - Arch User Repository (AUR) (Arch Linux用)**](#その-7-非公式-arch-user-repository-aur)
+  * [**7 - Arch Community Repository (Arch Linux用)**](#その-7-非公式-arch-community-repository)
   * [**8 - 自分でパッチを当てる**](#その-8-自分でフォントにパッチを当てる)
 
 [**特徴**](#特徴)
@@ -78,7 +78,7 @@ _あなたがもし……_
   * `その 4` **macOS** 利用者で **Homebrew** を使いたい方なら、[Homebrew Fonts](#その-4-homebrew-fonts)を見てください。
   * `その 5` **あなたの手で全てを管理したいのなら**、[リポジトリのクローン](#その-5-リポジトリをクローンする)を見てください。
   * `その 6` **`curl` コマンド**を使いたい、あるいは、**スクリプト**内で利用したい場合は [Curl で直接ダウンロード](#その-6-curl-で直接ダウンロード)を見てください。
-  * `その 7` **Arch Linux** 利用者で、**AUR packages** を使いたいならば、[非公式 Arch User Repository](#その-7-非公式-arch-user-repository-aur)を見てください。
+  * `その 7` **Arch Linux** 利用者で、**Community packages** を使いたいならば、[非公式 Arch Community Repository](#その-7-非公式-arch-community-repository)を見てください。
   * `その 8` 自分でフォントにパッチを当てたいのなら、[パッチスクリプト](#その-8-自分でフォントにパッチを当てる)を見てください。
 
 ## 特徴
@@ -267,30 +267,10 @@ _注意_: 以前別の選択肢として利用できたパス (`~/.fonts`) は d
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `その 7: 非公式 Arch User Repository (AUR)`
+### `その 7: 非公式 Arch Community Repository`
 
-> **Arch Linux**、かつ、 **AUR packages** を使いたい場合の選択肢です。
-
-Arch Linux 上の [AUR packages](https://aur.archlinux.org/) で以下のフォントが利用できます。
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `その 8: 自分でフォントにパッチを当てる`
 

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -40,7 +40,7 @@
   * [**4 - Homebrew Fonts (macOS (OS X))**](#옵션-4-homebrew-폰트)
   * [**5 - 저장소 클론**](#옵션-5-저장소-클론)
   * [**6 - Ad Hoc Curl 다운로드**](#옵션-6-ad-hoc-curl-다운로드)
-  * [**7 - Arch User Repository (AUR) (Arch Linux)**](#옵션-7-비공식-arch-user-repository-aur)
+  * [**7 - Arch Community Repository (Arch Linux)**](#옵션-7-비공식-arch-community-repository)
   * [**8 - 자신의 폰트 패치**](#옵션-8-자신의-폰트-패치)
 
 [**기능**](#기능)
@@ -78,7 +78,7 @@ _만약..._
   * `옵션 4.` **macOS**에서 **Homebrew**를 사용하고 싶은 경우 [Homebrew 폰트](#옵션-4-homebrew-폰트)를 확인하세요.
   * `옵션 5.` **완전히 통제**하고 싶은 경우 [저장소 클론](#옵션-5-저장소-클론)을 확인하세요.
   * `옵션 6.` **`curl` 명령**을 사용하고 싶거나 **스크립트**를 사용하고 싶은 경우 [Ad Hoc Curl 다운로드](#옵션-6-ad-hoc-curl-다운로드)를 확인하세요.
-  * `옵션 7.` **Arch Linux**에서 **AUR 패키지**를 사용하고 싶은 경우 [비공식 Arch User Repositories](#옵션-7-비공식-arch-user-repository-aur)를 확인하세요.
+  * `옵션 7.` **Arch Linux**에서 **Community 패키지**를 사용하고 싶은 경우 [비공식 Arch Community Repositories](#옵션-7-비공식-arch-community-repository)를 확인하세요.
   * `옵션 8.` 자신의 폰트를 패치하고 싶은 경우 [폰트 설치기](#옵션-8-자신의-폰트-패치)를 확인하세요.
 
 ## 기능
@@ -269,30 +269,10 @@ _주의:_ 사용되지 않는 대체 경로: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `옵션 7: 비공식 Arch User Repository (AUR)`
+### `옵션 7: 비공식 Arch Community Repository`
 
-> **Arch Linux**에서 **AUR 패키지**를 사용하기 위한 옵션.
-
-Arch Linux의 [AUR packages](https://aur.archlinux.org/)를 통해 아래 폰트들을 사용할 수 있습니다:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `옵션 8: 자신의 폰트 패치`
 

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -41,7 +41,7 @@ Poniższy diagram Sankey pokazuje aktualne zestawy dostępnych glifów (ikon):
   * [**4 - Czcionki Homebrew (macOS (OS X))**](#option-4-homebrew-fonts)
   * [**5 - Klonowanie repozytorium**](#option-5-clone-the-repo)
   * [**6 - Pobieranie za pomocą Ad Hoc Curl**](#option-6-ad-hoc-curl-download)
-  * [**7 - Arch User Repository (AUR) (Arch Linux)**](#option-7-unofficial-arch-user-repository-aur)
+  * [**7 - Arch Community Repository (Arch Linux)**](#opcja-7-arch-community-repository)
   * [**8 - Spatchuj własną czcionke**](#option-8-patch-your-own-font)
 
 [**Funkcje**](#features)
@@ -79,7 +79,7 @@ _Jeśli..._
   * `Opcja 4.` używasz **macOS** i chcesz skorzystać z czcionek **Homebrew** zajrzyj do [Czcionki Homebrew](#option-4-homebrew-fonts)
   * `Opcja 5.` chcesz mieć **pełną kontrolę** zajrzyj do sekcji [klonowanie Repozytorium](#option-5-clone-the-repo)
   * `Opcja 6.` chcesz użyć **komendy `curl`** lub korzystać ze **skryptów** zajrzyj do sekcji [pobieranie za pomocą Ad Hoc Curl](#option-6-ad-hoc-curl-download)
-  * `Opcja 7.` używasz **Arch Linux** i chcesz skorzystać z **pakietów AUR** zajrzyj do sekcji [nieoficjalne Arch User Repository (AUR)](#option-7-unofficial-arch-user-repository-aur)
+  * `Opcja 7.` używasz **Arch Linux** i chcesz skorzystać z **pakietów Community** zajrzyj do sekcji [Arch Community Repository](#opcja-7-arch-community-repository)
   * `Opcja 8.` chcesz spatchować własną czcionkę? Jeżeli tak, to zajrzyj do sekcji [patcher fontóczcionek](#option-8-patch-your-own-font)
 
 ## Funkcje
@@ -343,30 +343,10 @@ _Uwaga:_ przestarzała ścieżka alternatywna: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Opcja 7: Nieoficjalne Arch User Repository (AUR)`
+### `Opcja 7: Arch Community Repository`
 
-> Opcja dla **Arch Linux** jeśli chcesz wykorzystać **Pakietów AUR (Arch User Repository)**.
-
-Następujące czcionki są dostępne za pośrednictwem [Pakietów AUR](https://aur.archlinux.org/) na Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Option 8: Spatchuj własny font`
 

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -39,7 +39,7 @@ O diagram Sankey mostra os conjuntos de glifos incluídos abaixo:
   * [**4 - Tipos de letras do Homebrew (macOS (OS X))**](#opção-4-tipos-de-letra-do-homebrew)
   * [**5 - Dar clone ao repositório**](#opção-5-dar-clone-ao-repositório)
   * [**6 - Transferir *ad hoc* com `curl`**](#opção-6-transferir-ad-hoc-com-curl)
-  * [**7 - Repositório do Utilizador do Arch (AUR) não-oficial (Arch Linux)**](#opção-7-repositório-do-utilizador-do-arch-aur-não-oficial-arch-linux)
+  * [**7 - Repositório do Community do Arch (Arch Linux)**](#opção-7-repositório-arch-linux)
   * [**8 - Criar o teu tipo de letra**](#opção-8-criar-o-teu-tipo-de-letra)
 
 [**Características**](#características)
@@ -77,7 +77,7 @@ _Se tu..._
   * `Opção 4.` utilizas **macOS** e queres utilizar **Homebrew** vê: [Tipos de letras do Homebrew](#opção-4-tipos-de-letra-do-homebrew)
   * `Opção 5.` queres **controlo total**, então vê: [Dar clone ao repositório](#opção-5-dar-clone-ao-repositório)
   * `Opção 6.` queres utilizar o **comando `curl`** ou **executadores** vê: [Transferir *ad hoc* com `curl`](#opção-6-transferir-ad-hoc-com-curl)
-  * `Opção 7.` utilizas **Arch Linux** e queres utilizar o **AUR packages** vê: [Repositório do Utilizador do Arch (AUR) não-oficial](#opção-7-repositório-do-utilizador-do-arch-aur-não-oficial-arch-linux)
+  * `Opção 7.` utilizas **Arch Linux** e queres utilizar o **Community packages** vê: [Repositório do Utilizador do Community](#opção-7-repositório-arch-linux)
   * `Opção 8.` queres modificar o teu tipo de letra vê: [Modificador de tipo de letra](#opção-8-criar-o-teu-tipo-de-letra)
 
 ## Características
@@ -267,30 +267,10 @@ _Note:_ caminhos alternativos deprecados: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Opção 7: Repositório do Utilizador do Arch (AUR) não-oficial (Arch Linux`
+### `Opção 7: Repositório Arch Linux`
 
-> E a opção para utilizadores de **Arch Linux** que querem utilizar os **pacotes do AUR**.
-
-Os seguintes tipos de letra estão disponíveis nos [pacotes do AUR](https://aur.archlinux.org/) para Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Opção 8: Criar o teu tipo de letra`
 

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -38,7 +38,7 @@
   * [**4 - Шрифты Homebrew (macOS (OS X))**](#option-4-homebrew-fonts)
   * [**5 - Клонировать репозиторий**](#option-5-clone-the-repo)
   * [**6 - Скачать Ad Hoc Curl**](#option-6-ad-hoc-curl-download)
-  * [**7 - Пользовательский репозиторий Arch (AUR) (Arch Linux)**](#option-7-unofficial-arch-user-repository-aur)
+  * [**7 - Пользовательский репозиторий Arch (Community) (Arch Linux)**](#вариант-7-пользовательский-репозиторий-arch-community)
   * [**8 - Исправить свой собственный шрифт**](#option-8-patch-your-own-font)
 
 [**Особенности**](#features)
@@ -76,7 +76,7 @@ _Если Вы..._
   * `Вариант 4.` пользователь **macOS** и хотите использовать **Homebrew**, смотрите [Homebrew Fonts](#option-4-homebrew-fonts)
   * `Вариант 5.` хотите **полный контроль**, смотрите [клонировать репозиторий](#option-5-clone-the-repo)
   * `Вариант 6.` хотите использовать **`curl` команду** или использовать её в **скриптах**, смотрите [Ad Hoc Curl Download](#option-6-ad-hoc-curl-download)
-  * `Вариант 7.` пользователь **Arch Linux** и хотите использовать **AUR packages**, смотрите [Пользовательский репозиторий Arch (AUR)](#option-7-unofficial-arch-user-repository-aur)
+  * `Вариант 7.` пользователь **Arch Linux** и хотите использовать **Community packages**, смотрите [Пользовательский репозиторий Arch (Community)](#вариант-7-пользовательский-репозиторий-arch-community)
   * `Вариант 8.` хотите улучшить свой собственный шрифт, смотрите [Улучшитель Шрифтов](#option-8-patch-your-own-font)
 
 ## Особенности
@@ -323,30 +323,10 @@ _Внимание:_ устаревшие альтернативные пути: 
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Вариант 7: Пользовательский репозиторий Arch (AUR)`
+### `Вариант 7: Пользовательский репозиторий Arch (Community)`
 
-> Вариант для **Arch Linux** и использования **AUR packages**.
-
-Следующие шрифты доступны через [AUR packages](https://aur.archlinux.org/) на Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Вариант 8: Улучшить Свой Шрифт`
 

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -39,7 +39,7 @@
 - [**4 - Homebrew Fonts (macOS (OS X))**](#選項4-homebrew-字體)
 - [**5 - 複製 Repo**](#選項5-複製-repo)
 - [**6 - Ad Hoc Curl 下載**](#選項6-ad-hoc-curl-下載)
-- [**7 - Arch User Repository (AUR) (Arch Linux)**](#選項7-非官方-arch-user-repository-aur)
+- [**7 - Arch Community Repository (Arch Linux)**](#選項7-非官方-arch-community-repository)
 - [**8 - 打包你的個人字體**](#選項8-打包你的個人字體)
 
 [**特徵**](#特徵)
@@ -80,7 +80,7 @@ _如果你..._
 - `選項 4.` 是**macOS**的使用者，並且想要使用**Homebrew**，請見 [Homebrew Fonts](#選項4-homebrew-字體)
 - `選項 5.` 想要 **完全控制**，請見 [複製這個 repo](#選項5-複製-repo)
 - `選項 6.` 想要使用 **`curl` command** 或者使用 **scripts**，請見 [Ad Hoc Curl 下載](#選項6-ad-hoc-curl-下載)
-- `選項 7.` 是**Arch Linux**的使用者，並且想要使用**AUR packages**，請見 [Unofficial Arch User Repositories](#選項7-非官方-arch-user-repository-aur)
+- `選項 7.` 是**Arch Linux**的使用者，並且想要使用**Community packages**，請見 [Arch Community Repositories](#選項7-非官方-arch-community-repository)
 - `選項 8.` 想要打包你自訂的字體，請見 [字體包](#選項8-打包你的個人字體)
 
 - [FontForge Python script](#font-patcher) 可以打包任何字體
@@ -294,28 +294,10 @@ _註:_ deprecated alternative paths: `~/.fonts`
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `選項7: 非官方 Arch User Repository (AUR)`
+### `選項7: 非官方 Arch Community Repository`
 
-> 適用於 **Arch Linux** 下使用 **AUR packages**的情況
-
-下列字體可以在 Arch Linux 透過 [AUR packages](https://aur.archlinux.org/) 下載：
-
-- [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-- [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-- [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-- [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-- [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-- [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-- [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-- [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-- [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-- [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-- [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-- [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-- [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-- [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-- [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 列表尚未完成，但你可以[在這邊找到完整的列表](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off)。
 

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -39,7 +39,7 @@
 -   [**4 - Нативні шрифти (macOS (OS X))**](#option-4-homebrew-fonts)
 -   [**5 - Клонування репозиторію**](#option-5-clone-the-repo)
 -   [**6 - Конкретний випадок завантаження за допомогою Curl**](#option-6-ad-hoc-curl-download)
--   [**7 - Репозиторій користувачів Arch (AUR) (Arch Linux)**](#option-7-unofficial-arch-user-repository-aur)
+-   [**7 - Репозиторій користувачів Arch (Community) (Arch Linux)**](#варіант-7-неофіційні-репозиторії-користувачів-arch-community`)
 -   [**8 - Налаштуйте свій власний шрифт**](#option-8-patch-your-own-font)
 
 [**Особливості**](#features)
@@ -80,7 +80,7 @@ _Якщо ви..._
 -   `Варіант 4.` Я на **macOS** та бажаю використовувати **нативні шрифти**, дивись [Нативні Шрифти](#option-4-homebrew-fonts)
 -   `Варіант 5.` бажаю **повний контроль**, дивись [клонування репозиторії](#option-5-clone-the-repo)
 -   `Варіант 6.` бажаю використовувати **`curl` команду** або використовувати в **скриптах** дивись [Конкретний випадок завантаження за допомогою Curl](#option-6-ad-hoc-curl-download)
--   `Варіант 7.` Я на **Arch Linux** та бажаю використовувати **AUR packages**, дивись [Неофіційні репозиторії користувачів Arch](#option-7-unofficial-arch-user-repository-aur)
+-   `Варіант 7.` Я на **Arch Linux** та бажаю використовувати **Community packages**, дивись [Неофіційні репозиторії користувачів Arch](#варіант-7-неофіційні-репозиторії-користувачів-arch-community`)
 -   `Варіант 8.` Бажаю пропатчити власний шрифт, дивись [Патчер шрифтів](#option-8-patch-your-own-font)
 
 ## Особливості
@@ -269,30 +269,10 @@ _Примітка:_ застарілі альтернативні шляхи: `~
 cd ~/Library/Fonts && curl -fLo "Droid Sans Mono for Powerline Nerd Font Complete.otf" https://github.com/ryanoasis/nerd-fonts/raw/HEAD/patched-fonts/DroidSansMono/complete/Droid%20Sans%20Mono%20Nerd%20Font%20Complete.otf
 ```
 
-### `Варіант 7: Неофіційні репозиторії користувачів Arch (AUR)`
+### `Варіант 7: Неофіційні репозиторії користувачів Arch (Community)`
 
-> Варіант для **Arch Linux** і бажання використовувати **AUR пакети**.
-
-Наступні шрифти доступні через [AUR пакети](https://aur.archlinux.org/) на Arch Linux:
-
-* [Nerd Fonts Complete Release (double-width)](https://aur.archlinux.org/packages/nerd-fonts-complete/)
-* [Nerd Fonts Complete Release (single-width) (out of date)](https://aur.archlinux.org/packages/nerd-fonts-complete-mono-glyphs/)
-* [Nerd Fonts Complete Git (has always the newest fixes)](https://aur.archlinux.org/packages/nerd-fonts-git/)
-
-* [Nerd Fonts Anonymous Pro](https://aur.archlinux.org/packages/nerd-fonts-anonymous-pro/)
-* [Nerd Fonts DejaVu Complete](https://aur.archlinux.org/packages/nerd-fonts-dejavu-complete/)
-* [Nerd Fonts Fira Code](https://aur.archlinux.org/packages/nerd-fonts-fira-code/)
-* [Nerd Fonts Go Mono](https://aur.archlinux.org/packages/nerd-fonts-go-mono/)
-* [Nerd Fonts Hack](https://archlinux.org/packages/community/any/ttf-hack-nerd/)
-* [Nerd Fonts Inconsolata](https://aur.archlinux.org/packages/nerd-fonts-inconsolata/)
-* [Nerd Fonts Jetbrains Mono](https://aur.archlinux.org/packages/nerd-fonts-jetbrains-mono)
-* [Nerd Fonts Liberation Mono](https://aur.archlinux.org/packages/nerd-fonts-liberation-mono/)
-* [Nerd Fonts Noto](https://aur.archlinux.org/packages/nerd-fonts-noto/)
-* [Nerd Fonts Source Code Pro Complete](https://aur.archlinux.org/packages/nerd-fonts-source-code-pro/)
-* [Nerd Fonts Terminus](https://aur.archlinux.org/packages/nerd-fonts-terminus/)
-* [Nerd Fonts Victor Mono](https://aur.archlinux.org/packages/nerd-fonts-victor-mono)
-
-The list is not complete, but you can [search for a complete list here](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
+Most fonts are available via [Arch Community packages](https://archlinux.org/packages/?sort=&repo=Community&q=-nerd).
+Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fonts-&outdated=off).
 
 ### `Варіант 8: Налаштуйте свій власний шрифт`
 


### PR DESCRIPTION
**[why]**
All/most fonts are now available as Arch Community packages and not as AUR anymore.

**[how]**
Instead of listing all individually link to search page. Make sure the Symbols Only font in Community is also found.

Fixes: #1057

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
