### PR TITLE
Solved: Responsive Design div.subtlecircle Overflow on Small Screens (< 767px) #1367

### DIFF
--- a/_includes/css/main.scss
+++ b/_includes/css/main.scss
@@ -287,3 +287,25 @@ nav ul li:hover, nav ul li.active {
 .longlist { font-size: 14px !important; }
 .longlist li { margin-bottom: 3px; }
 
+
+@media screen and (min-width: 990px) {
+  .row .subtitle-icon {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: inherit;
+  }
+}
+
+.subtitle-icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin: auto;
+  flex-wrap: wrap;
+}
+
+.container ol, .container ul { 
+  padding: 0 8%; 
+  margin: 20px;
+}

--- a/_posts/2017-01-02-features.md
+++ b/_posts/2017-01-02-features.md
@@ -63,7 +63,7 @@ style: container
             <div class="subtitle-icon">
       <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
         <div>
-          <img src="/assets/img/nerd-fonts-patched-fonts.svg" alt="Preview of Patched Fonts">
+          <img src="./assets/img/nerd-fonts-patched-fonts.svg" alt="Preview of Patched Fonts">
         </div>
       </div>
             </div>
@@ -105,11 +105,11 @@ style: container
         </div>
         <div class="col-xs-12 col-md-3 col-lg-4">
           <a href="https://github.com/oh-my-fish/oh-my-fish" target="_blank" aria-label="Go to The Fish Shell Framework Github Page" rel="noreferrer">
-          <h3><img src="/assets/img/Fish-Shell-Network.svg" alt="The Fish Shell Framework" /></h3>
+          <h3><img src="./assets/img/Fish-Shell-Network.svg" alt="The Fish Shell Framework" /></h3>
           <h4>The Fish Shell Framework</h4></a><p>Oh My Fish provides core infrastructure to allow you to install packages which extend or modify the look of your shell. It's fast, extensible and easy to use.</p>
         </div>
         <div class="col-xs-12 col-md-3 col-lg-4">
-          <a href="https://github.com/ryanoasis/vim-devicons" target="_blank" aria-label="Go to VimDevIcons Github Page" rel="noreferrer"><h3><img src="/assets/img/VimDevIcons.svg" alt="VimDevIcons" /></h3>
+          <a href="https://github.com/ryanoasis/vim-devicons" target="_blank" aria-label="Go to VimDevIcons Github Page" rel="noreferrer"><h3><img src="./assets/img/VimDevIcons.svg" alt="VimDevIcons" /></h3>
           <h4>VimDevIcons</h4></a><p>Adds Icons to your Vim Plugins</p>
           <h3 class="faux-logo"><a href="https://github.com/Peltoche/lsd" target="_blank" aria-label="Go to LSD (LSDeluxe) Github Page" rel="noreferrer">LSD (LSDeluxe)</a></h3>
           <!-- <h4>LSD (LSDeluxe)</h4> --><p>The next gen ls command. Written in Rust and fast.</p>
@@ -129,17 +129,17 @@ style: container
       <div class="subtitle-icon">
           <div class="col-lg-4">
             <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
-              <img src="/assets/img/nerd-fonts-powerline-extra-terminal.png" alt="Preview of Powerline Extra Symbols usage in terminal emulator">
+              <img src="./assets/img/nerd-fonts-powerline-extra-terminal.png" alt="Preview of Powerline Extra Symbols usage in terminal emulator">
             </div>
           </div>
           <div class="col-lg-4">
             <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
-              <img src="/assets/img/nerd-fonts-icons-in-terminal.png" alt="Preview of Nerd Fonts Icons usage in terminal emulator">
+              <img src="./assets/img/nerd-fonts-icons-in-terminal.png" alt="Preview of Nerd Fonts Icons usage in terminal emulator">
             </div>
           </div>
           <div class="col-lg-4">
             <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
-              <img src="/assets/img/nerd-fonts-icons-in-vim.png" alt="Preview of Nerd Fonts Icons usage in terminal Vim">
+              <img src="./assets/img/nerd-fonts-icons-in-vim.png" alt="Preview of Nerd Fonts Icons usage in terminal Vim">
             </div>
           </div>
       </div>

--- a/_posts/2017-01-02-features.md
+++ b/_posts/2017-01-02-features.md
@@ -16,7 +16,7 @@ style: container
     <div class="feature-section">
       <h2>All the icons!</h2>
       <h3>{{ site.metrics.icons }}+ icons combined from popular sets</h3>
-      <div class="row">
+      <div class="row subtitle-icon">
       <!-- <div class="col-sm-12 col-md-8 col-lg-8"> -->
       <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
         <div>
