### PR TITLE
Bugfix/visualstudio2022

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -339,9 +339,9 @@ class FontnameParser:
         # back, but only as 'English (US)'. This makes sure we do not leave contradicting
         # names over different languages.
         for l, k, v in list(font.sfnt_names):
-            if not k in TO_DEL:
+            if not k in TO_DEL and l == 'English (US)':
                 sfnt_list += [( l, k, v )]
-                if k == 'Version' and l == 'English (US)':
+                if k == 'Version':
                     version_tag = ' ' + v.split()[-1]
 
         sfnt_list += [( 'English (US)', 'Family', self.checklen(31, 'Family (ID 1)', self.family()) )] # 1

--- a/bin/scripts/name_parser/query_name
+++ b/bin/scripts/name_parser/query_name
@@ -12,7 +12,14 @@ import fontforge
 
 def get_sfnt_dict(font):
     """Extract SFNT table as nice dict"""
-    return { k: v for l, k, v in font.sfnt_names }
+    d = { }
+    for l, k, v in font.sfnt_names:
+        if k not in d:
+            d[k] = [ v ]
+        else:
+            d[k] += [ v ]
+    d = { k: v[0] if v and len(v) == 1 else tuple(v) for k, v in d.items() }
+    return d
 
 ###### Let's go!
 
@@ -38,13 +45,13 @@ for filename in sys.argv[1:]:
     sfnt_full =    sfnt.get('Fullname', None)
     sfnt_fam =     sfnt.get('Family', None)
     sfnt_subfam =  sfnt.get('SubFamily', None)
-    sfnt_pfam =    sfnt.get('Preferred Family', '')
-    sfnt_psubfam = sfnt.get('Preferred Styles', '')
-    sfnt_psname =  sfnt.get('PostScriptName', '')
-    sfnt_compat =  sfnt.get('Compatible Full', '')
-    sfnt_cidff =   sfnt.get('CID findfont Name', '')
-    sfnt_wfam =    sfnt.get('WWS Family', '')
-    sfnt_wsubfam = sfnt.get('WWS Subfamily', '')
+    sfnt_pfam =    sfnt.get('Preferred Family', '-')
+    sfnt_psubfam = sfnt.get('Preferred Styles', '-')
+    sfnt_psname =  sfnt.get('PostScriptName', '-')
+    sfnt_compat =  sfnt.get('Compatible Full', '-')
+    sfnt_cidff =   sfnt.get('CID findfont Name', '-')
+    sfnt_wfam =    sfnt.get('WWS Family', '-')
+    sfnt_wsubfam = sfnt.get('WWS Subfamily', '-')
 
 
     if add_line:

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.9.0"
+script_version = "4.10.0"
 
 version = "3.1.1"
 projectName = "Nerd Fonts"
@@ -308,7 +308,8 @@ def get_old_average_x_width(font):
 
 def create_filename(fonts):
     """ Determine filename from font object(s) """
-    sfnt = { k: v for l, k, v in fonts[0].sfnt_names }
+    # Only consider the standard (i.e. English-US) names
+    sfnt = { k: v for l, k, v in fonts[0].sfnt_names if l == 'English (US)' }
     sfnt_pfam = sfnt.get('Preferred Family', sfnt['Family'])
     sfnt_psubfam = sfnt.get('Preferred Styles', sfnt['SubFamily'])
     if len(fonts) > 1:


### PR DESCRIPTION
#### Description

If `--makegroups` is >= 4 the name suffix `Nerd Font` (`Nerd Font Mono`, `Nerd Font Propo`) is shortened to `NF` (`NFM`, `NFP`). But not everywhere. To show the nice long name in applications that can handle long names, the long name is always (!) written to ID16.

VisualStudio 2022 does not like that and assumes the font is broken.
For that reason this extra rule (write the long name to ID16 even though all other places use the abbreviation) has been removed with `v3.1.0`. But that breaks all configurations that address the font by family name, because the long name is gone now.

This PR implements a work around such that two (!) family names are written to ID16, the short and the long one.
In this way both VisualStudio 2022 and configured family name applications can be happy.

Hopefully.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #1242
* #1406
* #1434
* #1439

Fixes: #1482

#### Screenshots (if appropriate or helpful)
