### PR TITLE
font-patcher: Fix patching non-monospaced fonts

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -774,19 +774,20 @@ class font_patcher:
         """ Creates list of dicts to with instructions on copying glyphs from each symbol font into self.sourceFont """
 
         box_enabled = self.source_monospaced # Box glyph only for monospaced
+        box_keep = False
         if box_enabled:
             self.sourceFont.selection.select(("ranges",), 0x2500, 0x259f)
             box_glyphs_target = len(list(self.sourceFont.selection))
             box_glyphs_current = len(list(self.sourceFont.selection.byGlyphs))
             if box_glyphs_target > box_glyphs_current:
-                # Sourcefont does not have all of these glyphs, do not mix sets
+                # Sourcefont does not have all of these glyphs, do not mix sets (overwrite existing)
                 if not self.args.quiet and box_glyphs_current > 0:
                     print("INFO: {}/{} box drawing glyphs will be replaced".format(
                         box_glyphs_current, box_glyphs_target))
-                box_keep = False
                 box_enabled = True
             else:
-                box_keep = True # just scale do not copy
+                # Sourcefont does have all of these glyphs
+                # box_keep = True # just scale do not copy (need to scale to fit new cell size)
                 box_enabled = False # Cowardly not scaling existing glyphs, although the code would allow this
 
         # Stretch 'xz' or 'pa' (preserve aspect ratio)


### PR DESCRIPTION
[why]
Any non-monospaced font will not be be patched, the patcher crashes.

[how]
This must have happened when the box drawing characters rescaling feature has been disabled. The default value (False) is not always set.

The box drawing patch has the ability to rescale existing box glyphs. That used to be done when all box glyphs are already existing in the source font. We do not patch in a new glyph set then, but we rescale the existing glyphs to match the possibly new cell size. But that feature is disabled and the attribute 'dont-copy' is never utilized. It is disabled because some existing box sets are rather ... sspecial in their overlap and can not be scaled as we would scale them.

Fixes: #1170

Reported-by: Henrique Monteiro <hrqmonteiro@protonmail.com>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
