### PR TITLE
Fix the REGULAR bit of the fsSelection being set incorrectly

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -255,7 +255,7 @@ class FontnameParser:
         elif 'Italic' in self.style_token:
             b |= ITALIC
         # Regular is just the basic weight
-        if len(self.weight_token) == 0:
+        if len(self.weight_token) == 0 and not b & (ITALIC | BOLD | OBLIQUE):
             b |= REGULAR
         b |= WWS # We assert this by our naming process
         return b


### PR DESCRIPTION
#### Description

This commit resolves the issue of the fsSelection of the OS/2 table not being properly set.

According to [Microsoft's documentation](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection), bit 6 (REGULAR) of fsSelection is recommended to be set only when bit 0 (ITALIC) and bit 5 (BOLD) are clear.
However, the current script sets bit 6 (REGULAR) without following this rule (for example, when the font name is `XXX-BoldItalic.ttf`).

So, I have made changes to ensure that bit 6 (REGULAR) is not set when bit 0 (ITALIC), bit 5 (BOLD), or bit 9 (OBLIQUE) is set.
While the documentation does not specify whether bit 6 (REGULAR) should be cleared when bit 9 (OBLIQUE) is set, I think it should be treated like 0 (ITALIC) and bit 5 (BOLD).

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
