### PR TITLE
Improve custom patching

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -898,7 +898,7 @@ class font_patcher:
         CUSTOM_ATTR = {
             # previous custom scaling => do not touch the icons
             # 'default': {'align': 'c', 'valign': '', 'stretch': '', 'params': {}}
-            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}}
+            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {'careful': self.args.careful}}
         }
 
         # Most glyphs we want to maximize (individually) during the scale
@@ -1337,7 +1337,8 @@ class font_patcher:
                     sys.stdout.flush()
 
             # check if a glyph already exists in this location
-            if careful or 'careful' in sym_attr['params'] or currentSourceFontGlyph in self.essential:
+            do_careful = sym_attr['params'].get('careful', careful) # params take precedence
+            if do_careful or currentSourceFontGlyph in self.essential:
                 if currentSourceFontGlyph in self.sourceFont:
                     careful_type = 'essential' if currentSourceFontGlyph in self.essential else 'existing'
                     logger.debug("Found %s Glyph at %X. Skipping...", careful_type, currentSourceFontGlyph)
@@ -1809,7 +1810,7 @@ def setup_arguments():
     parser.add_argument('--removeligs', '--removeligatures',         dest='removeligatures',  default=False, action='store_true', help='Removes ligatures specificed in JSON configuration file')
     parser.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str, nargs='?', help='Specify a Script for Post Processing')
     parser.add_argument('--configfile',                              dest='configfile',       default=False, type=str, nargs='?', help='Specify a file path for JSON configuration file (see sample: src/config.sample.json)')
-    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all new glyphs will be copied')
+    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all glyphs will be copied')
     parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
     parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
     parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.1.5"
+script_version = "4.2.0"
 
 version = "3.0.0"
 projectName = "Nerd Fonts"
@@ -896,8 +896,9 @@ class font_patcher:
             # 0x2593: {'align': 'c', 'valign': 'c', 'stretch': 'xy', 'params': {'dont_copy': box_keep}},
         }
         CUSTOM_ATTR = {
-            # 'pa' == preserve aspect ratio
-            'default': {'align': 'c', 'valign': '', 'stretch': '', 'params': {}}
+            # previous custom scaling => do not touch the icons
+            # 'default': {'align': 'c', 'valign': '', 'stretch': '', 'params': {}}
+            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}}
         }
 
         # Most glyphs we want to maximize (individually) during the scale
@@ -1808,7 +1809,7 @@ def setup_arguments():
     parser.add_argument('--removeligs', '--removeligatures',         dest='removeligatures',  default=False, action='store_true', help='Removes ligatures specificed in JSON configuration file')
     parser.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str, nargs='?', help='Specify a Script for Post Processing')
     parser.add_argument('--configfile',                              dest='configfile',       default=False, type=str, nargs='?', help='Specify a file path for JSON configuration file (see sample: src/config.sample.json)')
-    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font. All new glyphs will be copied, with no scaling applied.')
+    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all new glyphs will be copied')
     parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
     parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
     parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.2.0"
+script_version = "4.2.1"
 
 version = "3.0.0"
 projectName = "Nerd Fonts"
@@ -373,15 +373,16 @@ class font_patcher:
                     if symfont:
                         symfont.close()
                         symfont = None
-                    if not os.path.isfile(self.args.glyphdir + patch['Filename']):
+                    symfont_file = os.path.join(self.args.glyphdir, patch['Filename'])
+                    if not os.path.isfile(symfont_file):
                         logger.critical("Can not find symbol source for '%s' (i.e. %s)",
-                            patch['Name'], self.args.glyphdir + patch['Filename'])
+                            patch['Name'], symfont_file)
                         sys.exit(1)
-                    if not os.access(self.args.glyphdir + patch['Filename'], os.R_OK):
+                    if not os.access(symfont_file, os.R_OK):
                         logger.critical("Can not open symbol source for '%s' (i.e. %s)",
-                            patch['Name'], self.args.glyphdir + patch['Filename'])
+                            patch['Name'], symfont_file)
                         sys.exit(1)
-                    symfont = fontforge.open(os.path.join(self.args.glyphdir, patch['Filename']))
+                    symfont = fontforge.open(symfont_file)
                     symfont.encoding = 'UnicodeFull'
 
                     # Match the symbol font size to the source font size
@@ -1810,7 +1811,7 @@ def setup_arguments():
     parser.add_argument('--removeligs', '--removeligatures',         dest='removeligatures',  default=False, action='store_true', help='Removes ligatures specificed in JSON configuration file')
     parser.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str, nargs='?', help='Specify a Script for Post Processing')
     parser.add_argument('--configfile',                              dest='configfile',       default=False, type=str, nargs='?', help='Specify a file path for JSON configuration file (see sample: src/config.sample.json)')
-    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all glyphs will be copied')
+    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all glyphs will be copied; absolute path suggested')
     parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
     parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
     parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')


### PR DESCRIPTION
#### Description

This changes how custom patching (i.e. with `--custom`) is handled.
When I tried to use the feature myself several shortcomings became obvious.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
This is mostly triggered by @siduck 's problem

* https://github.com/ryanoasis/nerd-fonts/issues/1213#issuecomment-1539214446
* https://github.com/ryanoasis/nerd-fonts/issues/1190#issuecomment-1532632029
* #1207 

#### Screenshots
