### PR TITLE
Bugfix Codicon Circles

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -922,11 +922,7 @@ class font_patcher:
         #       with the same scaling and shifting. The basis for it is a 'combined
         #       bounding box' of all glyphs in that group. All glyphs are handled as
         #       if they fill that combined bounding box.
-        #   - ScaleGroupsVert:
-        #       Almost the same as ScaleGroups, but the shifting-as-one is only done
-        #       on the vertical axis, horizontally the shifting is individually.
-        #       Glyphs in this kind of group share all the same scale and y shift/alignment
-        #       but not the x alignment.
+        #  (- ScaleGroupsVert: Removed with this commit)
         #
         # The ScaleGlyph method: You set 'ScaleGlyph' to the unicode of the reference glyph.
         # Note that there can be only one per patch-set.
@@ -1426,7 +1422,7 @@ class font_patcher:
             # Use combined bounding box?
             if glyph_scale_data is not None and glyph_scale_data[1] is not None:
                 scaleglyph_dim = scale_bounding_box(glyph_scale_data[1], scale_ratio_x, scale_ratio_y)
-                if scaleglyph_dim['advance'] is None or scaleglyph_dim['width'] == 0:
+                if scaleglyph_dim['advance'] is None:
                     # On monospaced symbol collections use their advance with, otherwise align horizontally individually
                     scaleglyph_dim['xmin'] = sym_dim['xmin']
                     scaleglyph_dim['xmax'] = sym_dim['xmax']
@@ -1595,20 +1591,11 @@ class font_patcher:
         scaleRules['bbdims'] = []
         if 'ScaleGroups' not in scaleRules:
             scaleRules['ScaleGroups'] = []
-        for i, groups in enumerate([ scaleRules['ScaleGroups'], scaleRules.get('ScaleGroupsVert', []) ]):
-            for group in groups:
-                sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
-                scale = self.get_scale_factors(sym_dim, stretch)[0]
-                if i == 1:
-                    scaleRules['ScaleGroups'].append(group)
-                    if not self.args.single:
-                        # Do not keep these values, keep only vertical related bounding box:
-                        sym_dim['xmin'] = 0
-                        sym_dim['xmax'] = 0
-                        sym_dim['width'] = 0
-                        sym_dim['advance'] = None # Drop possibe monospaced flag
-                scaleRules['scales'].append(scale)
-                scaleRules['bbdims'].append(sym_dim)
+        for group in scaleRules['ScaleGroups']:
+            sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
+            scale = self.get_scale_factors(sym_dim, stretch)[0]
+            scaleRules['scales'].append(scale)
+            scaleRules['bbdims'].append(sym_dim)
 
         if 'ScaleGlyph' in scaleRules:
             # Rewrite to equivalent ScaleGroup

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.3.3"
+script_version = "4.3.4"
 
 version = "3.0.1"
 projectName = "Nerd Fonts"
@@ -961,15 +961,9 @@ class font_patcher:
             range(0x2591, 0x2593 + 1), # greys
             range(0x2594, 0x259f + 1), # quards (Note: quard 2597 in Hack is wrong, scales like block!)
         ]}
