### PR TITLE
install.sh: Honor XDG_DATA_HOME

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install Nerd Fonts
-__ScriptVersion="0.6"
+__ScriptVersion="0.7"
 
 # Default values for option variables:
 quiet=false
@@ -197,15 +197,20 @@ done
 # Get target root directory
 if [[ $(uname) == 'Darwin' ]]; then
   # MacOS
-  sys_font_dir="/Library/Fonts"
-  usr_font_dir="$HOME/Library/Fonts"
+  sys_share_dir="/Library"
+  usr_share_dir="$HOME/Library"
+  font_subdir="Fonts"
 else
   # Linux
-  sys_font_dir="/usr/local/share/fonts"
-  usr_font_dir="$HOME/.local/share/fonts"
+  sys_share_dir="/usr/local/share"
+  usr_share_dir="$HOME/.local/share"
+  font_subdir="fonts"
 fi
-sys_font_dir="${sys_font_dir}/NerdFonts"
-usr_font_dir="${usr_font_dir}/NerdFonts"
+if [ -n "${XDG_DATA_HOME}" ]; then
+  usr_share_dir="${XDG_DATA_HOME}"
+fi
+sys_font_dir="${sys_share_dir}/${font_subdir}/NerdFonts"
+usr_font_dir="${usr_share_dir}/${font_subdir}/NerdFonts"
 
 if [[ "system" == "$installpath" ]]; then
   font_dir="${sys_font_dir}"


### PR DESCRIPTION
**[why]**
When a user sets the `XDG_DATA_HOME` environment variable the default of `$HOME/.local/share` should not be used.

https://wiki.archlinux.org/title/XDG_Base_Directory

**[how]**
Enable `XDG_DATA_HOME` to override the default user data directory on Unix and MacOS platforms.

There is some controversy if `XDG_DATA_HOME` should be honored on MacOS, see for example platformdirs (link below). But me also working on Linux and MacOS (and Windows) in parallel, I can not quite follow the downsides and believe we should allow `XDG_DATA_HOME` also for MacOS.

Related: https://github.com/platformdirs/platformdirs/issues/4
Fixes: #1324

Suggested-by: Anthony Foglia <@afoglia>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

If envvar `XDG_DATA_HOME` is set and the user want to install into a user directory the default path is adjusted accordingly.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
