### PR TITLE
Issue with Subtitle Circle and Layout on Smaller Screens #1384 fixed

### DIFF
--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -14,7 +14,7 @@ input.nerd-font-input {
 }
 
 .highlight {
-	display: inline-block;
+	display: block;
 	width: auto;
 	margin: 0pt auto;
 }
@@ -466,8 +466,8 @@ a.nerd-font-button:before {
 }
 
 .section-page-wrapper .sectiondivider {
-	width: 270px;
-	height: 270px;
+	width: fit-content;
+	height: fit-content;
 	padding: 15px;
 	position: relative;
 	top: 0px;
@@ -703,8 +703,8 @@ a.nerd-font-button:before {
 
 	.section-page-wrapper .sectiondivider,
 	.sectiondivider {
-		width: 200px;
-		height: 200px;
+		width: fit-content;
+		height: fit-content;
 		padding: 15px;
 		margin-left: -100px;
 	}

--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -435,7 +435,7 @@ a.nerd-font-button:before {
 }
 
 .sectioninner3 {
-	line-height: 29px;
+	line-height: 29.5px;
 	word-spacing: 3px;
 	top: inherit;
 	left: inherit;
@@ -733,7 +733,7 @@ a.nerd-font-button:before {
 	}
 
 	.sectioninner3 {
-		line-height: 21px;
+		line-height: 20px;
 		font-size: 11px;
 	}
 }

--- a/_includes/css/nerd-font-tweaks.scss
+++ b/_includes/css/nerd-font-tweaks.scss
@@ -733,7 +733,7 @@ a.nerd-font-button:before {
 	}
 
 	.sectioninner3 {
-		line-height: 16px;
+		line-height: 21px;
 		font-size: 11px;
 	}
 }


### PR DESCRIPTION
#### Description

As discussed in [Pull Request #1368](https://github.com/ryanoasis/nerd-fonts/pull/1368#issuecomment-1751669936), I've addressed an issue where the circle shrinks horizontally but not vertically. There's also an additional problem with the layout of the entire website where within the Font Patcher script section, the ```<details>``` tag overflows from its parent. This results in a horizontal scrollbar, which disrupts the website's layout. 

#### Requirements / Checklist

- [x] I have searched the [issues](https://github.com/ryanoasis/nerd-fonts/issues) for my issue and found nothing related and/or helpful
- [x] I have searched the [FAQ](https://github.com/ryanoasis/nerd-fonts/wiki/FAQ-and-Troubleshooting) for help
- [x] I have searched the [Wiki](https://github.com/ryanoasis/nerd-fonts/wiki) for help

#### What does this Pull Request (PR) do?

I've created this issue to report and address the following problems:

- The subtitle inner circle inside the features section shrinks horizontally but not vertically for screens with a width less than 767px, leading to overflow issues.
- The `<details>` tag within the Font Patcher script section overflows from its parent, causing a horizontal scrollbar and breaking the website's layout.

#### How should this be manually tested?

The issue relates to the responsiveness and layout of the website, so manual testing would involve checking the behavior on various screen sizes, especially less than 767px, and verifying that the described issues are present.

Visit the website [here](https://vitthalgund.github.io/nerd-fonts/).
#### Any background context you can provide?

This issue is related to Pull Request #1368 and aims to highlight problems with the website's layout and responsiveness.

#### Screenshots (if appropriate or helpful)

Screenshots are provided to illustrate the issues. You also
#### Before:
![Before Image 1](https://github.com/ryanoasis/nerd-fonts/assets/97181033/377356ce-3f55-415d-b610-4e3aa420c22b)
![Before Image 2](https://github.com/ryanoasis/nerd-fonts/assets/97181033/b43e0a32-ee46-4043-8380-8714e6536b0d)

#### After:
![After Image 1](https://github.com/ryanoasis/nerd-fonts/assets/97181033/6a78d7e2-1356-4096-a57e-75efc632e4d3)
![After Image 2](https://github.com/ryanoasis/nerd-fonts/assets/97181033/81829635-75ac-44dd-8f05-b2e63654bb78)

#### Before:
![Before Image 3](https://github.com/ryanoasis/nerd-fonts/assets/97181033/2d9922bc-062d-41e0-b08d-0bbfc505e1c1)
![Before Image 4](https://github.com/ryanoasis/nerd-fonts/assets/97181033/bb848c22-a0dc-4966-b777-6d3670b44d59)

#### After:
![After Image 3](https://github.com/ryanoasis/nerd-fonts/assets/97181033/40b16723-1e55-419a-8fc6-c443579ce8b2)
![After Image 4](https://github.com/ryanoasis/nerd-fonts/assets/97181033/56395e3f-fbd4-439f-93a2-cae6bca0d760)

#### Your Setup
- Operating System: Windows 11
- Browser: Chrome
