### PR TITLE
Bugfix/fix octa scale

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -982,16 +982,17 @@ class font_patcher:
             range(0xf221, 0xf22d + 1), # gender or so
             range(0xf255, 0xf25b + 1), # hand symbols
         ]}
-        OCTI_SCALE_LIST = {'ScaleGlyph': 0xF0E7, # smily (probably biggest glyph / full design cell)
-            'GlyphsToScale+': [
-                (0xf03d, 0xf040), # arrows
-                0xf044, 0xf05a, 0xf05b, 0xf0aa, # triangles
-                0xf052, 0xf053, 0x296, 0xf250, # small stuff
-                0xf019, 0xf030, 0xf04a, 0xf050,  0xf071, 0xf08c, # other arrows
-                0xf078, 0xf0a2, 0xf0a3, 0xf0a4, # chevrons
-                0xf0ca, 0xf081, 0xf092, # dash, X, github-text
-                0xf09c, 0xf09f, 0xf0de, # bells
-                (0xf2c2, 0xf2c5), # move to
+        OCTI_SCALE_LIST = {'ScaleGroups': [
+                [*range(0xf03d, 0xf040 + 1), 0xf019, 0xf030, 0xf04a, 0xf050,  0xf071, 0xf08c ], # arrows
+                [0xF0E7, # Smily and ...
+                    0xf044, 0xf05a, 0xf05b, 0xf0aa, # triangles
+                    0xf052, 0xf053, 0x296, 0xf2f0, # small stuff
+                    0xf078, 0xf0a2, 0xf0a3, 0xf0a4, # chevrons
+                    0xf0ca, 0xf081, 0xf092, # dash, X, github-text
+                ],
+                [0xf09c, 0xf09f, 0xf0de], # bells
+                range(0xf2c2, 0xf2c5 + 1), # move to
+                [0xf07b, 0xf0a1, 0xf0d6], # bookmarks
         ]}
         WEATH_SCALE_LIST = {'ScaleGroups': [
             [0xf03c, 0xf042, 0xf045 ], # degree signs

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.1.3"
+script_version = "4.1.4"
 
 version = "3.0.0"
 projectName = "Nerd Fonts"
@@ -982,14 +982,16 @@ class font_patcher:
             range(0xf221, 0xf22d + 1), # gender or so
             range(0xf255, 0xf25b + 1), # hand symbols
         ]}
-        OCTI_SCALE_LIST = {'ScaleGlyph': 0xF02E, # looking glass (probably biggest glyph?)
-            'GlyphsToScale': [
+        OCTI_SCALE_LIST = {'ScaleGlyph': 0xF0E7, # smily (probably biggest glyph / full design cell)
+            'GlyphsToScale+': [
                 (0xf03d, 0xf040), # arrows
                 0xf044, 0xf05a, 0xf05b, 0xf0aa, # triangles
-                (0xf051, 0xf053), # small stuff
-                0xf071, 0xf09f, 0xf0a0, 0xf0a1, # small arrows
+                0xf052, 0xf053, 0x296, 0xf250, # small stuff
+                0xf019, 0xf030, 0xf04a, 0xf050,  0xf071, 0xf08c, # other arrows
                 0xf078, 0xf0a2, 0xf0a3, 0xf0a4, # chevrons
-                0xf0ca, # dash
+                0xf0ca, 0xf081, 0xf092, # dash, X, github-text
+                0xf09c, 0xf09f, 0xf0de, # bells
+                (0xf2c2, 0xf2c5), # move to
         ]}
         WEATH_SCALE_LIST = {'ScaleGroups': [
             [0xf03c, 0xf042, 0xf045 ], # degree signs


### PR DESCRIPTION
```
font-patcher: Fix some Octicons scales
    
    [why]
    With the Octicons update some codepoint contents changed.
    Also some symbols scale still wrong.
    
    [how]
    Check fonts and add / drop entries.
    Use GlyphsToScale+ to correct position of Github text icon.
```    

Fixes: #1198

```
font-patcher: Modernize and expand Octicons scale table
    
    [why]
    The scale glyph is not the biggest glyph; the bell-slash is a little bit
    wider than the design cell...
    
    [how]
    Switch to modern ScaleGroups. These determine the virtual combined
    bounding box of all glyphs in the group and scale them 'as one'.
    
    Also add some more groups.
    
    Also correct wrong code of one small stuff.
```

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #1156

#### Screenshots (if appropriate or helpful)
