### PR TITLE
Fix codepoint copy

### DIFF
--- a/site.js
+++ b/site.js
@@ -338,7 +338,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       }
     } else if (parent.className.startsWith('column') && target.className === 'codepoint') {
-        textToCopy = parent.parentNode.querySelector('.codepoint').innerText;
+        textToCopy = target.innerText;
     }
     if (textToCopy.length > 0) {
       gtag('event', event.target.className, {


### PR DESCRIPTION
#### Description

This pull request fixes copying codepoints on the cheatsheet. It looks like the previous version of the code was one node off in terms of how many parents it traversed which resulted in the first codepoint always being copied, instead of the one that the user clicked on.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Fixes copying of the codepoint from the bottom right corner of the character box on the cheat sheet page of the website.

#### How should this be manually tested?

Start the website with `jekyll s` and verify that copying codepoints on the cheatsheet now works, whereas it did not before these changes.

---

I assume I'm just supposed to make this change directly to the gh-pages branch, but if that's not right, lmk what branch I should be targetting instead.
