### PR TITLE
font-patcher: Fix crash if no roman characters

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.8.2"
+script_version = "4.8.3"
 
 version = "3.1.1"
 projectName = "Nerd Fonts"
@@ -1212,7 +1212,7 @@ class font_patcher:
                 'height': self.sourceFont.descent + self.sourceFont.ascent,
             }
             our_btb = self.sourceFont.descent + self.sourceFont.ascent
-        elif self.font_dim['height'] < 0:
+        if self.font_dim['height'] <= 0:
             logger.critical("Can not detect sane font height")
             sys.exit(1)
 
@@ -1266,6 +1266,9 @@ class font_patcher:
         if self.font_dim['width'] < self.font_dim['xmax']:
             logger.debug("Font has negative right side bearing in extended glyphs")
             self.font_dim['xmax'] = self.font_dim['width'] # In fact 'xmax' is never used
+        if self.font_dim['width'] <= 0:
+            logger.critical("Can not detect sane font width")
+            sys.exit(1)
         logger.debug("Final font cell dimensions %d w x %d h", self.font_dim['width'], self.font_dim['height'])
 
         self.xavgwidth.append(self.args.xavgwidth)


### PR DESCRIPTION
[why]
When we can not detect the cell width, for example because there are no glyphs in the range of extrended-roman that we examine, the width will be zero and that will result in a crash later on (on rescaling).

[how]
Just abort if height or width are zero or negative.

Related: #1460


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Add a new (potential) fatal check after determining source font dimensions.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
