### PR TITLE
cheat-sheet: Add autofocus on load to search input text

### DIFF
--- a/bin/scripts/data/cheatsheet-head.txt
+++ b/bin/scripts/data/cheatsheet-head.txt
@@ -10,7 +10,7 @@ style: container
 
 <h1 class="center">Cheat Sheet</h1>
 
-<input type="text" id="glyphSearch" placeholder="Search for glyphs/icons here..." title="Type in a glyph name or hex codepoint" class="nerd-font-cheat-sheet-search nerd-font-input tertiary sanity-test" />
+<input type="text" id="glyphSearch" placeholder="Search for glyphs/icons here..." title="Type in a glyph name or hex codepoint" class="nerd-font-cheat-sheet-search nerd-font-input tertiary sanity-test" autofocus />
 
 <div id="glyphCheatSheet" class="nerd-font-cheat-sheet"></div>
 


### PR DESCRIPTION
#### Description

Autofocusing the cheat sheet input text on page load would improve some workflows and I doubt would break other workflows.
> I'm not 100% sure I understood the framework, but hopefully this works.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

Adds the `autofocus` attribute to the search input field.

#### How should this be manually tested?

See if the search input field is focused automatically on page load