### PR TITLE
Allow auto original source growth

### DIFF
--- a/bin/scripts/generate-original-source.py
+++ b/bin/scripts/generate-original-source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Nerd Fonts Version: 2.3.3
-# Script Version: 1.0.0
+# Script Version: 1.0.1
 # Generates original-source.otf from individual glyphs
 #
 # Idea & original code taken from
@@ -14,7 +14,8 @@ import psMat
 # Double-quotes required here, for version-bump.sh:
 version = "2.3.3"
 
-start_codepoint = 0xE4FA
+start_codepoint = 0xE4FA # with shift this is 0xE5FA
+end_codepoint = 0xE5FF # Next set starts at 0xE700 - 0x0100 shift = 0xE600
 codepoint_shift = 0x0100 # shift introduced by font-patcher
 
 vector_datafile = 'icons.tsv'
@@ -28,7 +29,7 @@ def hasGaps(data, start_codepoint):
     """ Takes a list of integers and checks that it contains no gaps """
     for i in range(min(data) + 1, max(data)):
         if not i in data:
-            print("Gap at offset {}".format(i - start_codepoint))
+            print('Gap at offset {}'.format(i - start_codepoint))
             return True
     return False
 
@@ -157,6 +158,9 @@ icon_datasets, _, num_aliases = readIconFile(os.path.join(vectorsdir, vector_dat
 gaps = ' (with gaps)' if hasGaps(icon_datasets.keys(), start_codepoint) else ''
 
 for codepoint, data in icon_datasets.items():
+    if codepoint not in range(start_codepoint, end_codepoint + 1):
+        print('FATAL: We are leaving the allocated codepoint range with "{}", bailing out'.format(data[0][0]))
+        exit(1)
     addIcon(codepoint, data[0][0], data[1])
 num_icons = len(icon_datasets)
 

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.7"
+script_version = "3.5.8"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -909,7 +909,7 @@ class font_patcher:
         # Define the character ranges
         # Symbol font ranges
         self.patch_set = [
-            {'Enabled': True,                           'Name': "Seti-UI + Custom",        'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5AC, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
+            {'Enabled': True,                           'Name': "Seti-UI + Custom",        'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5FF, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': True,                           'Name': "Heavy Angle Brackets",    'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x0000, 'SymEnd': 0x0000, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_HEAVYBRACKETS},
             {'Enabled': True,                           'Name': "Devicons",                'Filename': "devicons.ttf",                                   'Exact': False, 'SymStart': 0xE600, 'SymEnd': 0xE6C5, 'SrcStart': 0xE700, 'ScaleRules': DEVI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.powerline,            'Name': "Powerline Symbols",       'Filename': "powerline-symbols/PowerlineSymbols.otf",         'Exact': True,  'SymStart': 0xE0A0, 'SymEnd': 0xE0A2, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_POWERLINE},

--- a/font-patcher
+++ b/font-patcher
@@ -1127,7 +1127,6 @@ class font_patcher:
         """ Copies symbol glyphs into self.sourceFont """
         progressText = ''
         careful = False
-        glyphSetLength = 0
         sourceFontCounter = 0
 
         if self.args.careful:
@@ -1148,14 +1147,12 @@ class font_patcher:
         glyphSetLength = len(symbolFontSelection)
 
         if not self.args.quiet:
-            sys.stdout.write("Adding " + str(max(1, glyphSetLength)) + " Glyphs from " + setName + " Set \n")
+            sys.stdout.write("Adding {} Glyphs from {} Set\n".format(glyphSetLength, setName))
 
         currentSourceFontGlyph = -1 # initialize for the exactEncoding case
         width_warning = False
 
         for index, sym_glyph in enumerate(symbolFontSelection):
-            index = max(1, index)
-
             sym_attr = attributes.get(sym_glyph.unicode)
             if sym_attr is None:
                 sym_attr = attributes['default']


### PR DESCRIPTION
#### Description

Allow for growing original icon set    
    
**[why]**
We have an automation for adding glyphs to the original set.    
If someone throws in the svg file and adds the glyph to the icons.tsv a    
new original-source font is generated.    
    
But the added glyphs are not patched in, because that would need a    
change at font-patcher (adjust the end codepoint).    
    
This can be forgotten easily.    
    
**[how]**
The maximum codepoint of our own (original + seti) set is 0xE6FF. At    
0xE700 the Devicons start.    
    
The original-source generation script now checks the offset, they may    
not be negative and on the positive end we may not leave our set-range.    
If that happens the script fails thus the workflow fails.    
    
Also increate the patch range in font-patcher. If there are no icons to    
patch in the symbol font the codepoints are just ignored.    
    
**[note]**  
See also PR #1119    

This PR also smuggles in a small unrelated code cleanup commit.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
