### PR TITLE
Allow not renaming the font with parameter

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.3.4"
+script_version = "4.3.5"
 
 version = "3.0.1"
 projectName = "Nerd Fonts"
@@ -450,7 +450,7 @@ class font_patcher:
                 for idx in range(source_font.num_fonts):
                     logger.debug("Tweaking %d/%d", idx + 1, source_font.num_fonts)
                     xwidth_s = ''
-                    xwidth = self.xavgwidth[idx]
+                    xwidth = self.xavgwidth[idx] if len(self.xavgwidth) > idx else None
                     if isinstance(xwidth, int):
                         if isinstance(xwidth, bool) and xwidth:
                             source_font.find_table([b'OS/2'], idx)

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.3.5"
+script_version = "4.4.0"
 
 version = "3.0.1"
 projectName = "Nerd Fonts"
@@ -706,7 +706,9 @@ class font_patcher:
         fullname   = replace_font_name(fullname,   additionalFontNameReplacements2)
         fontname   = replace_font_name(fontname,   additionalFontNameReplacements2)
 
-        if not (FontnameParserOK and self.args.makegroups > 0):
+        if self.args.makegroups < 0:
+            logger.warning("Renaming disabled! Make sure to comply with font license, esp RFN clause!")
+        elif not (FontnameParserOK and self.args.makegroups > 0):
             # replace any extra whitespace characters:
             font.familyname = " ".join(familyname.split())
             font.fullname   = " ".join(fullname.split())
@@ -1829,17 +1831,18 @@ def setup_arguments():
     parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
     parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
     parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')
-    parser.add_argument('--makegroups',                              dest='makegroups',       default=1,     type=int, nargs='?', help='Use alternative method to name patched fonts (recommended)', const=1, choices=range(0, 6 + 1))
+    parser.add_argument('--makegroups',                              dest='makegroups',       default=1,     type=int, nargs='?', help='Use alternative method to name patched fonts (recommended)', const=1, choices=range(-1, 6 + 1))
     # --makegroup has an additional undocumented numeric specifier. '--makegroup' is in fact '--makegroup 1'.
     # Original font name: Hugo Sans Mono ExtraCondensed Light Italic
-    #                                                             NF  Fam agg.
-    # 0  turned off, use old naming scheme                        [-] [-] [-]
-    # 1  HugoSansMono Nerd Font ExtraCondensed Light Italic       [ ] [ ] [ ]
-    # 2  HugoSansMono Nerd Font ExtCn Light Italic                [ ] [X] [ ]
-    # 3  HugoSansMono Nerd Font XCn Lt It                         [ ] [X] [X]
-    # 4  HugoSansMono NF ExtraCondensed Light Italic              [X] [ ] [ ]
-    # 5  HugoSansMono NF ExtCn Light Italic                       [X] [X] [ ]
-    # 6  HugoSansMono NF XCn Lt It                                [X] [X] [X]
+    #                                                              NF  Fam agg.
+    # -1  no renaming at all (keep old names and versions etc)     --- --- ---
+    #  0  turned off, use old naming scheme                        [-] [-] [-]
+    #  1  HugoSansMono Nerd Font ExtraCondensed Light Italic       [ ] [ ] [ ]
+    #  2  HugoSansMono Nerd Font ExtCn Light Italic                [ ] [X] [ ]
+    #  3  HugoSansMono Nerd Font XCn Lt It                         [ ] [X] [X]
+    #  4  HugoSansMono NF ExtraCondensed Light Italic              [X] [ ] [ ]
+    #  5  HugoSansMono NF ExtCn Light Italic                       [X] [X] [ ]
+    #  6  HugoSansMono NF XCn Lt It                                [X] [X] [X]
 
     parser.add_argument('--variable-width-glyphs',                   dest='nonmono',          default=False, action='store_true', help='Do not adjust advance width (no "overhang")')
     parser.add_argument('--has-no-italic',                           dest='noitalic',         default=False, action='store_true', help='Font family does not have Italic (but Oblique)')

--- a/font-patcher
+++ b/font-patcher
@@ -334,7 +334,6 @@ class font_patcher:
         self.sourceFont = font
         self.setup_version()
         self.get_essential_references()
-        self.setup_name_backup(font)
         self.assert_monospace()
         self.remove_ligatures()
         self.get_sourcefont_dimensions()
@@ -2007,6 +2006,7 @@ def main():
                 subfont)
             sys.exit(1)
 
+        patcher.setup_name_backup(sourceFonts[-1])
         patcher.patch(sourceFonts[-1])
 
     print("Done with Patch Sets, generating font...")

--- a/font-patcher
+++ b/font-patcher
@@ -433,14 +433,14 @@ class font_patcher:
                 sanitize_filename(self.args.outputdir, True),
                 sanitize_filename(fontname) + self.args.extension))
             bitmaps = str()
-            if len(self.sourceFont.bitmapSizes):
-                logger.debug("Preserving bitmaps %s", repr(self.sourceFont.bitmapSizes))
+            if len(sourceFont.bitmapSizes):
+                logger.debug("Preserving bitmaps %s", repr(sourceFont.bitmapSizes))
                 bitmaps = str('otf') # otf/ttf, both is bf_ttf
             if self.args.dry_run:
                 logger.debug("=====> Filename '%s'", outfile)
                 return
             sourceFont.generate(outfile, bitmap_type=bitmaps, flags=gen_flags)
-            message = "   {}\n   \===> '{}'".format(self.sourceFont.fullname, outfile)
+            message = "   {}\n   \===> '{}'".format(sourceFont.fullname, outfile)
 
         # Adjust flags that can not be changed via fontforge
         if re.search('\\.[ot]tf$', self.args.font, re.IGNORECASE) and re.search('\\.[ot]tf$', outfile, re.IGNORECASE):


### PR DESCRIPTION
#### Description

Add a flag for the user to not-rename (not touch) the name fields.

This can be useful for Visual Strudio and Cascadia Code, see https://github.com/ryanoasis/nerd-fonts/issues/1242#issuecomment-1575490749

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

See description.

Also corrects some logic errors (that do not really have an effect, but are nonetheless wrong).

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

Are in the issue.