### PR TITLE
Fix font previews

### DIFF
--- a/bin/scripts/generate-font-image-previews.sh
+++ b/bin/scripts/generate-font-image-previews.sh
@@ -56,4 +56,72 @@ generate_preview_symbols() {
   # svgo "${output_dir}${font}.svg"
 }
 
+image_font_files=( \
+  '3270/Regular/complete/IBM 3270 Nerd Font Complete.ttf' \
+  'Agave/complete/agave regular Nerd Font Complete.ttf' \
+  'AnonymousPro/complete/Anonymice Nerd Font Complete.ttf' \
+  'Arimo/Regular/complete/Arimo Regular Nerd Font Complete.ttf' \
+  'AurulentSansMono/complete/AurulentSansMono-Regular Nerd Font Complete.otf' \
+  'BigBlueTerminal/complete/BigBlue TerminalPlus Nerd Font Complete.TTF' \
+  'BitstreamVeraSansMono/Regular/complete/Bitstream Vera Sans Mono Nerd Font Complete.ttf' \
+  'CascadiaCode/Regular/complete/Caskaydia Cove Nerd Font Complete Regular.otf' \
+  'CodeNewRoman/Regular/complete/Code New Roman Nerd Font Complete.otf' \
+  'Cousine/Regular/complete/Cousine Regular Nerd Font Complete.ttf' \
+  'DaddyTimeMono/complete/DaddyTimeMono Nerd Font Complete.ttf' \
+  'DejaVuSansMono/Regular/complete/DejaVu Sans Mono Nerd Font Complete.ttf' \
+  'DroidSansMono/complete/Droid Sans Mono Nerd Font Complete.otf' \
+  'FantasqueSansMono/Regular/complete/Fantasque Sans Mono Regular Nerd Font Complete.ttf' \
+  'FiraCode/Regular/complete/Fira Code Regular Nerd Font Complete.ttf' \
+  'FiraMono/Regular/complete/Fura Mono Regular Nerd Font Complete.otf' \
+  'Gohu/uni-14/complete/GohuFont Nerd Font Complete.ttf' \
+  'Go-Mono/Regular/complete/Go Mono Nerd Font Complete.ttf' \
+  'Hack/Regular/complete/Hack Regular Nerd Font Complete.ttf' \
+  'Hasklig/Regular/complete/Hasklug Nerd Font Complete.otf' \
+  'HeavyData/complete/Heavy Data Nerd Font Complete.ttf' \
+  'Hermit/Medium/complete/Hurmit Medium Nerd Font Complete.otf' \
+  'iA-Writer/iA Writer Mono/Regular/complete/iM Writing Mono S Regular Nerd Font Complete.ttf' \
+  'IBMPlexMono/Mono/complete/Blex Mono Nerd Font Complete.ttf' \
+  'Inconsolata/complete/Inconsolata Regular Nerd Font Complete.ttf' \
+  'InconsolataGo/Regular/complete/InconsolataGo Nerd Font Complete.ttf' \
+  'InconsolataLGC/Regular/complete/Inconsolata LGC Nerd Font Complete.ttf' \
+  'Iosevka/Regular/complete/Iosevka Term Nerd Font Complete.ttf' \
+  'JetBrainsMono/Ligatures/Regular/complete/JetBrains Mono Nerd Font Complete Regular.ttf' \
+  'Lekton/Regular/complete/Lekton Nerd Font Complete.ttf' \
+  'LiberationMono/complete/Literation Mono Nerd Font Complete.ttf' \
+  'Lilex/Regular/complete/Lilex Regular Nerd Font Complete.ttf' \
+  'Meslo/M/Regular/complete/Meslo LG M Regular Nerd Font Complete.ttf' \
+  'Monofur/Regular/complete/monofur Nerd Font Complete.ttf' \
+  'Monoid/Regular/complete/Monoid Regular Nerd Font Complete.ttf' \
+  'Mononoki/Regular/complete/Mononoki Nerd Font Complete Regular.ttf' \
+  'MPlus/Regular/complete/M+ 1m Nerd Font Complete.ttf' \
+  'NerdFontsSymbolsOnly/complete/Symbols-2048-em Nerd Font Complete Mono.ttf' \
+  'Noto/Sans-Mono/complete/Noto Sans Mono Regular Nerd Font Complete.ttf' \
+  'OpenDyslexic/Regular/complete/OpenDyslexic Regular Nerd Font Complete.otf' \
+  'Overpass/Mono/Regular/complete/Overpass Mono Regular Nerd Font Complete.otf' \
+  'ProFont/profontiix/complete/ProFont IIx Nerd Font Complete.ttf' \
+  'ProggyClean/Regular/complete/ProggyCleanTT Nerd Font Complete.ttf' \
+  'RobotoMono/Regular/complete/Roboto Mono Nerd Font Complete.ttf' \
+  'ShareTechMono/complete/Shure Tech Mono Nerd Font Complete.ttf' \
+  'SourceCodePro/Regular/complete/Sauce Code Pro Nerd Font Complete.ttf' \
+  'SpaceMono/Regular/complete/Space Mono Nerd Font Complete.ttf' \
+  'Terminus/terminus-ttf-4.40.1/Regular/complete/Terminess (TTF) Nerd Font Complete.ttf' \
+  'Tinos/Regular/complete/Tinos Nerd Font Complete.ttf' \
+  'Ubuntu/Regular/complete/Ubuntu Nerd Font Complete.ttf' \
+  'UbuntuMono/Regular/complete/Ubuntu Mono Nerd Font Complete.ttf' \
+  'VictorMono/Regular/complete/Victor Mono Regular Nerd Font Complete.ttf' \
+)
+
+# Enable this to get a list of instruction to install all the needed fonts
+#
+# for f in "${image_font_files[@]}"; do
+#   echo "cp '../../patched-fonts/$f' ~/.local/share/fonts"
+# done
+# exit
+
+# Enable this to get a list of Family names
+#
+# for f in "${image_font_files[@]}"; do
+#   fc-query "../../patched-fonts/$f" '-f %{family}\n'
+# done
+
 main "$@"; exit