-        CODI_SCALE_LIST = {'ScaleGroupsVert': [
-            range(0xea99, 0xeaa1 + 1), # arrows
+        CODI_SCALE_LIST = {'ScaleGroups': [
             range(0xeb6e, 0xeb71 + 1), # triangles
             range(0xeab4, 0xeab7 + 1), # chevrons
-            [0xea71, *range(0xeaa6, 0xeaab + 1), 0xeabc, 0xeb18, 0xeb87, 0xeb88, 0xeb8a, 0xeb8c, 0xebb4], # small circles and similar
-            [0xeacc, 0xeaba], # dash
-            [0xea75, 0xebe7], # lock pair
-            [0xeacf, 0xebe0], # debug-continue pair
-            [0xeb91, 0xeba8], # debug-alt pair
         ]}
         DEVI_SCALE_LIST = {'ScaleGlyph': 0xE60E, # Android logo
             'GlyphsToScale': [

--- a/font-patcher
+++ b/font-patcher
@@ -922,6 +922,11 @@ class font_patcher:
         #       with the same scaling and shifting. The basis for it is a 'combined
         #       bounding box' of all glyphs in that group. All glyphs are handled as
         #       if they fill that combined bounding box.
+        #   - ScaleGroupsVert:
+        #       Almost the same as ScaleGroups, but the shifting-as-one is only done
+        #       on the vertical axis, horizontally the shifting is individually.
+        #       Glyphs in this kind of group share all the same scale and y shift/alignment
+        #       but not the x alignment.
         #
         # The ScaleGlyph method: You set 'ScaleGlyph' to the unicode of the reference glyph.
         # Note that there can be only one per patch-set.
@@ -956,11 +961,11 @@ class font_patcher:
             range(0x2591, 0x2593 + 1), # greys
             range(0x2594, 0x259f + 1), # quards (Note: quard 2597 in Hack is wrong, scales like block!)
         ]}
-        CODI_SCALE_LIST = {'ScaleGroups': [
+        CODI_SCALE_LIST = {'ScaleGroupsVert': [
             range(0xea99, 0xeaa1 + 1), # arrows
             range(0xeb6e, 0xeb71 + 1), # triangles
             range(0xeab4, 0xeab7 + 1), # chevrons
-            [0xea71, *range(0xeaa6, 0xeaab + 1), 0xeabc, 0xeb18, 0xeb87, 0xeb88, 0xeb8a, 0xeb8c, 0xebb4], # cicles
+            [0xea71, *range(0xeaa6, 0xeaab + 1), 0xeabc, 0xeb18, 0xeb87, 0xeb88, 0xeb8a, 0xeb8c, 0xebb4], # small circles and similar
             [0xeacc, 0xeaba], # dash
             [0xea75, 0xebe7], # lock pair
             [0xeacf, 0xebe0], # debug-continue pair
@@ -1427,7 +1432,7 @@ class font_patcher:
             # Use combined bounding box?
             if glyph_scale_data is not None and glyph_scale_data[1] is not None:
                 scaleglyph_dim = scale_bounding_box(glyph_scale_data[1], scale_ratio_x, scale_ratio_y)
-                if scaleglyph_dim['advance'] is None:
+                if scaleglyph_dim['advance'] is None or scaleglyph_dim['width'] == 0:
                     # On monospaced symbol collections use their advance with, otherwise align horizontally individually
                     scaleglyph_dim['xmin'] = sym_dim['xmin']
                     scaleglyph_dim['xmax'] = sym_dim['xmax']
@@ -1596,11 +1601,20 @@ class font_patcher:
         scaleRules['bbdims'] = []
         if 'ScaleGroups' not in scaleRules:
             scaleRules['ScaleGroups'] = []
-        for group in scaleRules['ScaleGroups']:
-            sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
-            scale = self.get_scale_factors(sym_dim, stretch)[0]
-            scaleRules['scales'].append(scale)
-            scaleRules['bbdims'].append(sym_dim)
+        for i, groups in enumerate([ scaleRules['ScaleGroups'], scaleRules.get('ScaleGroupsVert', []) ]):
+            for group in groups:
+                sym_dim = get_multiglyph_boundingBox([ symbolFont[g] if g in symbolFont else None for g in group ], destGlyph)
+                scale = self.get_scale_factors(sym_dim, stretch)[0]
+                if i == 1:
+                    scaleRules['ScaleGroups'].append(group)
+                    if not self.args.single:
+                        # Do not keep these values, keep only vertical related bounding box:
+                        sym_dim['xmin'] = 0
+                        sym_dim['xmax'] = 0
+                        sym_dim['width'] = 0
+                        sym_dim['advance'] = None # Drop possibe monospaced flag
+                scaleRules['scales'].append(scale)
+                scaleRules['bbdims'].append(sym_dim)
 
         if 'ScaleGlyph' in scaleRules:
             # Rewrite to equivalent ScaleGroup


### PR DESCRIPTION
#### Description

Revert scaling of (most of) the Codicons back to individual maximize as it has been with `v2.3` and before.

On the way a new Scaling method is introduced and removed again as it does technically solve the problem but probably people do not want relative consistency but big icons i.e. maximizing.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

Fixes: #1240

#### Screenshots (if appropriate or helpful)
