### PR TITLE
Fix changelog formatting

### DIFF
--- a/_posts/2017-01-07-release.md
+++ b/_posts/2017-01-07-release.md
@@ -29,6 +29,7 @@ This bugfix release handles the following issues.
 * Fix Ubuntu Mono Condensed font property (upstream bug)
 * Fix small scaling glitch for 4 Codicons
 * Correct CaskaydiaCove's version string (which contains the autohinter)
+
   </div>
 </details>
 


### PR DESCRIPTION
#### Description

I think the `</div> </details>` at the end of the v3.0.1 release notes was being parsed as part of the last `<li>` item, resulting in `</div> </details>` being escaped. This PR should fix the issue where in the HTML output, the v3.0.1 release `<details>` included the release notes for v3.0.0, v2.3.3, etc.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Adds a new line after the last list item and before the `</div> </details>` in the changelog post for GH Pages.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

The issue on https://www.nerdfonts.com/releases:

![](https://github.com/ryanoasis/nerd-fonts/assets/31467609/65206cb3-f6ed-4a79-836b-12c587288f9c)

<img width="669" alt="image" src="https://github.com/ryanoasis/nerd-fonts/assets/31467609/2c8f7d11-dbff-47a8-966f-dc34dfccf923">
