### PR TITLE
name-parser: Remove filename parsing code and more

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -7,8 +7,8 @@ from FontnameTools import FontnameTools
 class FontnameParser:
     """Parse a font name and generate all kinds of names"""
 
-    def __init__(self, filename, logger):
-        """Parse a font filename and store the results"""
+    def __init__(self, fontname, logger):
+        """Parse a fontname and store the results"""
         self.parse_ok = False
         self.use_short_families = (False, False, False) # ( camelcase name, short styles, aggressive )
         self.keep_regular_in_family = None # None = auto, True, False
@@ -17,7 +17,7 @@ class FontnameParser:
         self.ps_fontname_suff = ''
         self.short_family_suff = ''
         self.name_subst = []
-        [ self.parse_ok, self._basename, self.weight_token, self.style_token, self.other_token, self._rest ] = FontnameTools.parse_font_name(filename)
+        [ self.parse_ok, self._basename, self.weight_token, self.style_token, self.other_token, self._rest ] = FontnameTools.parse_font_name(fontname)
         self.basename = self._basename
         self.rest = self._rest
         self.add_name_substitution_table(FontnameTools.SIL_TABLE)

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -64,7 +64,6 @@ class FontnameTools:
         known_names = {
             # Source of the table is the current sourcefonts
             # Left side needs to be lower case
-            '-':            '',
             'book':         '',
             'text':         '',
             'ce':           'CE',
@@ -150,7 +149,12 @@ class FontnameTools:
         not_matched = ""
         all_tokens = []
         j = 1
-        regex = re.compile('(.*?)(' + '|'.join(tokens) + ')(.*)', re.IGNORECASE)
+        token_regex = '|'.join(tokens)
+        if not allow_regex_token:
+            # Allow a dash between CamelCase token word parts, i.e. Camel-Case
+            # This allows for styles like Extra-Bold
+            token_regex = re.sub(r'(?<=[a-z])(?=[A-Z])', '-?', token_regex)
+        regex = re.compile('(.*?)(' + token_regex + ')(.*)', re.IGNORECASE)
         while j:
             j = regex.match(name)
             if not j:
@@ -159,6 +163,9 @@ class FontnameTools:
                 sys.exit('Malformed regex in FontnameTools.get_name_token()')
             not_matched += ' ' + j.groups()[0] # Blanc prevents unwanted concatenation of unmatched substrings
             tok = j.groups()[1].lower()
+            if not allow_regex_token:
+                # Remove dashes between CamelCase token words
+                tok = tok.replace('-', '')
             if tok in lower_tokens:
                 tok = tokens[lower_tokens.index(tok)]
             tok = FontnameTools.unify_style_names(tok)

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -65,9 +65,7 @@ class FontnameTools:
             # Source of the table is the current sourcefonts
             # Left side needs to be lower case
             'book':         '',
-            'text':         '',
             'ce':           'CE',
-            #'semibold':     'Demi',
             'normal':       'Regular',
         }
         return known_names.get(style_name.lower(), style_name)
@@ -232,6 +230,7 @@ class FontnameTools:
         'Medium': ('Md', 'Med'),
         'Nord': ('Nd', 'Nord'),
         'Book': ('Bk', 'Book'),
+        'Text': ('Txt', 'Text'),
         'Poster': ('Po', 'Poster'),
         'Demi': ('Dm', 'Demi'), # Demi is sometimes used as a weight, sometimes as a modifier
         'Regular': ('Rg', 'Reg'),
@@ -341,7 +340,6 @@ class FontnameTools:
         # Some font specialities:
         other = [
             '-', 'Book', 'For', 'Powerline',
-            'Text',             # Plex
             'IIx',              # Profont IIx
             'LGC',              # Inconsolata LGC
             r'\bCE\b',          # ProggycleanTT CE

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -5,7 +5,7 @@ import re
 import sys
 
 class FontnameTools:
-    """Deconstruct a font filename to get standardized name parts"""
+    """Deconstruct a fontname to get standardized name parts"""
 
     @staticmethod
     def front_upper(word):
@@ -69,15 +69,7 @@ class FontnameTools:
             'text':         '',
             'ce':           'CE',
             #'semibold':     'Demi',
-            'ob':           'Oblique',
-            'it':           'Italic',
-            'i':            'Italic',
-            'b':            'Bold',
             'normal':       'Regular',
-            'c':            'Condensed',
-            'r':            'Regular',
-            'm':            'Medium',
-            'l':            'Light',
         }
         if style_name in known_names:
             return known_names[style_name.lower()]
