### PR TITLE
FontnameParser: Fix fsSelection for --has-no-italic

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -252,6 +252,9 @@ class FontnameParser:
         # Ignore Italic if we have Oblique
         if 'Oblique' in self.weight_token:
             b |= OBLIQUE
+            if not self.rename_oblique:
+                # If we have no dedicated italic, than oblique = italic
+                b |= ITALIC
         elif 'Italic' in self.style_token:
             b |= ITALIC
         # Regular is just the basic weight

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.3.1"
+script_version = "4.3.2"
 
 version = "3.0.1"
 projectName = "Nerd Fonts"


### PR DESCRIPTION
**[why]**
For fonts that have no Italic but an Oblique - i.e. when Oblique shall replace the Italic role in RIBBI font grouping (classic group of 4) - that grouping fails.

This affects DejaVu on Putty.

**[how]**
For RIBBI grouping only the classic bits are considered. That means that for fonts that have Oblique instead of Italic (and not additionally) we need to set the ITALIC bit and the OBLIQUE bit. This has been overlooked.

Cite from the specs:

> This bit, unlike the ITALIC bit (bit 0), is not related to style-linking
> in applications that assume a four-member font-family model comprised
> of regular, italic, bold and bold italic. It may be set or unset
> independently of the ITALIC bit. In most cases, if OBLIQUE is set, then
> ITALIC will also be set, though this is not required.

Fixes: #1249

Reported-by: Huifeng Shen <liaoya@gmail.com>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

Create new set of DejaVu, install NFM on Windows, start putty.

#### Any background context you can provide?

https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