--- a/bin/scripts/lib/fonts.json
+++ b/bin/scripts/lib/fonts.json
@@ -55,7 +55,7 @@
       "RFN": false,
       "patchedName": "BigBlueTerminal",
       "folderName": "BigBlueTerminal",
-      "imagePreviewFont": "BigBlueTerminal Nerd Font",
+      "imagePreviewFont": "BigBlue_TerminalPlus Nerd Font",
       "linkPreviewFont": false,
       "caskName": "bigblue-terminal",
       "description": "Nostalgic, closely based on IBM's 8x14 EGA/VGA charset"
@@ -165,7 +165,7 @@
       "RFN": false,
       "patchedName": "FiraMono",
       "folderName": "FiraMono",
-      "imagePreviewFont": "FiraMono Nerd Font",
+      "imagePreviewFont": "FuraMono Nerd Font",
       "linkPreviewFont": "fira",
       "caskName": "fira-mono",
       "description": "Mozilla typeface, dotted zero"
@@ -175,7 +175,7 @@
       "RFN": false,
       "patchedName": "Go-Mono",
       "folderName": "Go-Mono",
-      "imagePreviewFont": "Go-Mono Nerd Font",
+      "imagePreviewFont": "GoMono Nerd Font",
       "linkPreviewFont": "go-mono",
       "caskName": "go-mono",
       "description": "Created specifically for the Go project, looks particularly clear for use with the Go language"
@@ -185,7 +185,7 @@
       "RFN": false,
       "patchedName": "Gohu",
       "folderName": "Gohu",
-      "imagePreviewFont": "Gohu Nerd Font",
+      "imagePreviewFont": "GohuFont Nerd Font",
       "linkPreviewFont": false,
       "caskName": "gohufont",
       "description": "Bitmap font, tall capitals and ascenders, small serifs"