@@ -306,8 +298,9 @@ class FontnameTools:
 
     @staticmethod
     def _parse_simple_font_name(name):
-        """Parse a filename that does not follow the 'FontFamilyName-FontStyle' pattern"""
-        # No dash in name, maybe we have blanc separated filename?
+        """Parse a fontname that does not follow the 'FontFamilyName-FontStyle' pattern"""
+        # This is the usual case, because the font-patcher usually uses the fullname and
+        # not the PS name
         if ' ' in name:
             return FontnameTools.parse_font_name(name.replace(' ', '-'))
         # Do we have a number-name boundary?
@@ -322,7 +315,8 @@ class FontnameTools:
 
     @staticmethod
     def parse_font_name(name):
-        """Expects a filename following the 'FontFamilyName-FontStyle' pattern and returns ... parts"""
+        """Expects a fontname following the 'FontFamilyName-FontStyle' pattern and returns ... parts"""
+        # This could parse filenames in the beginning but that was never used in production; code removed with this commit
         name = re.sub(r'\bsemi-condensed\b', 'SemiCondensed', name, 1, re.IGNORECASE) # Just for "3270 Semi-Condensed" :-/
         name = re.sub('[_\s]+', ' ', name)
         matches = re.match(r'([^-]+)(?:-(.*))?', name)
@@ -353,19 +347,9 @@ class FontnameTools:
             r'(?:uni-)?1[14]',  # GohuFont uni
         ]
 
-        # Sometimes used abbreviations
-        weight_abbrevs = [ 'ob', 'c', 'm', 'l', ]
-        style_abbrevs = [ 'it', 'r', 'b', 'i', ]
-
         ( style, weight_token ) = FontnameTools.get_name_token(style, weights)
         ( style, style_token ) = FontnameTools.get_name_token(style, styles)
         ( style, other_token ) = FontnameTools.get_name_token(style, other, True)
-        if (len(style) < 4
-                and style.lower() != 'pro'): # Prevent 'r' of Pro to be detected as style_abbrev
-            ( style, weight_token_abbrevs ) = FontnameTools.get_name_token(style, weight_abbrevs)
-            ( style, style_token_abbrevs ) = FontnameTools.get_name_token(style, style_abbrevs)
-            weight_token += weight_token_abbrevs
-            style_token += style_token_abbrevs
         while 'Regular' in style_token and len(style_token) > 1:
             # Correct situation where "Regular" and something else is given
             style_token.remove('Regular')

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -318,7 +318,13 @@ class FontnameTools:
     def parse_font_name(name):
         """Expects a fontname following the 'FontFamilyName-FontStyle' pattern and returns ... parts"""
         # This could parse filenames in the beginning but that was never used in production; code removed with this commit
-        name = re.sub(r'\bsemi-condensed\b', 'SemiCondensed', name, 1, re.IGNORECASE) # Just for "3270 Semi-Condensed" :-/
+        for special in [
+                ('ExtLt', 'ExtraLight'), # IBM-Plex
+                ('Medm', 'Medium'), # IBM-Plex
+                ('Semi-Condensed', 'SemiCondensed'), # 3270
+                ('SmBld', 'SemiBold'), # IBM-Plex
+            ]:
+            name = re.sub(r'\b' + special[0] + r'\b', special[1], name, 1, re.IGNORECASE)
         name = re.sub('[_\s]+', ' ', name)
         matches = re.match(r'([^-]+)(?:-(.*))?', name)
         familyname = FontnameTools.camel_casify(matches.group(1))

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -71,9 +71,7 @@ class FontnameTools:
             #'semibold':     'Demi',
             'normal':       'Regular',
         }
