### PR TITLE
font-patcher: Fix DaddyTimeMono NFM

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1205,6 +1205,7 @@ class font_patcher:
                     0x132, 0x133, # IJ, ij (in Overpass Mono)
                     0x022, 0x027, 0x060, # Single and double quotes in Inconsolata LGC
                     0x0D0, 0x10F, 0x110, 0x111, 0x127, 0x13E, 0x140, 0x165, # Eth and others with stroke or caron in RobotoMono
+                    0x149, # napostrophe in DaddyTimeMono
                     0x02D, # hyphen for Monofur
                     ]:
                 continue # ignore special characters like '1/4' etc and some specifics


### PR DESCRIPTION
**[why]**
Although DaddyTimeMono is monospaced it has one glyph (napostrophe at 0x149) that is in fact two spaces wide. This breaks the created Nerd Font Mono font.

**[how]**
Add that glyph to the list of non-standard glyphs that are ignored.

Fixes: #1243

Reported-by: fabestah

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
