### PR TITLE
 Reform PowerlineExtra sizing

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.8"
+script_version = "3.5.9"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -734,6 +734,9 @@ class font_patcher:
         """ Creates list of dicts to with instructions on copying glyphs from each symbol font into self.sourceFont """
         # Supported params: overlap | careful
         # Overlap value is used horizontally but vertically limited to 0.01
+        # The xy-ratio limits the x-scale for a given y-scale to make the ratio <= this value (to prevent over-wide glyphs)
+        # '1' means occupu 1 cell (default for 'xy')
+        # '2' means occupy 2 cells (default for 'pa')
         # Powerline dividers
         SYM_ATTR_POWERLINE = {
             'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
@@ -751,16 +754,16 @@ class font_patcher:
             0xe0b7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'xy-ratio': 0.5}},
 
             # Bottom Triangles
-            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
-            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
-            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
+            0xe0b8: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0b9: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0ba: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bb: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Top Triangles
-            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
-            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
-            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02}},
-            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
+            0xe0bc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0be: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0bf: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
 
             # Flames
             0xe0c0: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
@@ -769,25 +772,26 @@ class font_patcher:
             0xe0c3: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {}},
 
             # Small squares
-            0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0c5: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0c4: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': -0.03, 'xy-ratio': 0.86}},
+            0xe0c5: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': -0.03, 'xy-ratio': 0.86}},
 
             # Bigger squares
-            0xe0c6: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0c7: {'align': 'r', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0c6: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': -0.03, 'xy-ratio': 0.78}},
+            0xe0c7: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': -0.03, 'xy-ratio': 0.78}},
 
             # Waveform
             0xe0c8: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
             0xe0ca: {'align': 'r', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.01}},
 
             # Hexagons
-            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
-            0xe0cd: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
+            0xe0cc: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'overlap': 0.02, 'xy-ratio': 0.85}},
+            0xe0cd: {'align': 'l', 'valign': 'c', 'stretch': 'xy2', 'params': {'xy-ratio': 0.865}},
 
             # Legos
-            0xe0ce: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0cf: {'align': 'c', 'valign': 'c', 'stretch': 'xy', 'params': {}},
-            0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02}},
+            0xe0ce: {'align': 'l', 'valign': 'c', 'stretch': 'pa', 'params': {}},
+            0xe0cf: {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}},
+            0xe0d0: {'align': 'l', 'valign': 'c', 'stretch': 'pa', 'params': {}},
+            0xe0d1: {'align': 'l', 'valign': 'c', 'stretch': 'pa', 'params': {}},
 
             # Top and bottom trapezoid
             0xe0d2: {'align': 'l', 'valign': 'c', 'stretch': 'xy', 'params': {'overlap': 0.02, 'xy-ratio': 0.7}},
@@ -1095,7 +1099,7 @@ class font_patcher:
 
         # For monospaced fonts all chars need to be maximum 'one' space wide
         # other fonts allows double width glyphs for 'pa' or if requested with '2'
-        if self.args.single or (stretch != 'pa' and '2' not in stretch):
+        if self.args.single or ('pa' not in stretch and '2' not in stretch) or '1' in stretch:
             relative_width = 1.0
         else:
             relative_width = 2.0
@@ -1107,7 +1111,7 @@ class font_patcher:
         target_height = self.font_dim['height']
         scale_ratio_y = target_height / sym_dim['height']
 
-        if stretch == 'pa':
+        if 'pa' in stretch:
             # We want to preserve x/y aspect ratio, so find biggest scale factor that allows symbol to fit
             scale_ratio_x = min(scale_ratio_x, scale_ratio_y)
             if not self.args.single:

--- a/font-patcher
+++ b/font-patcher
@@ -1039,6 +1039,7 @@ class font_patcher:
                 'width' : self.sourceFont.em,
                 'height': self.sourceFont.descent + self.sourceFont.ascent,
             }
+            our_btb = self.sourceFont.descent + self.sourceFont.ascent
         elif self.font_dim['height'] < 0:
             sys.exit("{}: Can not detect sane font height".format(projectName))
 


### PR DESCRIPTION
#### Description

**[why]**
The Powerline extra glyph sizing is not really clear.
    
**[how]**

* Make the triangulars 1 cell wide, as for example Iosevka also does.
* Make the Legos 2 cell wide with pa scaling to make them look nicer.
* Make the Hexagons 2 cells wide and keep their aspect ratio if possible.
* Make small and big Squares also 2 cell wide and keep their aspect ratio
of possible.
    
For the small and big Squares add a tiny bit of border (negative
overlap), because they have no smooth border line over their open and
closed squares, and that might look strange if some touch and some dont.
    
Fixes: #1106

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

Will follow