### PR TITLE
test-fonts.sh: allow wrapping at any number

### DIFF
--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -177,8 +177,8 @@ function test-fonts() {
   print-unicode-ranges 23fb 23fe 2b58 2b58
   echo; echo
 
-  echo "Nerd Fonts - Material Design Icons"
-  print-unicode-ranges f500 fd46
+  echo "Nerd Fonts - Material Design Icons (first few)"
+  print-unicode-ranges f0001 f0010
   echo; echo
 
   echo "Nerd Fonts - Weather Icons"

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -23,9 +23,15 @@ function print-decimal-unicode-range() {
   local allChars=""
   local allCodes=""
   local wrapAt=5
-  local topLine="${bgColorBorder}╔══════╦══════╦══════╦══════╦══════╗${reset_color}"
-  local bottomLine="${bgColorBorder}╚══════╩══════╩══════╩══════╩══════╝${reset_color}"
-  local line="${bgColorBorder}╠══════╬══════╬══════╬══════╬══════╣${reset_color}"
+  local topLineStart="${bgColorBorder}╔═══"
+  local topLineMiddle="═══╦═══"
+  local topLineEnd="═══╗${reset_color}"
+  local bottomLineStart="${bgColorBorder}╚═══"
+  local bottomLineMiddle="═══╩═══"
+  local bottomLineEnd="═══╝${reset_color}"
+  local lineStart="${bgColorBorder}╠═══"
+  local lineMiddle="═══╬═══"
+  local lineEnd="═══╣${reset_color}"
   local bar="${bgColorBorder}║${reset_color}"
   local originalSequenceLength=${#originalSequence[@]}
   local leftoverSpaces=$((wrapAt - (originalSequenceLength % wrapAt)))
@@ -41,7 +47,11 @@ function print-decimal-unicode-range() {
 
   local sequenceLength=${#originalSequence[@]}
 
-  printf "%b\\n" "$topLine"
+  printf "%b" "$topLineStart"
+  for ((c = 2; c <= wrapAt; c++)); do
+    printf "%b" "$topLineMiddle"
+  done
+  printf "%b\\n" "$topLineEnd"
 
   for decimalCode in "${originalSequence[@]}"; do
     local hexCode
@@ -76,7 +86,11 @@ function print-decimal-unicode-range() {
       printf "\\n"
 
       if [ "$counter" != "$sequenceLength" ]; then
-        printf "%b\\n" "$line"
+        printf "%b" "$lineStart"
+        for ((c = 2; c <= wrapAt; c++)); do
+          printf "%b" "$lineMiddle"
+        done
+        printf "%b\\n" "$lineEnd"
       fi
 
       allCodes=""
@@ -85,7 +99,12 @@ function print-decimal-unicode-range() {
 
   done
 
-  printf "%b\\n" "$bottomLine"
+  printf "%b" "$bottomLineStart"
+  for ((c = 2; c <= wrapAt; c++)); do
+    printf "%b" "$bottomLineMiddle"
+  done
+  printf "%b\\n" "$bottomLineEnd"
+
 
 }
 

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -39,7 +39,7 @@ function print-decimal-unicode-range() {
 
   # add fillers to array to maintain table:
   if [ "$leftoverSpaces" -lt "$wrapAt" ]; then
-    for _ in $(seq 1 $leftoverSpaces); do
+    for ((c = 1; c <= leftoverSpaces; c++)); do
       originalSequence+=(0)
     done
   fi

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -22,7 +22,7 @@ function print-decimal-unicode-range() {
   local reset_color='\033[0m'
   local allChars=""
   local allCodes=""
-  local wrapAt=5
+  local wrapAt=16
   local topLineStart="${bgColorBorder}╔═══"
   local topLineMiddle="═══╦═══"
   local topLineEnd="═══╗${reset_color}"

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.0.1
-# Script Version: 1.0.0
+# Script Version: 1.1.0
 
 # Run this script in your local bash:
 # curl https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/bin/scripts/test-fonts.sh | bash
+# Is possible to change the number of columns passing a number as the first parameter (default=16):
+# ./test-fonts.sh 8
 
 # Given an array of decimal numbers print all unicode codepoint.
 function print-decimal-unicode-range() {

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -127,7 +127,8 @@ function print-unicode-ranges() {
     local startDecimal=$((16#$start))
     local endDecimal=$((16#$end))
 
-    mapfile -t combinedRanges < <(seq "$startDecimal" "$endDecimal")
+    # shellcheck disable=SC2207 # We DO WANT the output to be split
+    combinedRanges+=($(seq "$startDecimal" "$endDecimal"))
 
   done
 

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -37,7 +37,7 @@ function print-decimal-unicode-range() {
   local leftoverSpaces=$((wrapAt - (originalSequenceLength % wrapAt)))
 
   # add fillers to array to maintain table:
-  if [[ "$leftoverSpaces" < "$wrapAt" ]]; then
+  if [[ "$leftoverSpaces" -lt "$wrapAt" ]]; then
     # shellcheck disable=SC2034
     # needs rework without 'i' var?
     for i in $(seq 1 $leftoverSpaces); do

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -38,7 +38,7 @@ function print-decimal-unicode-range() {
   local leftoverSpaces=$((wrapAt - (originalSequenceLength % wrapAt)))
 
   # add fillers to array to maintain table:
-  if [[ "$leftoverSpaces" -lt "$wrapAt" ]]; then
+  if [ "$leftoverSpaces" -lt "$wrapAt" ]; then
     for _ in $(seq 1 $leftoverSpaces); do
       originalSequence+=(0)
     done

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -38,9 +38,7 @@ function print-decimal-unicode-range() {
 
   # add fillers to array to maintain table:
   if [[ "$leftoverSpaces" -lt "$wrapAt" ]]; then
-    # shellcheck disable=SC2034
-    # needs rework without 'i' var?
-    for i in $(seq 1 $leftoverSpaces); do
+    for _ in $(seq 1 $leftoverSpaces); do
       originalSequence+=(0)
     done
   fi

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -184,11 +184,6 @@ function test-fonts() {
   echo "Nerd Fonts - Weather Icons"
   print-unicode-ranges e300 e3eb
   echo; echo
-
-  echo "Nerd Fonts - All"
-  print-unicode-ranges e000 e00d e0a0 e0a2 e0b0 e0b3 e0a3 e0a3 e0b4 e0c8 e0cc e0d2 e0d4 e0d4 e5fa e62b e700 e7c5 f000 f2e0 e200 e2a9 f400 f4a8 2665 2665 26A1 26A1 f27c f27c f300 f313 23fb 23fe 2b58 2b58 f500 fd46 e300 e3eb
-
-  echo; echo
 }
 
 wrappingValue="$1"

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -162,7 +162,7 @@ function test-fonts() {
   echo; echo
 
   echo "Nerd Fonts - Font Logos"
-  print-unicode-ranges f300 f313
+  print-unicode-ranges f300 f32f
   echo; echo
 
   echo "Nerd Fonts - Font Power Symbols"

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -23,6 +23,7 @@ function print-decimal-unicode-range() {
   local allChars=""
   local allCodes=""
   local wrapAt=16
+  [[ "$wrappingValue" =~ ^[0-9]+$ ]] && [ "$wrappingValue" -gt 2 ] && wrapAt="$wrappingValue"
   local topLineStart="${bgColorBorder}╔═══"
   local topLineMiddle="═══╦═══"
   local topLineEnd="═══╗${reset_color}"
@@ -181,5 +182,7 @@ function test-fonts() {
 
   echo; echo
 }
+
+wrappingValue="$1"
 
 test-fonts

--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.0.1
-# Script Version: 1.1.0
+# Script Version: 1.1.1
 
 # Run this script in your local bash:
 # curl https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/bin/scripts/test-fonts.sh | bash
@@ -58,15 +58,20 @@ function print-decimal-unicode-range() {
     local hexCode
     hexCode=$(printf '%x' "${decimalCode}")
     local code="${hexCode}"
-    local char="\\u${hexCode}"
+    local char="\\U${hexCode}"
 
     # fill in placeholder cells properly formatted:
-    if [ "${char}" = "\\u0" ]; then
+    if [ "${char}" = "\\U0" ]; then
       char=" "
-      code="    "
+      code=""
     fi
 
-    allCodes+="${currentColorCode} ${underline}${code}${reset_color}${currentColorCode} ${reset_color}$bar"
+    filler=""
+    for ((c = ${#code}; c < 5; c++)); do
+      filler=" ${filler}"
+    done
+
+    allCodes+="${currentColorCode}${filler}${underline}${code}${reset_color}${currentColorCode} ${reset_color}$bar"
     allChars+="${currentColorChar}  ${char}   ${reset_color}$bar"
     counter=$((counter + 1))
     count=$(( (count + 1) % wrapAt))


### PR DESCRIPTION
#### Description

_The line decorations are hardcoded to 5 elements, with these changes you just need to change the `wrapAt` varible and the line decorations length will change as well_

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [X] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Change the printing method of decorations.
#### How should this be manually tested?
Just change `wrapAt` variable and execute the script.
#### Any background context you can provide?
The default value wastes a lot of usable space in the terminal.
#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
Example with length of 16 elements.
![Screenshot from 2023-05-30 20-08-06](https://github.com/ryanoasis/nerd-fonts/assets/53124818/eac509c1-6813-48f2-b5a4-dd48becca192)
