### PR TITLE
Drop support for Python 2

### DIFF
--- a/readme_cn.md
+++ b/readme_cn.md
@@ -347,7 +347,7 @@ Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fon
 </h2>
 
 可以通过[VimDevIcons ➶][vim-devicons]打包你选中的字体:
-* 需要: Python 2 (or Python 3), python-fontforge package (version 20141231 或者更新版本，请见 [安装说明](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
+* 需要: Python 3, python-fontforge package (version 20141231 或者更新版本，请见 [安装说明](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * OSX上的替代安装方法为: `brew install fontforge`
 * 使用:
 

--- a/readme_es.md
+++ b/readme_es.md
@@ -294,7 +294,7 @@ Ve a: [Parchador de fuentes](#font-patcher) para ver como usarlo.
 </h2>
 
 Parcha la fuente de tu preferencia para usar los [VimDevIcons ➶][vim-devicons]:
-* requiere: Python 2 (o Python 3), el paquete `python-fontforge` (version `20141231` o superior, mira
+* requiere: Python 3, el paquete `python-fontforge` (version `20141231` o superior, mira
   las [instrucciones de instalación](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * método alternativo de instalación en OSX: `brew install fontforge`
 * Uso:

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -372,7 +372,7 @@ Voir: [Font Patcher](#font-patcher) pour utilisation
 </h2>
 
 Générer la police de votre choix pour l'utiliser avec [VimDevIcons ➶][vim-devicons]:
-* Requis : Python 2 (or Python 3), `python-fontforge` package (version `20141231` ou plus récente, voir
+* Requis : Python 3, `python-fontforge` package (version `20141231` ou plus récente, voir
   les [instructions d'installation](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * Méthode alternative sur OSX : `brew install fontforge`
 * Utilisation:

--- a/readme_it.md
+++ b/readme_it.md
@@ -293,7 +293,7 @@ Leggi: [Font Patcher](#font-patcher) per come invocarlo
 </h2>
 
 Modificare il font di tua scelta per utilizzare i [VimDevIcons ➶][vim-devicons]:
-* richiede: Python 2 (o Python 3), il modulo `python-fontforge` (versione `20141231` o successiva, leggi
+* richiede: Python 3, il modulo `python-fontforge` (versione `20141231` o successiva, leggi
   le [istruzioni d’installazione](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * metodi d’installazione alternativo su OSX: `brew install fontforge`
 * Utilizzo:

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -290,7 +290,7 @@ Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fon
 </h2>
 
 [VimDevIcons ➶][vim-devicons]에서 자신이 선택한 폰트를 패치하기:
-* 요구 사항: Python 2 (또는 Python 3), `python-fontforge` 패키지 (버전 `20141231` 또는 그 이상, [설치 안내](http://designwithfontforge.com/en-US/Installing_Fontforge.html)를 참고하세요.)
+* 요구 사항: Python 3, `python-fontforge` 패키지 (버전 `20141231` 또는 그 이상, [설치 안내](http://designwithfontforge.com/en-US/Installing_Fontforge.html)를 참고하세요.)
 * OSX의 설치 방법: `brew install fontforge`
 * 사용법:
 

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -365,7 +365,7 @@ Zobacz: [Patcher fontów](#font-patcher)
 </h2>
 
 Patchowanie wybranych przez ciebie fontów z wykorzystaniem [VimDevIcons ➶][vim-devicons]:
-* wymagania: Python 2 (lub Python 3), `python-fontforge` package (wersja `20141231` lub nowsza, zobacz
+* wymagania: Python 3, `python-fontforge` package (wersja `20141231` lub nowsza, zobacz
   [instrukcje instalacji](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * alternatywan metoda instalacji na OSX: `brew install fontforge`
 * Użycie:

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -289,7 +289,7 @@ Vê: [Modificador de tipo de letra](#font-patcher) para instruções de utiliza�
 </h2>
 
 Modificar o tipo de letra à tua escolha com [VimDevIcons ➶][vim-devicons]:
-* requer: Python 2 (ou Python 3), o pacote `python-fontforge` (versão `20141231` ou mais recente, vê
+* requer: Python 3, o pacote `python-fontforge` (versão `20141231` ou mais recente, vê
   as [instruções de instalação (em inglês)](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * método alternativo para macOS: `brew install fontforge`
 * Utilização:

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -344,7 +344,7 @@ Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fon
 </h2>
 
 Исправление шрифта по собственному выбору для использования с [VimDevIcons ➶][vim-devicons]:
-* требуется: Python 2 (или Python 3), python-fontforge package (версия 20141231 или более поздние, смотрите
+* требуется: Python 3, python-fontforge package (версия 20141231 или более поздние, смотрите
   [инструкцию по установке](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 * альтернативный способ установки на macOS (OS X): `brew install fontforge`
 * Используйте:

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -318,7 +318,7 @@ Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fon
 
 可以透過 [VimDevIcons ➶][vim-devicons] 打包你選中的字體:
 
-- 需要: Python 2 (or Python 3), python-fontforge package (version 20141231 或者更新版本，請見 [安裝說明](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
+- 需要: Python 3, python-fontforge package (version 20141231 或者更新版本，請見 [安裝說明](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 - OSX 上的替代安裝方法為: `brew install fontforge`
 
 * Linux 上的替代安裝方法: 使用 [AppImage](https://github.com/fontforge/fontforge/releases)

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -291,7 +291,7 @@ Some special packages are [in AUR](https://aur.archlinux.org/packages?K=nerd-fon
 
 Виправлення шрифту за власним вибором для використання з [VimDevIcons ➶][vim-devicons]:
 
--   вимагає: Python 2 (чи Python 3), `python-fontforge` пакет (версіі `20141231` чи пізніше, дивись [інструкції по встановленню](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
+-   вимагає: Python 3, `python-fontforge` пакет (версіі `20141231` чи пізніше, дивись [інструкції по встановленню](http://designwithfontforge.com/en-US/Installing_Fontforge.html))
 -   альтернативний метод інсталювання на OSX: `brew install fontforge`
 -   Використання:
 


### PR DESCRIPTION
**[why]**
Python 2 is long since EOL.

With the last commit we want to use Enums, which are not available in Python 2.

I believe Python 2 broke some time before already, I stopped caring for Python 2 some time ago.

This does not change any existing code. It just documents that there are no efforts anymore to support Python 2.

This is PR #1121

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
