### PR TITLE
Rename Bitstream Vera (due to RFN)

### DIFF
--- a/.github/workflows/font-patcher.yml
+++ b/.github/workflows/font-patcher.yml
@@ -116,12 +116,12 @@ jobs:
       - name: Patcher OTF, Bold variant, and RFN compliance
         run: |
           mkdir -p $GITHUB_WORKSPACE/temp/
-          fontforge --script ./font-patcher src/unpatched-fonts/CascadiaCode/Bold/CascadiaCode-Bold.otf \
+          fontforge --script ./font-patcher src/unpatched-fonts/CascadiaCode/Bold/CascadiaCode-Bold-vtt.ttf \
           --complete --quiet --no-progressbars --outputdir $GITHUB_WORKSPACE/temp/
 
       - name: Check if patched font generated
         run: |
-          [ -e "$GITHUB_WORKSPACE/temp/CaskaydiaCoveNerdFont-Bold.otf" ] && echo "File exists" || exit 1
+          [ -e "$GITHUB_WORKSPACE/temp/CaskaydiaCoveNerdFont-Bold.ttf" ] && echo "File exists" || exit 1
 
       - name: Check if font with references is patched
         # (patch result not checked)

--- a/bin/scripts/lib/fonts.json
+++ b/bin/scripts/lib/fonts.json
@@ -62,10 +62,10 @@
     },
     {
       "unpatchedName": "Bitstream Vera Sans Mono",
-      "RFN": false,
-      "patchedName": "BitstreamVeraSansMono",
+      "RFN": true,
+      "patchedName": "BitstromWera",
       "folderName": "BitstreamVeraSansMono",
-      "imagePreviewFont": "BitstreamVeraSansMono Nerd Font",
+      "imagePreviewFont": "BitstromWera Nerd Font",
       "linkPreviewFont": "bitstream-vera",
       "caskName": "bitstream-vera-sans-mono",
       "description": "Dotted zero, compact lowercase characters"

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -192,6 +192,7 @@ class FontnameTools:
 
     SIL_TABLE = [
         ( '(a)nonymous',                r'\1nonymice' ),
+        ( '(b)itstream( ?)(v)era',      r'\1itstrom\2Wera' ),
         ( '(s)ource',                   r'\1auce' ),
         ( '(h)ermit',                   r'\1urmit' ),
         ( '(h)asklig',                  r'\1asklug' ),

--- a/font-patcher
+++ b/font-patcher
@@ -636,6 +636,10 @@ class font_patcher:
         reservedFontNameReplacements = {
             'source'         : 'sauce',
             'Source'         : 'Sauce',
+            'Bitstream Vera' : 'Bitstrom Wera',
+            'BitstreamVera'  : 'BitstromWera',
+            'bitstream vera' : 'bitstrom wera',
+            'bitstreamvera'  : 'bitstromwera',
             'hermit'         : 'hurmit',
             'Hermit'         : 'Hurmit',
             'hasklig'        : 'hasklug',

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ See [Wiki: Icon names in shell][wiki-icon-names-in-shell]
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | NO   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | NO   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | NO   | ![w] ![m2] ![l]   |
-| [Bitstream Vera Sans Mono Nerd Font][p-bitstream] | Bitstream Inc                     | 1.1   | NO   | ![w] ![m2] ![l]   |
+| [Bitstrom Wera Nerd Font][p-bitstream]            | Bitstream Inc                     | 1.1   | YES  | ![w] ![m2] ![l]   |
 | [Blex Mono][p-blex]                               | [IBM Plex Mono][f-ibm-plex]       | 2.3   | YES  | ![w] ![m2] ![l]   |
 | [Caskaydia Cove Nerd Font][p-cascadia]            | [Cascadia Code][f-cascadia]       |2111.01| YES  | ![w] ![m2] ![l]   |
 | [Code New Roman Nerd Font][p-code-nr]             | Sam Radian                        | 2.0   | NO   | ![w] ![m2] ![l]   |


### PR DESCRIPTION
[why]
The license of Bitstream Vera requires patched fonts to contain neither "Bitstream" nor "Vera" in the name. It explicitly requires that also for fonts that (only) add some glyphs.

Yes, we are rather late to notice this :-( Sorry.

[how]
Rename Bitstream Vera to BitstromWera, and also drop the Sans Mono part of the name. The new name looks and sounds similar enough to get the reference, while being shorter and somewhat logical.

Fixes: #1173

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
