### PR TITLE
Mark old MDI as obsolete on cheat sheet

### DIFF
--- a/bin/scripts/generate-css.sh
+++ b/bin/scripts/generate-css.sh
@@ -83,6 +83,9 @@ for var in "${!i@}"; do
   {
     printf "  <div class=\"column\">"
     printf "\\n"
+    if [[ "$glyph_name" = mdi-* ]]; then
+      printf "    <span class=\"corner-red\"></span><span class=\"corner-text\">obsolete</span>\\n"
+    fi
     printf "    <div class=\"nf nf-%s center\"></div>" "$glyph_name"
     printf "\\n"
     printf "    <div class=\"class-name\">nf-%s</div><div title=\"Copy Hex Code to Clipboard\" class=\"codepoint\">%s</div>" "$glyph_name" "$glyph_code"


### PR DESCRIPTION
**[why]**
The (old) Material Design Icons are to be removed. We should communicate that on the Cheat Sheet.

**[how]**
See commit
  4452ceee5  `Add possibility to add "obsolete" to glyphs`

that implements the CSS stuff to display an 'obsolete' marker.

Change the cheat-sheet generatot to actually insert the markers for the appropriate codepoints. That is, the codepoints are not checked but the ID.

Fixes: #1096

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

Before:

![image](https://user-images.githubusercontent.com/16012374/216005844-67df852d-70d1-4ba3-878d-348b431804cc.png)

After:

![image](https://user-images.githubusercontent.com/16012374/216047377-28192822-070b-4fbc-97a4-ba58cb89c45d.png)
