### PR TITLE
Feature: Select name source

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1825,12 +1825,12 @@ def setup_arguments():
     parser.add_argument('-c', '--complete',                          dest='complete',         default=False, action='store_true', help='Add all available Glyphs')
     parser.add_argument('--careful',                                 dest='careful',          default=False, action='store_true', help='Do not overwrite existing glyphs if detected')
     parser.add_argument('--removeligs', '--removeligatures',         dest='removeligatures',  default=False, action='store_true', help='Removes ligatures specificed in JSON configuration file')
-    parser.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str, nargs='?', help='Specify a Script for Post Processing')
-    parser.add_argument('--configfile',                              dest='configfile',       default=False, type=str, nargs='?', help='Specify a file path for JSON configuration file (see sample: src/config.sample.json)')
-    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str, nargs='?', help='Specify a custom symbol font, all glyphs will be copied; absolute path suggested')
-    parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str, nargs='?', help='Change font file type to create (e.g., ttf, otf)')
-    parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str, nargs='?', help='The directory to output the patched font file to')
-    parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, nargs='?', help='Path to glyphs to be used for patching')
+    parser.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str,            help='Specify a Script for Post Processing')
+    parser.add_argument('--configfile',                              dest='configfile',       default=False, type=str,            help='Specify a file path for JSON configuration file (see sample: src/config.sample.json)')
+    parser.add_argument('--custom',                                  dest='custom',           default=False, type=str,            help='Specify a custom symbol font, all glyphs will be copied; absolute path suggested')
+    parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str,            help='Change font file type to create (e.g., ttf, otf)')
+    parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str,            help='The directory to output the patched font file to')
+    parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, help='Path to glyphs to be used for patching')
     parser.add_argument('--makegroups',                              dest='makegroups',       default=1,     type=int, nargs='?', help='Use alternative method to name patched fonts (recommended)', const=1, choices=range(-1, 6 + 1))
     # --makegroup has an additional undocumented numeric specifier. '--makegroup' is in fact '--makegroup 1'.
     # Original font name: Hugo Sans Mono ExtraCondensed Light Italic

--- a/font-patcher
+++ b/font-patcher
@@ -1831,7 +1831,7 @@ def setup_arguments():
     parser.add_argument('-ext', '--extension',                       dest='extension',        default="",    type=str,            help='Change font file type to create (e.g., ttf, otf)')
     parser.add_argument('-out', '--outputdir',                       dest='outputdir',        default=".",   type=str,            help='The directory to output the patched font file to')
     parser.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, help='Path to glyphs to be used for patching')
-    parser.add_argument('--makegroups',                              dest='makegroups',       default=1,     type=int, nargs='?', help='Use alternative method to name patched fonts (recommended)', const=1, choices=range(-1, 6 + 1))
+    parser.add_argument('--makegroups',                              dest='makegroups',       default=1,     type=int, nargs='?', help='Use alternative method to name patched fonts (default=1)', const=1, choices=range(-1, 6 + 1))
     # --makegroup has an additional undocumented numeric specifier. '--makegroup' is in fact '--makegroup 1'.
     # Original font name: Hugo Sans Mono ExtraCondensed Light Italic
     #                                                              NF  Fam agg.

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.4.2"
+script_version = "4.5.0"
 
 version = "3.0.2"
 projectName = "Nerd Fonts"
@@ -557,17 +557,28 @@ class font_patcher:
         additionalFontNameSuffix = " " + projectNameSingular + variant_full + additionalFontNameSuffix
 
         if FontnameParserOK and self.args.makegroups > 0:
