### PR TITLE
fix: added missing glyphs in test-fonts.sh

### DIFF
--- a/bin/scripts/test-fonts.sh
+++ b/bin/scripts/test-fonts.sh
@@ -150,7 +150,7 @@ function test-fonts() {
   echo; echo
 
   echo "Nerd Fonts - Symbols original"
-  print-unicode-ranges e5fa e62b
+  print-unicode-ranges e5fa e6b2
   echo; echo
 
   echo "Nerd Fonts - Devicons"


### PR DESCRIPTION
#### Description

Added gkpyhs that were missing from test-fonts.sh 

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Change the range for the Symbols Original set int the font-test.sh script to include all the glyphs in that set.
#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
This is the Symbols Original set before the change:
![nf_before](https://github.com/ryanoasis/nerd-fonts/assets/16373114/65219968-939a-4413-ad8c-5a999bad9144)

And after the change:
![nf_after](https://github.com/ryanoasis/nerd-fonts/assets/16373114/5e0852a7-ed33-4180-b6d4-a9952532c3ce)

