### PR TITLE
archive-fonts: Unify README handling

### DIFF
--- a/src/archive-readme.md
+++ b/src/archive-readme.md
@@ -1,8 +1,0 @@
-
-# Nerd Fonts
-
-This is an archived font from a Nerd Fonts release.
-
-For more information see:
-* https://github.com/ryanoasis/nerd-fonts/
-* https://github.com/ryanoasis/nerd-fonts/releases/latest/


### PR DESCRIPTION
**[why]**
The readmes in the zip and tar.xz archives differ. The zips have only a very small and generic `readme.md`. The tar.xz have that readme as well as the `README.md` from the patched-fonts/ directory. This should be the same for both.

To have two files with names that just differ in case (`readme.md` and `README.md`) can be problematic on some platforms.

**[how]**
Combine both readmes into one file - put the generic info in the top of the readme.

Also include the RELEASE_VERSION if known into the readme. That makes it more easy to identify which Nerd Font release that archive came from.

RELEASE_VERSION is set in the release workflow.

Fixes: #1284

Reported-by: Jan Klass <kissaki@posteo.de>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
