### PR TITLE
font-patcher: Make sure nf-custom-asm and nf-custom-v_lang icons are included

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.5"
+script_version = "3.5.6"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -908,7 +908,7 @@ class font_patcher:
         # Define the character ranges
         # Symbol font ranges
         self.patch_set = [
-            {'Enabled': True,                           'Name': "Seti-UI + Custom",        'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5AA, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
+            {'Enabled': True,                           'Name': "Seti-UI + Custom",        'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5AC, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': True,                           'Name': "Heavy Angle Brackets",    'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x0000, 'SymEnd': 0x0000, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_HEAVYBRACKETS},
             {'Enabled': True,                           'Name': "Devicons",                'Filename': "devicons.ttf",                                   'Exact': False, 'SymStart': 0xE600, 'SymEnd': 0xE6C5, 'SrcStart': 0xE700, 'ScaleRules': DEVI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.powerline,            'Name': "Powerline Symbols",       'Filename': "powerline-symbols/PowerlineSymbols.otf",         'Exact': True,  'SymStart': 0xE0A0, 'SymEnd': 0xE0A2, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_POWERLINE},


### PR DESCRIPTION
#### Description

The `nf-custom-asm` and `nf-custom-v_lang` icons are present in the [css file](https://github.com/ryanoasis/nerd-fonts/blob/master/css/nerd-fonts-generated.css) and [database script](https://github.com/ryanoasis/nerd-fonts/blob/master/bin/scripts/lib/i_seti.sh), but not in any patched fonts. Also, in the [cheat sheet](https://www.nerdfonts.com/cheat-sheet) they are displayed as blank rectangles since glyphs are not available (see below).

This PR fixes the `font-patcher` script to include these glyphs in font.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### Screenshots (if appropriate or helpful)

<img src="https://user-images.githubusercontent.com/90523111/218310567-aabfe0f6-e3e7-4d76-9dce-5c851f9612d3.png" alt="cheatsheet" width="40%" />