### PR TITLE
font-patcher: Drop box-drawing from SymbolsOnly

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -324,7 +324,7 @@ class font_patcher:
         self.font_dim = None  # class 'dict'
         self.font_extrawide = False
         self.source_monospaced = None # Later True or False
-        self.symbolsonly = False
+        self.symbolsonly = False # Are we generating the SymbolsOnly font?
         self.onlybitmaps = 0
         self.essential = set()
         self.config = configparser.ConfigParser(empty_lines_in_values=False, allow_no_value=True)
@@ -337,8 +337,8 @@ class font_patcher:
         self.setup_name_backup(font)
         self.assert_monospace()
         self.remove_ligatures()
-        self.setup_patch_set()
         self.get_sourcefont_dimensions()
+        self.setup_patch_set()
         self.improve_line_dimensions()
         self.sourceFont.encoding = 'UnicodeFull'  # Update the font encoding to ensure that the Unicode glyphs are available
         self.onlybitmaps = self.sourceFont.onlybitmaps  # Fetch this property before adding outlines. NOTE self.onlybitmaps initialized and never used
@@ -784,7 +784,7 @@ class font_patcher:
     def setup_patch_set(self):
         """ Creates list of dicts to with instructions on copying glyphs from each symbol font into self.sourceFont """
 
-        box_enabled = self.source_monospaced # Box glyph only for monospaced
+        box_enabled = self.source_monospaced and not self.symbolsonly # Box glyph only for monospaced and not for Symbols Only
         box_keep = False
         if box_enabled:
             self.sourceFont.selection.select(("ranges",), 0x2500, 0x259f)


### PR DESCRIPTION
[why]
The Box Drawing glyphs need to be carefully scaled. This can not be done if the glyphs are pulled in via font-fallback I guess.

As people may have the fontconfig set up in a way to prefer the Symbols Only font these glyphs could overrule other box drawing glyphs that might fit better.

I'm not really sure about this one, but the glyphs look rather bad anyhow, because they end up in the 1:1 ascpect ratio cell of the Symbols Only font.

[how]
Just turn the set off if we patch the Symbols Only font. Need to swap around two subroutine calls for that; first detect if we are patching the Symbols Only font (through the font metrics) and then set the patch sets up.

Fixes: #1210


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Drop the box drawing glyphs from the Symbols Only font(s).
They have been introduced with 3.0.0

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