-            use_fullname = isinstance(font.fullname, str) # Usually the fullname is better to parse
-            # Use fullname if it is 'equal' to the fontname
-            if font.fullname:
-                use_fullname |= font.fontname.lower() == FontnameTools.postscript_char_filter(font.fullname).lower()
-            # Use fullname for any of these source fonts (that are impossible to disentangle from the fontname, we need the blanks)
-            for hit in [ 'Meslo' ]:
-                use_fullname |= font.fontname.lower().startswith(hit.lower())
-            parser_name = font.fullname if use_fullname else font.fontname
-            # Gohu fontnames hide the weight, but the file names are ok...
-            if parser_name.startswith('Gohu'):
-                parser_name = os.path.splitext(os.path.basename(self.args.font))[0]
+            if not isinstance(self.args.force_name, str):
+                use_fullname = isinstance(font.fullname, str) # Usually the fullname is better to parse
+                # Use fullname if it is 'equal' to the fontname
+                if font.fullname:
+                    use_fullname |= font.fontname.lower() == FontnameTools.postscript_char_filter(font.fullname).lower()
+                # Use fullname for any of these source fonts (that are impossible to disentangle from the fontname, we need the blanks)
+                for hit in [ 'Meslo' ]:
+                    use_fullname |= font.fontname.lower().startswith(hit.lower())
+                parser_name = font.fullname if use_fullname else font.fontname
+                # Gohu fontnames hide the weight, but the file names are ok...
+                if parser_name.startswith('Gohu'):
+                    parser_name = os.path.splitext(os.path.basename(self.args.font))[0]
+            else:
+                if self.args.force_name == 'full':
+                    parser_name = font.fullname
+                elif self.args.force_name == 'postscript':
+                    parser_name = font.fontname
+                else:
+                    parser_name = self.args.force_name
+                if not isinstance(parser_name, str) or len(parser_name) < 1:
+                    logger.critical("Specified --name not usable because the name will be empty")
+                    sys.exit(2)
             n = FontnameParser(parser_name, logger)
             if not n.parse_ok:
                 logger.warning("Have only minimal naming information, check resulting name. Maybe specify --makegroups 0")
@@ -719,9 +730,11 @@ class font_patcher:
             font.appendSFNTName(str('English (US)'), str('Compatible Full'), font.fullname)
             font.appendSFNTName(str('English (US)'), str('SubFamily'), subFamily)
         else:
-            short_family = projectNameAbbreviation + variant_abbrev if self.args.makegroups >= 4 else projectNameSingular + variant_full
-            # inject_suffix(family, ps_fontname, short_family)
-            n.inject_suffix(verboseAdditionalFontNameSuffix, ps_suffix, short_family)
+            # Add Nerd Font suffix unless user specifically asked for some excplicit name via --name
+            if not self.args.force_name or self.args.force_name == 'full' or self.args.force_name == 'postscript':
+                short_family = projectNameAbbreviation + variant_abbrev if self.args.makegroups >= 4 else projectNameSingular + variant_full
+                # inject_suffix(family, ps_fontname, short_family)
+                n.inject_suffix(verboseAdditionalFontNameSuffix, ps_suffix, short_family)
             n.rename_font(font)
 
         font.comment = projectInfo
@@ -1860,6 +1873,7 @@ def setup_arguments():
     # <none>  - copy from sourcefont (default)
     # 0       - calculate from font according to OS/2-version-2
     # 500     - set to 500
+    parser.add_argument('--name',                                    dest='force_name',       default=None, type=str,             help='Specify naming source (\'full\', \'postscript\', or concrete free name-string)')
 
     # symbol fonts to include arguments
     sym_font_group = parser.add_argument_group('Symbol Fonts')


### PR DESCRIPTION
#### Description

font-patcher: Add option to select postscript name as name source

**[why]**  
In the post we used these information sources to determine the name and
weights/styles of the to-be-patched font:
* The filename
* The fullname (ID 4)
* The postscriptname (ID 6)

Usually it is best to use the Fullname of a font to determine its real
name and styles/weights:

The Postscript name has the advantage to have a hyphen between name and
styles/weight; but as it can not contain blanks the correct name can not
be determined by this. To get the styles/weights back we use a list of
all possible (?!) weights and styles and sort all the string parts.

This works reasonably well and the fullname is usually best.

Not so with Input Mono Condensed. Here are its names:
ID4: `"InputMonoCondensed LightIta"`
ID6: `"InputMonoConsensed-LightItalic"`

**[how]**
Add option to select between fullname and postscriptname as font naming
source.

For special purposes, also allow a custom (arbitrary) name input.
If that is given the specified name will be used to name the patched
font without adding any suffix - the user has full control on the name.

Fixes: #1314

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