-        if style_name in known_names:
-            return known_names[style_name.lower()]
-        return style_name
+        return known_names.get(style_name.lower(), style_name)
 
     @staticmethod
     def find_in_dicts(key, dicts):

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -135,7 +135,7 @@ class FontnameTools:
         return (weights, styles)
 
     @staticmethod
-    def get_name_token(name, tokens, allow_regex_token = False):
+    def get_name_token(name, tokens):
         """Try to find any case insensitive token from tokens in the name, return tuple with found token-list and rest"""
         # The default mode (allow_regex_token = False) will try to find any verbatim string in the
         # tokens list (case insensitive matching) and give that tokens list item back with
@@ -150,10 +150,9 @@ class FontnameTools:
         all_tokens = []
         j = 1
         token_regex = '|'.join(tokens)
-        if not allow_regex_token:
-            # Allow a dash between CamelCase token word parts, i.e. Camel-Case
-            # This allows for styles like Extra-Bold
-            token_regex = re.sub(r'(?<=[a-z])(?=[A-Z])', '-?', token_regex)
+        # Allow a dash between CamelCase token word parts, i.e. Camel-Case
+        # This allows for styles like Extra-Bold
+        token_regex = re.sub(r'(?<=[a-z])(?=[A-Z])', '-?', token_regex)
         regex = re.compile('(.*?)(' + token_regex + ')(.*)', re.IGNORECASE)
         while j:
             j = regex.match(name)
@@ -163,9 +162,7 @@ class FontnameTools:
                 sys.exit('Malformed regex in FontnameTools.get_name_token()')
             not_matched += ' ' + j.groups()[0] # Blanc prevents unwanted concatenation of unmatched substrings
             tok = j.groups()[1].lower()
-            if not allow_regex_token:
-                # Remove dashes between CamelCase token words
-                tok = tok.replace('-', '')
+            tok = tok.replace('-', '') # Remove dashes between CamelCase token words
             if tok in lower_tokens:
                 tok = tokens[lower_tokens.index(tok)]
             tok = FontnameTools.unify_style_names(tok)
@@ -354,7 +351,7 @@ class FontnameTools:
 
         ( style, weight_token ) = FontnameTools.get_name_token(style, weights)
         ( style, style_token ) = FontnameTools.get_name_token(style, styles)
-        ( style, other_token ) = FontnameTools.get_name_token(style, other, True)
+        ( style, other_token ) = FontnameTools.get_name_token(style, other)
         while 'Regular' in style_token and len(style_token) > 1:
             # Correct situation where "Regular" and something else is given
             style_token.remove('Regular')

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.3.2"
+script_version = "4.3.3"
 
 version = "3.0.1"
 projectName = "Nerd Fonts"


### PR DESCRIPTION
**[why]**
Patching CartographCF-Bold.ttf creates this naming:

    Family (ID 1)      : CartographF Nerd Font Condensed
    SubFamily (ID 2)   : Bold
    Fullname (ID 4)    : CartographF Nerd Font Condensed Bold
    PSN (ID 6)         : CartographFNF-CondensedBold
    PrefFamily (ID 16) : CartographF Nerd Font
    PrefStyles (ID 17) : Condensed Bold

    CartographF Nerd Font Condensed Bold
    \===> 'CartographFNerdFont-CondensedBold.ttf'

**[how]**
The font-patcher historically used the file name of the to-be-patched font to come up with the new name. When the FontnameParser has been developed that mechanics has been copied at least for fallback. The earliest tests compared old and new naming with all the filenames.

Later, when the FontnameParser has been used to really apply name changes it has always based the parsing on the Fullname or the PSname, because they really hold the information (or at least should hold); while the filename might be completely random.

Still code the dealt with specific problems in FILEnames prevailed. The Ubuntu font for example has a file name like `Ubuntu-C.ttf`, and we needed to convert the `C` to `Condensed`.

As that requirement vanished we can drop all the code that has been added specifically only for parsing the Ubuntu font filenames.

Side note: USUALLY font filenames should be roughly equal to the PSname.

Fixes: #1258

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

Check all generated font names from prepatched fonts

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
