### PR TITLE
Fix weather icon scale and shift

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.9"
+script_version = "3.5.10"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -1302,14 +1302,13 @@ class font_patcher:
                     x_align_distance += self.font_dim['width'] - sym_dim['width']
                     if not self.args.single and '2' in sym_attr['stretch']:
                         x_align_distance += self.font_dim['width']
+                # If symbol glyph is wider than target font cell, just left-align
+                x_align_distance = max(-sym_dim['xmin'], x_align_distance)
 
             if overlap:
                 overlap_width = self.font_dim['width'] * overlap
                 if sym_attr['align'] == 'l':
                     x_align_distance -= overlap_width
-                if sym_attr['align'] == 'r' and not self.args.nonmono:
-                    # Nonmono is 'left aligned' per definition, translation does not help here
-                    x_align_distance += overlap_width
 
             align_matrix = psMat.translate(x_align_distance, y_align_distance)
             self.sourceFont[currentSourceFontGlyph].transform(align_matrix)

--- a/font-patcher
+++ b/font-patcher
@@ -899,11 +899,22 @@ class font_patcher:
                 0xf0ca, # dash
             ]}
         WEATH_SCALE_LIST = {'ScaleGroups': [
+            [0xf03c, 0xf042, 0xf045 ], # degree signs
+            [0xf043, 0xf044, 0xf048, 0xf04b, 0xf04c, 0xf04d, 0xf057, 0xf058, 0xf087, 0xf088], # arrows
+            range(0xf053, 0xf055 + 1), # thermometers
+            [*range(0xf059, 0xf061 + 1), 0xf0b1], # wind directions
+            range(0xf089, 0xf094 + 1), # clocks
             range(0xf095, 0xf0b0 + 1), # moon phases
             range(0xf0b7, 0xf0c3 + 1), # wind strengths
-            range(0xf053, 0xf055 + 1), # thermometer
-            [0xf06e, 0xf070 ], # solar eclipse
-            [0xf042, 0xf045 ], # degree sign
+            [0xf06e, 0xf070 ], # solar/lunar eclipse
+            # Note: Codepoints listed before that are also in the following range
+            # will take the scaling of the previous group (the ScaleGroups are
+            # searched through in definition order).
+            # But be careful, the combined bounding box for the following group
+            # _will_ include all glyphs in its definition: Make sure the exempt
+            # glyphs from above are smaller (do not extend) the combined bounding
+            # box of this range:
+            range(0xf000, 0xf0cb + 1), # lots of clouds and other (Please read note above!)
         ]}
         MDI_SCALE_LIST = {'ScaleGlyph': 0xf068d, # 'solid' fills complete design space
             'GlyphsToScale+': [


### PR DESCRIPTION
#### Description

The clouds in the weather icons are all scaled individually.
This makes it hard to exchange one for the other when the weather changes.

Also a problem are the moon phases, all the increasing phases are shifted a bit to the left?!

This PR fixes both issues with one commit each.

Fixes: #1107

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
