### PR TITLE
Bugfix Ubuntu ligatures

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -338,9 +338,9 @@ class font_patcher:
     def patch(self, font):
         self.sourceFont = font
         self.setup_version()
-        self.get_essential_references()
         self.assert_monospace()
         self.remove_ligatures()
+        self.get_essential_references()
         self.get_sourcefont_dimensions()
         self.setup_patch_set()
         self.improve_line_dimensions()

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.13.0"
+script_version = "4.13.1"
 
 version = "3.2.0"
 projectName = "Nerd Fonts"
@@ -1135,14 +1135,14 @@ class font_patcher:
         # glyphs intact.
         # 0x0000-0x017f is the Latin Extended-A range
         # 0xfb00-0xfb06 are 'fi' and other ligatures
-        basic_glyphs = set()
+        basic_glyphs = { c for c in range(0x21, 0x17f + 1) if c in self.sourceFont }
         # Collect substitution destinations
-        for glyph in [*range(0x21, 0x17f + 1), *range(0xfb00, 0xfb06 + 1)]:
+        for glyph in list(basic_glyphs) + [*range(0xfb00, 0xfb06 + 1)]:
             if not glyph in self.sourceFont:
                 continue
-            basic_glyphs.add(glyph)
             for possub in self.sourceFont[glyph].getPosSub('*'):
                 if possub[1] == 'Substitution' or possub[1] == 'Ligature':
+                    basic_glyphs.add(glyph)
                     basic_glyphs.add(self.sourceFont[possub[2]].unicode)
         basic_glyphs.discard(-1) # the .notdef glyph
         for glyph in basic_glyphs:

--- a/src/unpatched-fonts/Ubuntu/README.md
+++ b/src/unpatched-fonts/Ubuntu/README.md
@@ -13,6 +13,8 @@ you are expressly encouraged to experiment, modify, share and improve.
 
 http://font.ubuntu.com/
 
+The `fi`, `fl`, and similar ligatures are removed because they would block some Font Awesome glyphs.
+
 Version: 0.83
 
 ## Preprocessed Source Font

--- a/src/unpatched-fonts/Ubuntu/config.json
+++ b/src/unpatched-fonts/Ubuntu/config.json
@@ -1,0 +1,5 @@
+[Subtables]
+	ligatures: [
+		"'liga' Standard Ligatures in Latin lookup 20 subtable",
+		"'liga' Standard Ligatures in Greek lookup 21 subtable",
+		"'liga' Standard Ligatures in Cyrillic lookup 22 subtable" ]


### PR DESCRIPTION
#### Description

Remove the `fi`, `fl` etc ligatures from Ubuntu to free that glyphs for overpatching. At the moment two Font Awesome glyphs (music, magnifying_glass) can not be inserted for that reason.

Also fix some code in the patcher that accidentially protected that glyphs albeit no ligatures are active in that font.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

Fixes: #1595
Related: #1221

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