@@ -31,7 +31,7 @@ style: container
         </div>
       </div>
       </div><!-- end inner row -->
-      <div class="row subtitle-icon">
+      <div class="row">
       <!--</div> end inner col -->
       <!-- <div class="col-sm-12 col-md-4 col-lg-4"> -->
       <ul>
@@ -59,7 +59,7 @@ style: container
     <div class="col-xs-12 col-md-6 col-lg-6">
     <div class="feature-section">
       <h2>The best developer fonts</h2>
-      <h3>{{ site.metrics.fonts }}+ patched and ready to use programming fonts</h3>
+      <h3> {{ site.metrics.fonts }} + patched and ready to use programming fonts</h3>
             <div class="subtitle-icon">
       <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
         <div>

--- a/_posts/2017-01-02-features.md
+++ b/_posts/2017-01-02-features.md
@@ -31,7 +31,7 @@ style: container
         </div>
       </div>
       </div><!-- end inner row -->
-      <div class="row">
+      <div class="row subtitle-icon">
       <!--</div> end inner col -->
       <!-- <div class="col-sm-12 col-md-4 col-lg-4"> -->
       <ul>
@@ -60,11 +60,13 @@ style: container
     <div class="feature-section">
       <h2>The best developer fonts</h2>
       <h3>{{ site.metrics.fonts }}+ patched and ready to use programming fonts</h3>
+            <div class="subtitle-icon">
       <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
         <div>
           <img src="/assets/img/nerd-fonts-patched-fonts.svg" alt="Preview of Patched Fonts">
         </div>
       </div>
+            </div>
       <ul>
         <li>Hack</li>
         <li>FiraCode</li>
@@ -124,6 +126,7 @@ style: container
       <h3>Experiment &amp; see what's possible in the terminal with Powerline &amp; other glyphs</h3>
       <div class="row center">
         <!-- <div class="col-sm-12 col-md-7 col-lg-7"> -->
+      <div class="subtitle-icon">
           <div class="col-lg-4">
             <div class="subtlecircle sectiondivider faicon sectioninner sectioninner3">
               <img src="/assets/img/nerd-fonts-powerline-extra-terminal.png" alt="Preview of Powerline Extra Symbols usage in terminal emulator">
@@ -139,6 +142,7 @@ style: container
               <img src="/assets/img/nerd-fonts-icons-in-vim.png" alt="Preview of Nerd Fonts Icons usage in terminal Vim">
             </div>
           </div>
+      </div>
           <p>
             All patched fonts have Powerline symbols, extra powerline symbols and many icons to choose from. Build your own status line, add icons to filetypes, make visual grepping easier. You are only limited by your imagination.
           </p>


### PR DESCRIPTION
#### Description

To solve the overflow problem of `div.subtitlecircle`, the following CSS has been added:
``` 
@media screen and (min-width: 990px) {
  .row .subtitle-icon {
    display: flex;
    flex-wrap: wrap;
    flex-direction: inherit;
  }
}

.subtitle-icon {
  display: flex;
  justify-content: center;
  align-items: center;
  flex-direction: column;
  margin: auto;
  flex-wrap: wrap;
}

.container ol, .container ul { 
  padding: 0 8%; 
  margin: 20px;
}
```
The .subtitle-icon class is added to the parent element (wrapper) of div.subtlecircle, preventing the element from overflowing and aligning it to the center of the features section. The media query is specifically added to resolve the overflow of the Terminal Fonts subtitle icon without creating a new class or adding specific styling(i have reused the css class which i made for features section). This approach efficiently reuses existing CSS classes.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I have also test the code locally.
- [x] All necessary checks and test are done.

#### What does this Pull Request (PR) do?
This PR addresses issue #1367. The issue involved the div.subtlecircle element overflowing its parent container below a width of 767px. The same issue was observed in the Terminal Fonts Examples container, where the div.subtlecircle images also overflowed below this width, leading to a design problem for smaller screen sizes.

#### How should this be manually tested?
After implementing the solution, I tested this application locally on my machine using Chrome DevTools. I ensured that it works well across various screen sizes.


#### Screenshots (if appropriate or helpful)
Before:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/a2b08b07-2672-4a84-8751-f7436bdb0819)

After:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/c59d8721-0b18-4957-826d-e86915b20b00)

Before:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/00afb7c6-0379-48c1-b21e-43bd0fc98b92)

After:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/f1cae6af-9343-422e-9773-0a0207ae3ca6)

(Note: Apologies for not capturing a screenshot of the terminal font section, but I can assure you that it functions correctly. You can verify it as well.)