### PR TITLE
font-patcher: Correct icon path direction

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.10.1"
+script_version = "4.11.0"
 
 version = "3.1.1"
 projectName = "Nerd Fonts"
@@ -1443,6 +1443,19 @@ class font_patcher:
                 # Paste it
                 self.sourceFont.selection.select(currentSourceFontGlyph)
                 self.sourceFont.paste()
+
+                # Correct path(s) and check for problems
+                old_validate = self.sourceFont[currentSourceFontGlyph].validate(True)
+                self.sourceFont[currentSourceFontGlyph].removeOverlap()
+                self.sourceFont[currentSourceFontGlyph].correctDirection()
+                new_validate = self.sourceFont[currentSourceFontGlyph].validate(True)
+                # Usually self-intersection can not be fixed, so only show if we introduce it
+                if (new_validate & 0x4 and not (old_validate & 0x4)) or new_validate & (0x8 | 0x2):
+                    logger.debug("Problematic glyph %04X (%X -> %X): %s",
+                        currentSourceFontGlyph, old_validate & 0xE, new_validate & 0xE,
+                        sym_glyph.glyphname)
+
+                # Name the glyph
                 self.sourceFont[currentSourceFontGlyph].glyphname = sym_glyph.glyphname
                 self.sourceFont[currentSourceFontGlyph].manualHints = True # No autohints for symbols
 


### PR DESCRIPTION
**[why]**
We create fonts with lots of path in the wrong direction. Although that is usually fine it is not guaranteed to be ok with all renderers.

**[how]**
Just flatten the inserted glyph and then correct the path directions.

Output a debug message when that made the glyph worse or at least did not fix the direction.

A complete patched font changes from

```
======== AurulentSansMNerdFont-Regular_OLD.otf ========
Sum of problems: open 0, intersect 295, direction 5099 (for a total of 9710 glyphs)
======== CaskaydiaCoveNerdFont-Regular_OLD.ttf ========
Sum of problems: open 0, intersect 188, direction 5201 (for a total of 12477 glyphs)
```

to

```
======== AurulentSansMNerdFont-Regular_NEW.otf ========
Sum of problems: open 0, intersect 222, direction 4 (for a total of 9710 glyphs)
======== CaskaydiaCoveNerdFont-Regular_NEW.ttf ========
Sum of problems: open 0, intersect 185, direction 0 (for a total of 12477 glyphs)
```

with

```
DEBUG: Problematic glyph E0D0 (4 -> 8): uniE0D0
DEBUG: Problematic glyph E261 (8 -> 4): chess-pawn
DEBUG: Problematic glyph E2A2 (4 -> 8): isle
DEBUG: Problematic glyph E74C (4 -> 8): uniE64C
DEBUG: Problematic glyph E767 (4 -> 8): uniE667
DEBUG: Problematic glyph F342 (0 -> 4): QubesOS
DEBUG: Problematic glyph F34E (4 -> 2): OpenSCAD
DEBUG: Problematic glyph F470 (4 -> 8): logo-github
DEBUG: Problematic glyph F0DE4 (8 -> 4): pen-off
DEBUG: Problematic glyph F10F7 (8 -> 4): application-brace
DEBUG: Problematic glyph F1304 (8 -> 4): ski
DEBUG: Problematic glyph F1367 (8 -> 4): sticker-check
DEBUG: Problematic glyph F1675 (8 -> 4): paw-outline
```

where the bits are
 2 : open path
 4 : self intersecting
 8 : wrong direction

One TTF and one OTF is shown because the standard direction is opposite for both formats.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
