### PR TITLE
font-patcher: Scale all Material Design Icons individually

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.10"
+script_version = "3.5.11"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -919,10 +919,7 @@ class font_patcher:
             # box of this range:
             range(0xf000, 0xf0cb + 1), # lots of clouds and other (Please read note above!)
         ]}
-        MDI_SCALE_LIST = {'ScaleGlyph': 0xf068d, # 'solid' fills complete design space
-            'GlyphsToScale+': [
-                (0xf0000, 0xfffff) # all because they are very well scaled already
-        ]}
+        MDI_SCALE_LIST = None # Maybe later add some selected ScaleGroups
 
         # Define the character ranges
         # Symbol font ranges


### PR DESCRIPTION
**[why]**
The Material Design Icons have for sure pairs of glyphs that people would like to have scaled identically. Because the sheer number of glyphs and because they are already very nicely and uniformly scaled within their design space the MDI at the new codepoints where all scaled the same with taking the theoretical design space as ScaleGlyph.

But that means all icons get scaled a bit smaller than before, where we individually scaled each Material Design Icon to fill the cell. This lead to numerous complaints.

**[how]**
We take a different approach now, more conventional maybe. Especially in the light that the older bigger icons will get dropped; and people love them.
So the uniform scaling is ditched and the individual scaling is used.

Fixes: #1061

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

https://github.com/greshake/i3status-rust/pull/1728

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
