### PR TITLE
Bugfix logging on AppImage

### DIFF
--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.0.0
-# Script Version: 1.4.4
+# Script Version: 1.4.5
 #
 # You can supply options to the font-patcher via environment variable NERDFONTS
 # That option will override the defaults (also defaults of THIS script).
@@ -246,6 +246,8 @@ function patch_font {
     echo >&2 "# Could not find project parent directory"
     exit 3
   }
+  # Add logfile always (but can be overridden by config_patch_flags in config.cfg and env var NERDFONTS)
+  config_patch_flags="--debug 1 ${config_patch_flags}"
   # Use absolute path to allow fontforge being an AppImage (used in CI)
   PWD=`pwd`
   # Create "Nerd Font"

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.1.4"
+script_version = "4.1.5"
 
 version = "3.0.0"
 projectName = "Nerd Fonts"
@@ -1955,9 +1955,13 @@ def main():
     global logger
     logger = logging.getLogger(os.path.basename(args.font))
     logger.setLevel(logging.DEBUG)
-    f_handler = logging.FileHandler('font-patcher-log.txt')
-    f_handler.setFormatter(logging.Formatter('%(levelname)s: %(name)s %(message)s'))
-    logger.addHandler(f_handler)
+    log_to_file = True
+    try:
+        f_handler = logging.FileHandler('font-patcher-log.txt')
+        f_handler.setFormatter(logging.Formatter('%(levelname)s: %(name)s %(message)s'))
+        logger.addHandler(f_handler)
+    except:
+        log_to_file = False
     logger.debug(allversions)
     logger.debug("Options %s", repr(sys.argv[1:]))
     c_handler = logging.StreamHandler(stream=sys.stdout)
@@ -1965,6 +1969,8 @@ def main():
     if not args.debugmode:
         c_handler.setLevel(logging.INFO)
     logger.addHandler(c_handler)
+    if not log_to_file:
+        logger.info("Can not write logfile, disabling")
     logger.debug("Naming mode %d", args.makegroups)
 
     patcher = font_patcher(args)

--- a/font-patcher
+++ b/font-patcher
@@ -1832,7 +1832,7 @@ def setup_arguments():
     progressbars_group_parser.add_argument('--progressbars',         dest='progressbars',     action='store_true',                help='Show percentage completion progress bars per Glyph Set (default)')
     progressbars_group_parser.add_argument('--no-progressbars',      dest='progressbars',     action='store_false',               help='Don\'t show percentage completion progress bars per Glyph Set')
     parser.set_defaults(progressbars=True)
-    parser.add_argument('--debug',                                   dest='debugmode',        default=False, action='store_true', help='Verbose mode')
+    parser.add_argument('--debug',                                   dest='debugmode',        default=0,     type=int, nargs='?', help='Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)', const=2, choices=range(0, 3 + 1))
     parser.add_argument('--dry',                                     dest='dry_run',          default=False, action='store_true', help='Do neither patch nor store the font, to check naming')
     parser.add_argument('--xavgcharwidth',                           dest='xavgwidth',        default=None,  type=int, nargs='?', help='Adjust xAvgCharWidth (optional: concrete value)', const=True)
     # --xavgcharwidth for compatibility with old applications like notepad and non-latin fonts
@@ -1955,21 +1955,22 @@ def main():
     global logger
     logger = logging.getLogger(os.path.basename(args.font))
     logger.setLevel(logging.DEBUG)
-    log_to_file = True
-    try:
-        f_handler = logging.FileHandler('font-patcher-log.txt')
-        f_handler.setFormatter(logging.Formatter('%(levelname)s: %(name)s %(message)s'))
-        logger.addHandler(f_handler)
-    except:
-        log_to_file = False
-    logger.debug(allversions)
-    logger.debug("Options %s", repr(sys.argv[1:]))
+    log_to_file = (args.debugmode & 1 == 1)
+    if log_to_file:
+        try:
+            f_handler = logging.FileHandler('font-patcher-log.txt')
+            f_handler.setFormatter(logging.Formatter('%(levelname)s: %(name)s %(message)s'))
+            logger.addHandler(f_handler)
+        except:
+            log_to_file = False
+        logger.debug(allversions)
+        logger.debug("Options %s", repr(sys.argv[1:]))
     c_handler = logging.StreamHandler(stream=sys.stdout)
     c_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
-    if not args.debugmode:
+    if not (args.debugmode & 2 == 2):
         c_handler.setLevel(logging.INFO)
     logger.addHandler(c_handler)
-    if not log_to_file:
+    if (args.debugmode & 1 == 1) and not log_to_file:
         logger.info("Can not write logfile, disabling")
     logger.debug("Naming mode %d", args.makegroups)
 


### PR DESCRIPTION
#### Description

The `font-patcher` always logs the debug messages in a file.
That fails when `fontforge` is an AppImage (and maybe when we are a docker image?)

This PR drops that feature. Logging to file has to be explicitly requested with a parameter to the `--debug` option.

    Introduce parameter to --debug option.
    0 = no debug output
    1 = log to file only (previously always selected)
    2 = log to stdout only
    3 = log to file and stdout (previous default for --debug)

    Just specifying --default equals now --debug 2.
    The gotta-patch-em runs now with --debug 1.


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

Reported on Gitter by @loveFluffy - Thank you for the report!

#### Screenshots (if appropriate or helpful)
