### PR TITLE
Parallel execution fontforge in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.title="Nerd Fonts Patcher" \
       org.opencontainers.image.source="https://github.com/ryanoasis/nerd-fonts" \
       org.opencontainers.image.licenses="MIT"
 
-RUN apk update && apk upgrade && apk add --no-cache fontforge --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community
+RUN apk update && apk upgrade && apk add --no-cache fontforge parallel --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 
 ENV PYTHONIOENCODING=utf-8
 

--- a/bin/scripts/docker-entrypoint.sh
+++ b/bin/scripts/docker-entrypoint.sh
@@ -23,6 +23,6 @@ done
 printf "Running with options:\n%s\n" "$args"
 
 # shellcheck disable=SC2086
-for f in /in/*.otf /in/*.ttf /in/*.woff /in/*.eot /in/*.ttc; do [ -f "$f" ] && fontforge -script /nerd/font-patcher -out /out $args "$f"; done
+find /in -type f \( -name "*.otf" -o -name "*.ttf" -o -name "*.woff" -o -name "*.eot" -o -name "*.ttc" \) | parallel fontforge -script /nerd/font-patcher -out /out $args {}
 
 exit 0

--- a/bin/scripts/docker-entrypoint.sh
+++ b/bin/scripts/docker-entrypoint.sh
@@ -23,6 +23,16 @@ done
 printf "Running with options:\n%s\n" "$args"
 
 # shellcheck disable=SC2086
-find /in -type f \( -iname "*.otf" -o -iname "*.ttf" -o -iname "*.woff" -o -iname "*.eot" -o -iname "*.ttc" \) | parallel fontforge -script /nerd/font-patcher -out /out $args {}
+if [ "$PN" -eq 1 ]; then
+	find /in -type f \
+	  \( -iname '*.otf' -o -iname '*.ttf' -o -iname '*.woff' -o -iname '*.eot' -o -iname '*.ttc' \) \
+	  -exec fontforge -script /nerd/font-patcher -out /out $args {} \;
+else
+	njob=""
+	[ "$PN" -gt 1 ] && njob="-j $PN"
+	find /in -type f \
+	  \( -iname '*.otf' -o -iname '*.ttf' -o -iname '*.woff' -o -iname '*.eot' -o -iname '*.ttc' \) \
+	  | parallel $njob fontforge -script /nerd/font-patcher -out /out $args {}
+fi
 
 exit 0

--- a/bin/scripts/docker-entrypoint.sh
+++ b/bin/scripts/docker-entrypoint.sh
@@ -23,6 +23,6 @@ done
 printf "Running with options:\n%s\n" "$args"
 
 # shellcheck disable=SC2086
-find /in -type f \( -name "*.otf" -o -name "*.ttf" -o -name "*.woff" -o -name "*.eot" -o -name "*.ttc" \) | parallel fontforge -script /nerd/font-patcher -out /out $args {}
+find /in -type f \( -iname "*.otf" -o -iname "*.ttf" -o -iname "*.woff" -o -iname "*.eot" -o -iname "*.ttc" \) | parallel fontforge -script /nerd/font-patcher -out /out $args {}
 
 exit 0

--- a/readme.md
+++ b/readme.md
@@ -365,9 +365,19 @@ Patching the font of your own choosing:
   ```
 
 * Use docker
+  * Default parallel tasks
   ```
   docker run --rm -v /path/to/fonts:/in:Z -v /path/for/output:/out:Z nerdfonts/patcher [OPTIONS]
   ```
+  * Single process (slow)
+  ```
+  docker run --rm -v /path/to/fonts:/in:Z -v /path/for/output:/out:Z -e "PN=1" nerdfonts/patcher [OPTIONS]
+  ```
+  * Specify the parallel tasks number to 10
+  ```
+  docker run --rm -v /path/to/fonts:/in:Z -v /path/for/output:/out:Z -e "PN=10" nerdfonts/patcher [OPTIONS]
+  ```
+
 
 > [!NOTE]
 > The resulting font's family (aka font name) will be set to the original family after CamelCasing, removing whitespace and appending ` Nerd Font`. For example, `iosevka term` would become `IosevkaTerm Nerd Font`.


### PR DESCRIPTION
#### Description

Improve the docker execution method, optimize from single process to parallel execution, and increase the speed of font patching.
see [issue 1507](https://github.com/ryanoasis/nerd-fonts/issues/1507)

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?
Speed up docker patcher
#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
