### PR TITLE
Describe patcher family-name generation in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,8 +362,8 @@ Patching the font of your own choosing:
   docker run --rm -v /path/to/fonts:/in:Z -v /path/for/output:/out:Z nerdfonts/patcher [OPTIONS]
   ```
 
-[!NOTE]
-The resulting font's family will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.
+> [!NOTE]
+> The resulting font's family will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.
 
 Full options:
 

--- a/readme.md
+++ b/readme.md
@@ -363,7 +363,7 @@ Patching the font of your own choosing:
   ```
 
 > [!NOTE]
-> The resulting font's family will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.
+> The resulting font's family (aka font name) will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.
 
 Full options:
 

--- a/readme.md
+++ b/readme.md
@@ -362,6 +362,9 @@ Patching the font of your own choosing:
   docker run --rm -v /path/to/fonts:/in:Z -v /path/for/output:/out:Z nerdfonts/patcher [OPTIONS]
   ```
 
+[!NOTE]
+The resulting font's family will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.
+
 Full options:
 
 ```


### PR DESCRIPTION
#### Description

updated the project's readme to mention that the font patcher CamelCases and removing whitespace from the resulting font's family names.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

the change contains GitHub's alert syntax, which might not render in the preview, but should render in the actual readme. (ref: https://github.com/orgs/community/discussions/16925#discussioncomment-6879962)

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
