### PR TITLE
font-patcher: Improve weight checking

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -283,10 +283,14 @@ class FontnameParser:
         os2_weight = font.os2_weight
         ps_weight = FontnameTools.weight_string_to_number(font.weight)
         name_weight = FontnameTools.weight_string_to_number(weight)
+        weightproblem = False
+        if ps_weight is None:
+            self.logger.warn('Can not parse PS-weight: {}'.format(restored_weight_token))
+            weightproblem = True
         if name_weight is None:
-            self.logger.error('Can not parse name for weight: {}'.format(restored_weight_token))
-            return
-        if abs(os2_weight - ps_weight) > 50 or abs(os2_weight - name_weight) > 50:
+            self.logger.warn('Can not parse name for weight: {}'.format(restored_weight_token))
+            weightproblem = True
+        if weightproblem or abs(os2_weight - ps_weight) > 50 or abs(os2_weight - name_weight) > 50:
             self.logger.warning('Possible problem with the weight metadata detected, check with --debug')
         self.logger.debug('Weight approximations: OS2/PS/Name: {}/{}/{} (from {}/\'{}\'/\'{}\')'.format(
             os2_weight, ps_weight, name_weight,

--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -285,10 +285,10 @@ class FontnameParser:
         name_weight = FontnameTools.weight_string_to_number(weight)
         weightproblem = False
         if ps_weight is None:
-            self.logger.warn('Can not parse PS-weight: {}'.format(restored_weight_token))
+            self.logger.warn('Can not parse PS-weight: {}'.format(font.weight))
             weightproblem = True
         if name_weight is None:
-            self.logger.warn('Can not parse name for weight: {}'.format(restored_weight_token))
+            self.logger.warn('Can not parse name for weight: {}'.format(weight))
             weightproblem = True
         if weightproblem or abs(os2_weight - ps_weight) > 50 or abs(os2_weight - name_weight) > 50:
             self.logger.warning('Possible problem with the weight metadata detected, check with --debug')

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -289,8 +289,9 @@ class FontnameTools:
         """ Convert a common string approximation to a PS/2 weight value """
         if not isinstance(w, str) or len(w) < 1:
             return 400
+        w = w.lower().replace('-', '').replace(' ', '')
         for num, strs in FontnameTools.equivalent_weights.items():
-            if w.lower() in strs:
+            if w in strs:
                 return num
         return None
 

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -287,7 +287,7 @@ class FontnameTools:
     @staticmethod
     def weight_string_to_number(w):
         """ Convert a common string approximation to a PS/2 weight value """
-        if not len(w):
+        if not isinstance(w, str) or len(w) < 1:
             return 400
         for num, strs in FontnameTools.equivalent_weights.items():
             if w.lower() in strs:

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.5.2"
+script_version = "4.5.3"
 
 version = "3.0.2"
 projectName = "Nerd Fonts"


### PR DESCRIPTION
[why]
When the font does not have a PSweight string the font-patcher bugs.

[how]
Rewrite the code to be more robust against unexpected weight values. Also make detected problems non-fatal.

Reported-by: František Hanzlík <frantisek_hanzlik@protonmail.com>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
