### PR TITLE
install.sh: Fix installing more than 2 fonts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,11 @@ implode() {
     # $3... are the elements to join
     local retname=$1 sep=$2 ret=$3
     shift 3 || shift $(($#))
-    printf -v "$retname" "%s" "$ret${*/#/$sep}"
+    while [ $# -gt 0 ]; do
+        ret=$ret$sep$1
+        shift
+    done
+    printf -v "$retname" "%s" "$ret"
 }
 find_include=
 find_exclude=


### PR DESCRIPTION
**[why]**
The implode function can not work correctly because the bash pattern expansion inserts blanks in unexpected places.

**[how]**
Use a dump loop instead of being smart.

Fixes: #280

Reported-by: Geoffrey Biggs <gbiggs>
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
