### PR TITLE
font-patcher: Fix crash with older fontforge

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "3.5.11"
+script_version = "3.5.12"
 
 version = "2.3.3"
 projectName = "Nerd Fonts"
@@ -983,9 +983,10 @@ class font_patcher:
                     self.add_glyphrefs_to_essential(altcode)
         # From fontforge documentation:
         # glyph.references return a tuple of tuples containing, for each reference in foreground,
-        # a glyph name, a transformation matrix, and whether the reference is currently selected.
+        # a glyph name, a transformation matrix, and (depending on ff version) whether the
+        # reference is currently selected.
         references = self.sourceFont[unicode].references
-        for refcode in [ self.sourceFont[n].unicode for n, m, s in references ]:
+        for refcode in [ self.sourceFont[n].unicode for n, *_ in references ]: # tuple of 2 or 3 depending on ff version
             if refcode not in self.essential and refcode >= 0:
                 self.add_glyphrefs_to_essential(refcode)
 


### PR DESCRIPTION
[why]
If a font has references in glyphs that we want to add to the essential set of glyphs, and fontforge is old (i.e. 2020*) the patcher crashes.

[how]
The fontforge function glyph.references returns a three element tuple in current fontforge (i.e. 20230101). But older versions skip the selection bit and return only tuples of two.

As we use only the first tuple element we do not care about the 2nd and possible 3rd element(s) and just thrash them.

Fixes: #1142

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Fix running `font-patcher` on older `fontforge`

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
