### PR TITLE
doc: Correct name for AnonymicePro Nerd Font

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ See [Wiki: Icon names in shell][wiki-icon-names-in-shell]
 |:--------------------------------------------------|:----------------------------------|:------|:-----|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | 3.0.1 | NO   | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | 37    | NO   | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | NO   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | NO   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | NO   | ![w] ![m2] ![l]   |

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -182,7 +182,7 @@ echo $i_oct_heart
 |:--------------------------------------------------|:----------------------------------|:------|:-----|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | 3.0.1 | NO   | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | 37    | NO   | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | NO   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | NO   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | NO   | ![w] ![m2] ![l]   |

--- a/readme_es.md
+++ b/readme_es.md
@@ -114,7 +114,7 @@ Ve a la [Wiki: Nombres de iconos en la shell][wiki-icon-names-in-shell]
 |:--------------------------------------------------|:----------------------------------|:------|:-----|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | 3.0.1 | NO   | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | 37    | NO   | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | NO   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | NO   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | NO   | ![w] ![m2] ![l]   |

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -195,7 +195,7 @@ echo $i_oct_heart
 | Nom de la police                                  | Nom de la police et dépôt         |\*RFN | EM Size | Statut            |
 |:--------------------------------------------------|:----------------------------------|:-----|:--------|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | NO   | 1000    | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                   | NO   | 1000    | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  |                                   | NO   | 1200    | ![w] ![m2] ![l]   |

--- a/readme_it.md
+++ b/readme_it.md
@@ -113,7 +113,7 @@ Leggi la [Wiki: Nomi delle Icone per la shell][wiki-icon-names-in-shell]
 |:--------------------------------------------------|:----------------------------------|:-----|:--------|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | NO   | 1000    | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | NO   | 2048    | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                   | NO   | 1000    | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  |                                   | NO   | 1200    | ![w] ![m2] ![l]   |

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -110,7 +110,7 @@ _あなたがもし……_
 |:--------------------------------------------------|:-----------------------------------|:------|:----------|:-----------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                     | NO    | 1000      | ![w] ![m2] ![l]  |
 | [Agave][p-agave]                                  | [Agave][f-agave]                   | NO    | 2048      | ![w] ![m2] ![l]  |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]           | NO    | 2048      | ![w] ![m2] ![l]  |
+| [AnonymicePro Nerd Font][p-anonymous-pro]          | [Anonymous Pro][f-a-pro]           | NO    | 2048      | ![w] ![m2] ![l]  |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                   | NO    | 2048      | ![w] ![m2] ![l]  |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                    | NO    | 1000      | ![w] ![m2] ![l]  |
 | [BigBlueTerminal][p-bigblueterm]                  |                                    | NO    | 1200      | ![w] ![m2] ![l]  |

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -111,7 +111,7 @@ _만약..._
 |:--------------------------------------------------|:----------------------------------|:-----|:--------|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | NO   | 1000    | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | NO   | 2048    | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                   | NO   | 1000    | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  |                                   | NO   | 1200    | ![w] ![m2] ![l]   |

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -188,7 +188,7 @@ echo $i_oct_heart
 | Nazwa fontu                                       | Nazwa fontu i repozytorium        |\*RFN | Rozmiar EM | Status            |
 |:--------------------------------------------------|:----------------------------------|:-----|:--------|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | NO   | 1000    | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | NO   | 2048    | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                   | NO   | 1000    | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  |                                   | NO   | 1200    | ![w] ![m2] ![l]   |

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -108,7 +108,7 @@ See [Wiki: Nomes dos ícones em Unix Shell][wiki-icon-names-in-shell]
 | :------------------------------------------------ | :---------------------------------- | :---- | :--------- | :--------------- |
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                      | NÃO   | 1000       | ![w] ![m2] ![l]  |
 | [Agave][p-agave]                                  | [Agave][f-agave]                    | NÃO   | 2048       | ![w] ![m2] ![l]  |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]            | NÃO   | 2048       | ![w] ![m2] ![l]  |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]            | NÃO   | 2048       | ![w] ![m2] ![l]  |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                    | NÃO   | 2048       | ![w] ![m2] ![l]  |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                     | NÃO   | 1000       | ![w] ![m2] ![l]  |
 | [BigBlueTerminal][p-bigblueterm]                  |                                     | NÃO   | 1200       | ![w] ![m2] ![l]  |

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -114,7 +114,7 @@ See [Wiki: Icon names in shell][wiki-icon-names-in-shell]
 |:--------------------------------------------------|:----------------------------------|:------|:-----|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | 3.0.1 | НЕТ   | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | 37    | НЕТ   | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | 1.002 | ДА  | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | 1.002 | ДА  | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | НЕТ   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | НЕТ   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | НЕТ   | ![w] ![m2] ![l]   |

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -110,7 +110,7 @@ _如果你..._
 |:--------------------------------------------------|:----------------------------------|:------|:-----|:------------------|
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                    | 3.0.1 | NO   | ![w] ![m2] ![l]   |
 | [Agave][p-agave]                                  | [Agave][f-agave]                  | 37    | NO   | ![w] ![m2] ![l]   |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]          | 1.002 | YES  | ![w] ![m2] ![l]   |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                  | 1.33  | NO   | ![w] ![m2] ![l]   |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        | Stephen G. Hartke                 |       | NO   | ![w] ![m2] ![l]   |
 | [BigBlueTerminal][p-bigblueterm]                  | VileR                             |       | NO   | ![w] ![m2] ![l]   |

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -112,7 +112,7 @@ _Якщо ви..._
 | :------------------------------------------------ | :--------------------------------- | :---- | :------ | :--------------- |
 | [3270 Nerd Font][p-3270]                          | [3270][f-3270]                     | NO    | 1000    | ![w] ![m2] ![l]  |
 | [Agave][p-agave]                                  | [Agave][f-agave]                   | NO    | 2048    | ![w] ![m2] ![l]  |
-| [Anonymice Nerd Font][p-anonymous-pro]            | [Anonymous Pro][f-a-pro]           | NO    | 2048    | ![w] ![m2] ![l]  |
+| [AnonymicePro Nerd Font][p-anonymous-pro]         | [Anonymous Pro][f-a-pro]           | NO    | 2048    | ![w] ![m2] ![l]  |
 | [Arimo][p-arimo]                                  | [Arimo][f-arimo]                   | NO    | 2048    | ![w] ![m2] ![l]  |
 | [Aurulent Sans Mono Nerd Font][p-aurulent]        |                                    | NO    | 1000    | ![w] ![m2] ![l]  |
 | [BigBlueTerminal][p-bigblueterm]                  |                                    | NO    | 1200    | ![w] ![m2] ![l]  |


### PR DESCRIPTION
#### Description

The AnonymicePro Nerd Font is incorrectly named Anonymice Nerd Font.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
