### PR TITLE
Implement GitHub Icon for Improved Accessibility to Repository - Issue #1372

### DIFF
--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -541,7 +541,7 @@ a.nerd-font-button:before {
 
 #github {
 	text-decoration: none;
-	color: #ffffff;
+	color: #000000;
 	background-color: #ffffff;
 	width: 60px;
 	height: 60px;

--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -475,67 +475,6 @@ a.nerd-font-button:before {
 	margin-left: -135px;
 }
 
-/* ----- fork on github banner ----- */
-/*
-#forkongithub a {
-	color: #fff;
-	background: #1E5D8A;
-	text-decoration: none;
-	font-family: arial, sans-serif;
-	text-align: center;
-	font-weight: 700;
-	font-size: 1rem;
-	line-height: 2rem;
-	position: relative;
-	transition: .5s;
-	padding: 5px 40px;
-}
-
-#forkongithub a::before,
-#forkongithub a::after {
-	content: "";
-	width: 100%;
-	display: block;
-	position: absolute;
-	top: 1px;
-	left: 0;
-	height: 1px;
-	background: #fff;
-}
-
-#forkongithub a::after {
-	bottom: 1px;
-	top: auto;
-}
-
-@media screen and (min-width:800px) {
-	#forkongithub {
-		position: fixed;
-		display: block;
-		top: 0;
-		right: 0;
-		width: 200px;
-		overflow: hidden;
-		height: 209px;
-		z-index: 99;
-	}
-
-	#forkongithub a {
-		width: 200px;
-		position: absolute;
-		top: 60px;
-		right: -60px;
-		transform: rotate(45deg);
-		-webkit-transform: rotate(45deg);
-		-ms-transform: rotate(45deg);
-		-moz-transform: rotate(45deg);
-		-o-transform: rotate(45deg);
-		box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.8);
-		box-sizing: content-box;
-	}
-}
-*/
-
 // Github url button
 #github {
 	text-decoration: none;

--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -535,10 +535,8 @@ a.nerd-font-button:before {
 	}
 }
 */
+
 // Github url button
-
-@import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
-
 #github {
 	text-decoration: none;
 	color: #000000;

--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -310,12 +310,12 @@ a.nerd-font-button:before {
 	font-size: 2em
 }
 
-#forkongithub .nf {
-	font-size: 1.25rem;
-}
+// #forkongithub .nf {
+// 	font-size: 1.25rem;
+// }
 
 /* for any ASCII :) */
-
+/*
 #forkongithub span {
 	font-size: 1.75rem;
 }
@@ -323,7 +323,7 @@ a.nerd-font-button:before {
 #forkongithub a {
 	display: inline-block;
 }
-
+*/
 /* color scheme */
 
 .nf1 {
@@ -476,6 +476,7 @@ a.nerd-font-button:before {
 }
 
 /* ----- fork on github banner ----- */
+/*
 #forkongithub a {
 	color: #fff;
 	background: #1E5D8A;
@@ -532,6 +533,28 @@ a.nerd-font-button:before {
 		box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.8);
 		box-sizing: content-box;
 	}
+}
+*/
+// Github url button
+
+@import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
+
+#github {
+	text-decoration: none;
+	color: #ffffff;
+	background-color: #ffffff;
+	width: 60px;
+	height: 60px;
+	text-align: center;
+	line-height: 60px;
+	border-radius: 25%;
+	font-size: 2.5em;
+	box-shadow: 2px 2px 5px rgba(0, 0, 0, .8);
+	transition: all .3s ease-in-out;
+	position: fixed;
+	bottom: 0.7rem;
+	right: 0.7rem;
+	z-index: 10;
 }
 
 .icon-backdrop {

--- a/_posts/2017-01-01-home.md
+++ b/_posts/2017-01-01-home.md
@@ -42,11 +42,6 @@ style: center container
 </a>
 <div class="text-left"><small><sub><em>Diagram created using <a href="http://sankeymatic.com/" title="SankeyMATIC (BETA): A Sankey diagram builder for everyone">SankeyMATIC</a></em></sub></small></div>
 </div>
-<span id="forkongithub">
-  <a href="{{ site.source_link }}">
-    <i class="nf nf-fa-code_fork"></i> Fork us on GitHub <i class="nf nf-fa-heart ow"></i>
-  </a>
-</span>
 
 <!--
 Repo References

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <div id="main">
     <div class="container">
       <a href="https://github.com/ryanoasis/nerd-fonts/tree/master" target="_blank" id="github"
-        class="fa fa-github"></a>
+        class="nf nf-fa-github"></a>
     </div>
     {% include topnav.html %}
     {% for page in site.posts reversed %}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <body>
   <div id="main">
     <div class="container">
-      <a href="https://github.com/ryanoasis/nerd-fonts/tree/master" target="_blank" id="github"
+      <a href="https://github.com/ryanoasis/nerd-fonts" target="_blank" id="github"
         class="nf nf-fa-github"></a>
     </div>
     {% include topnav.html %}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
 {% include header.html %}
 <body>
   <div id="main">
+    <div class="container">
+      <a href="https://github.com/ryanoasis/nerd-fonts/tree/master" target="_blank" id="github"
+        class="fa fa-github"></a>
+    </div>
     {% include topnav.html %}
     {% for page in site.posts reversed %}
       {% if page.page == nil %}


### PR DESCRIPTION
#### Description

Implemented Solution 2 to address the user experience issue with the "Fork-me" banner on smaller screens. Added a GitHub icon in the bottom left corner with margin and padding. This icon serves as a persistent and easily accessible link to the GitHub repository.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

This pull request enhances the user experience by providing a persistent link to the GitHub repository through a GitHub icon in the bottom left corner of the page.

#### How should this be manually tested?

1. Visit the website (https://vitthalgund.github.io/nerd-fonts/).
2. Observe the presence of the GitHub icon in the bottom left corner.
3. Click the icon to ensure it redirects to the GitHub repository (https://github.com/ryanoasis/nerd-fonts).

#### Any background context you can provide?

This PR is a response to issue #1372, which identified an issue with the "Fork-me" banner on smaller screens.

#### What are the relevant tickets (if any)?

This PR is related to issue #1372.

Fixes: #1366 
Fixes: #1372

#### Screenshots (if appropriate or helpful)
#### Before:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/81daeea8-8a9a-452c-b7a3-b0f4d8424230)

#### After:
![image](https://github.com/ryanoasis/nerd-fonts/assets/97181033/d68ef0b0-a264-4ed4-b36a-b3936df86e55)