@@ -235,7 +235,7 @@
       "RFN": true,
       "patchedName": "iM Writing",
       "folderName": "iA-Writer",
-      "imagePreviewFont": "iM Writing Nerd Font",
+      "imagePreviewFont": "iMWritingMonoS Nerd Font",
       "linkPreviewFont": "ia-writer-mono",
       "caskName": "im-writing",
       "description": "A heavy modification of IBM's Plex font"
@@ -275,7 +275,7 @@
       "RFN": false,
       "patchedName": "Iosevka",
       "folderName": "Iosevka",
-      "imagePreviewFont": "Iosevka Nerd Font",
+      "imagePreviewFont": "IosevkaTerm Nerd Font",
       "linkPreviewFont": "iosevka",
       "caskName": "iosevka",
       "description": "Narrow and horizontally tight characters, slashed zero"
@@ -325,7 +325,7 @@
       "RFN": false,
       "patchedName": "MesloLG",
       "folderName": "Meslo",
-      "imagePreviewFont": "Meslo Nerd Font",
+      "imagePreviewFont": "MesloLGM Nerd Font",
       "linkPreviewFont": "meslo",
       "caskName": "meslo-lg",
       "description": "Slashed zeros, customized version of Apple's Menlo"
@@ -365,7 +365,7 @@
       "RFN": false,
       "patchedName": "MPlus",
       "folderName": "MPlus",
-      "imagePreviewFont": "MPlus Nerd Font",
+      "imagePreviewFont": "M+ 1m",
       "linkPreviewFont": false,
       "caskName": "mplus",
       "description": "Multiple styles and weights, many glyph sets (e.g. Kana glyphs)"
@@ -375,7 +375,7 @@
       "RFN": false,
       "patchedName": "Noto",
       "folderName": "Noto",
-      "imagePreviewFont": "Noto Nerd Font",
+      "imagePreviewFont": "NotoSansMono Nerd Font",
       "linkPreviewFont": "noto",
       "caskName": "noto",
       "description": "`0` and `O` very similar, characters are either very curvy or straight lined"
@@ -385,7 +385,7 @@
       "RFN": false,
       "patchedName": "ProFont",
       "folderName": "ProFont",
-      "imagePreviewFont": "ProFont Nerd Font",
+      "imagePreviewFont": "ProFontIIx Nerd Font",
       "linkPreviewFont": "profont",
       "caskName": "profont",
       "description": "Looks best with anti-aliasing turned off, squared off character corners, vertically tight small `s`"
@@ -395,7 +395,7 @@
       "RFN": false,
       "patchedName": "ProggyClean",
       "folderName": "ProggyClean",
-      "imagePreviewFont": "ProggyClean Nerd Font",
+      "imagePreviewFont": "ProggyCleanTT Nerd Font",
       "linkPreviewFont": "proggy-clean",
       "caskName": "proggy-clean-tt",
       "description": "Designed particularly for use at small point sizes"
@@ -415,7 +415,7 @@
       "RFN": false,
       "patchedName": "Overpass",
       "folderName": "Overpass",
-      "imagePreviewFont": "Overpass Nerd Font",
+      "imagePreviewFont": "OverpassMono Nerd Font",
       "linkPreviewFont": "overpass",
       "caskName": "overpass",
       "description": "An open source font family inspired by Highway Gothic"


### PR DESCRIPTION
**[why]**
Some font previews in the `gh-pages` are obviously wrong (showing some fallback font).

[how]
Recreate all image previes from current `master` branch.

To make this more easy:
- Add commented out code that displays command to install just the needed fonts but all the needed fonts
- Add commented out code that displays the family names of the needed fonts - these have to be in sync with the `fonts.json` database

Fixes: #489

Reported-by: CosmosAtlas
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Change the preview generator script to enable its users easier preview generation.
The code is commented out (for laziness reasons). If you need instructions how to install the needed fonts _on my machine_ ;-) or how their family names are, uncomment that code.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
