### PR TITLE
Prepatched fonts: Revive some ligature removal

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.0.0
-# Script Version: 1.4.3
+# Script Version: 1.4.4
 #
 # You can supply options to the font-patcher via environment variable NERDFONTS
 # That option will override the defaults (also defaults of THIS script).
@@ -228,7 +228,6 @@ function patch_font {
   if [ -f "$config_parent_dir/config.json" ]
   then
     # load font configuration file and remove ligatures (for mono fonts):
-    # (tables have been removed from the repo with >this< commit)
     font_config="--removeligatures --configfile $config_parent_dir/config.json"
   else
     font_config=""
@@ -252,9 +251,9 @@ function patch_font {
   # Create "Nerd Font"
   if [ -n "${verbose}" ]
   then
-    echo "fontforge -quiet -script ${PWD}/font-patcher "$f" -q $powerline $post_process -c --no-progressbars --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS}"
+    echo "fontforge -quiet -script ${PWD}/font-patcher "$f" -q ${font_config} $powerline $post_process -c --no-progressbars --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS}"
   fi
-  { OUT=$(fontforge -quiet -script ${PWD}/font-patcher "$f" -q $powerline $post_process -c --no-progressbars \
+  { OUT=$(fontforge -quiet -script ${PWD}/font-patcher "$f" -q ${font_config} $powerline $post_process -c --no-progressbars \
                     --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS} 2>&1 1>&3 3>&- ); } 3>&1
   if [ $? -ne 0 ]; then printf "$OUT\nPatcher run aborted!\n\n"; fi
   # Create "Nerd Font Mono"
@@ -268,9 +267,9 @@ function patch_font {
   # Create "Nerd Font Propo"
   if [ -n "${verbose}" ]
   then
-    echo "fontforge -quiet -script ${PWD}/font-patcher "$f" -q --variable $powerline $post_process -c --no-progressbars --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS}"
+    echo "fontforge -quiet -script ${PWD}/font-patcher "$f" -q --variable ${font_config} $powerline $post_process -c --no-progressbars --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS}"
   fi
-  { OUT=$(fontforge -quiet -script ${PWD}/font-patcher "$f" -q --variable $powerline $post_process -c --no-progressbars \
+  { OUT=$(fontforge -quiet -script ${PWD}/font-patcher "$f" -q --variable ${font_config} $powerline $post_process -c --no-progressbars \
                     --outputdir "${patched_font_dir}" $config_patch_flags ${NERDFONTS} 2>&1 1>&3 3>&- ); } 3>&1
   if [ $? -ne 0 ]; then printf "$OUT\nPatcher run aborted!\n\n"; fi
 

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.1.1"
+script_version = "4.1.2"
 
 version = "3.0.0"
 projectName = "Nerd Fonts"
@@ -741,7 +741,7 @@ class font_patcher:
 
     def remove_ligatures(self):
         # let's deal with ligatures (mostly for monospaced fonts)
-        # the tables have been removed from the repo with >this< commit
+        # Usually removes 'fi' ligs that end up being only one cell wide, and 'ldot'
         if self.args.configfile and self.config.read(self.args.configfile):
             if self.args.removeligatures:
                 logger.info("Removing ligatures from configfile `Subtables` section")

--- a/src/unpatched-fonts/Lekton/README.md
+++ b/src/unpatched-fonts/Lekton/README.md
@@ -4,4 +4,6 @@ Lekton has been designed at ISIA Urbino, Italy, and is inspired by some of the t
 
 https://fonts.google.com/specimen/Lekton
 
+The `fi` and `fl` ligatures are removed because the map to only one advance width.
+
 Version: 34

--- a/src/unpatched-fonts/Lekton/config.json
+++ b/src/unpatched-fonts/Lekton/config.json
@@ -1,0 +1,4 @@
+[Subtables]
+	ligatures: [
+		"'liga' Standard Ligatures in Latin lookup 6 subtable",
+		"'liga' Standard Ligatures in Latin lookup 5 subtable" ]

--- a/src/unpatched-fonts/Noto/README.md
+++ b/src/unpatched-fonts/Noto/README.md
@@ -6,5 +6,7 @@ https://fonts.google.com/noto
 
 The **Noto Mono** is an ancient font, nowadays the equivalent is Noto Sans Mono.
 
+The `ldot` ligatures are removed because the map to only one advance width.
+
 Version: 2.000 (20170915)
 Version: 1.0 (2007) for Noto Mono

--- a/src/unpatched-fonts/Noto/config.json
+++ b/src/unpatched-fonts/Noto/config.json
@@ -1,0 +1,7 @@
+[Subtables]
+	ligatures: [
+		"Ligature Substitution lookup 18 subtable",
+		"Ligature Substitution lookup 17 subtable",
+		"Ligature Substitution lookup 16 subtable",
+		"Ligature Substitution lookup 15 subtable",
+		"Ligature Substitution lookup 14 subtable" ]

--- a/src/unpatched-fonts/OpenDyslexic/README.md
+++ b/src/unpatched-fonts/OpenDyslexic/README.md
@@ -6,4 +6,6 @@ https://opendyslexic.org/
 
 For more information have a look at the upstream website: https://github.com/antijingoist/opendyslexic
 
+The `ldot` ligatures are removed because the map to only one advance width.
+
 Version: 2.001

--- a/src/unpatched-fonts/OpenDyslexic/config.json
+++ b/src/unpatched-fonts/OpenDyslexic/config.json
@@ -1,0 +1,6 @@
+[Subtables]
+	ligatures: [
+		"Ligature Substitution lookup 8 subtable",
+		"Ligature Substitution lookup 7 subtable",
+		"'liga' Standard Ligature lookup 7 subtable",
+		"'liga' Standard Ligature lookup 4 subtable" ]

--- a/src/unpatched-fonts/Overpass/Mono/config.json
+++ b/src/unpatched-fonts/Overpass/Mono/config.json
@@ -1,0 +1,3 @@
+[Subtables]
+	ligatures: [
+		"Ligature Substitution lookup 23 subtable" ]

--- a/src/unpatched-fonts/Overpass/Non-Mono/config.json
+++ b/src/unpatched-fonts/Overpass/Non-Mono/config.json
@@ -1,0 +1,4 @@
+[Subtables]
+	ligatures: [
+		"Ligature Substitution lookup 20 subtable",
+		"'liga' Standard Ligatures in Latin lookup 18 subtable" ]

--- a/src/unpatched-fonts/Overpass/README.md
+++ b/src/unpatched-fonts/Overpass/README.md
@@ -4,4 +4,6 @@
 
 For more information have a look at the upstream website: https://github.com/RedHatOfficial/Overpass
 
+The `fi`, `fl`, and `ldot` ligatures are removed because the map to only one advance width.
+
 Version: 3.0.5

--- a/src/unpatched-fonts/SpaceMono/README.md
+++ b/src/unpatched-fonts/SpaceMono/README.md
@@ -4,4 +4,6 @@ Space Mono is an original fixed-width type family designed by Colophon Foundry f
 
 https://fonts.google.com/specimen/Space+Mono
 
+The `fi` and `fl` ligatures are removed because the map to only one advance width.
+
 Version: 1.001

--- a/src/unpatched-fonts/SpaceMono/config.json
+++ b/src/unpatched-fonts/SpaceMono/config.json
@@ -1,0 +1,4 @@
+[Subtables]
+	ligatures: [
+		"'liga' Standard Ligatures in Latin lookup 9 subtable",
+		"'liga' Standard Ligatures in Latin lookup 8 subtable" ]


### PR DESCRIPTION
**[why]**
Some sourcefonts, even that are monospaced, have a `fi` and/or `fl` ligature that maps into one cell. That looks very strange.

**[how]**
Partially revert commit
  148b0c445  Sunset ligature removal

for the cases that have a one-cell `fi`, `fl`, etc ligature, or a `ldot` related ligature - that is active by default. Discretionary ligatures or Stylistic Sets are not changed.

Do the removal on all patched fonts for consistency, not just `Nerd Font Mono`.

**[note]**
On Noto different subtables are needed for Sans, Serif and Sans-Mono. We can not set up different configs for each, so all are tried in all fonts and might fail (this is normal).

Fixes: #1187

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
