### PR TITLE
Bugfix ligatures in ubuntu

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1084,10 +1084,11 @@ class font_patcher:
         # Sometimes basic glyphs are constructed from multiple other glyphs.
         # Find out which other glyphs are also needed to keep the basic
         # glyphs intact.
-        # 0x00-0x17f is the Latin Extended-A range
+        # 0x0000-0x017f is the Latin Extended-A range
+        # 0xfb00-0xfb06 are 'fi' and other ligatures
         basic_glyphs = set()
         # Collect substitution destinations
-        for glyph in range(0x21, 0x17f + 1):
+        for glyph in [*range(0x21, 0x17f + 1), *range(0xfb00, 0xfb06 + 1)]:
             if not glyph in self.sourceFont:
                 continue
             basic_glyphs.add(glyph)


### PR DESCRIPTION
#### Description

    font-patcher: Fix vanishing fi ligature
    
    [why]
    With Ubuntu-Regular the fi and fl ligatures are replaced by some font
    awesome icons.
    
    The problem is that the font uses the non-standard F001 and F002
    codepoints as intermediate referencve to create the actual ligatures
    that are at codepoints FB01 to FB04.
    
    [how]
    All the normal ligature codepoints (FB00-FB06) are added to the glyph
    reference checker and codepoints that are referenced by these are not
    patched.
    
    This means that F001 and F002 stay on the original ligatures and the
    Font Awesome icons are missing, but this can not be fixed automatically
    and would need to 'rewrite' the references inside the font.
    
Fixes: #1221


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
