### PR TITLE
Improve licensing info

### DIFF
--- a/bin/scripts/lib/fonts.json
+++ b/bin/scripts/lib/fonts.json
@@ -2,6 +2,7 @@
   "fonts": [
     {
       "unpatchedName": "0xProto",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.603",
       "patchedName": "0xProto",
@@ -15,6 +16,7 @@
     },
     {
       "unpatchedName": "IBM 3270",
+      "licenseId": "BSD-3-Clause",
       "RFN": false,
       "version": "3.0.1",
       "patchedName": "3270",
@@ -28,6 +30,7 @@
     },
     {
       "unpatchedName": "Agave",
+      "licenseId": "MIT",
       "RFN": false,
       "version": "37",
       "patchedName": "Agave",
@@ -41,6 +44,7 @@
     },
     {
       "unpatchedName": "Anonymous Pro",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.002",
       "patchedName": "AnonymicePro",
@@ -54,6 +58,7 @@
     },
     {
       "unpatchedName": "Arimo",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "1.33",
       "patchedName": "Arimo",
@@ -67,6 +72,7 @@
     },
     {
       "unpatchedName": "Aurulent Sans Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "-",
       "patchedName": "AurulentSansM",
@@ -80,6 +86,7 @@
     },
     {
       "unpatchedName": "BigBlue Terminal",
+      "licenseId": "CC-BY-SA-4.0",
       "RFN": false,
       "version": "-",
       "patchedName": "BigBlueTerm",
@@ -93,6 +100,7 @@
     },
     {
       "unpatchedName": "Bitstream Vera Sans Mono",
+      "licenseId": "Bitstream-Vera",
       "RFN": true,
       "version": "1.1",
       "patchedName": "BitstromWera",
@@ -106,6 +114,7 @@
     },
     {
       "unpatchedName": "IBM Plex Mono",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2.004 (6.4.0)",
       "patchedName": "BlexMono",
@@ -119,6 +128,7 @@
     },
     {
       "unpatchedName": "Cascadia Code",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2111.01",
       "patchedName": "CaskaydiaCove",
@@ -132,6 +142,7 @@
     },
     {
       "unpatchedName": "Cascadia Mono",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2111.01",
       "patchedName": "CaskaydiaMono",
@@ -145,6 +156,7 @@
     },
     {
       "unpatchedName": "Code New Roman",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "2.0",
       "patchedName": "CodeNewRoman",
@@ -158,6 +170,7 @@
     },
     {
       "unpatchedName": "Comic Shanns Mono",
+      "licenseId": "MIT",
       "RFN": false,
       "version": "1.3.1",
       "patchedName": "ComicShannsMono",
@@ -171,6 +184,7 @@
     },
     {
       "unpatchedName": "Commit Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.143",
       "patchedName": "CommitMono",
@@ -184,6 +198,7 @@
     },
     {
       "unpatchedName": "Cousine",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "1.211",
       "patchedName": "Cousine",
@@ -197,6 +212,7 @@
     },
     {
       "unpatchedName": "D2Coding",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.3.2",
       "patchedName": "D2CodingLigature",
@@ -210,6 +226,7 @@
     },
     {
       "unpatchedName": "DaddyTimeMono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.2.3",
       "patchedName": "DaddyTimeMono",
@@ -223,6 +240,7 @@
     },
     {
       "unpatchedName": "DejaVu Sans Mono",
+      "licenseId": "Bitstream-Vera",
       "RFN": false,
       "version": "2.37",
       "patchedName": "DejaVuSansM",
@@ -236,6 +254,7 @@
     },
     {
       "unpatchedName": "Droid Sans Mono",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "1.00-113",
       "patchedName": "DroidSansM",
@@ -249,6 +268,7 @@
     },
     {
       "unpatchedName": "Envy Code R",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "0.79",
       "patchedName": "EnvyCodeR",
@@ -262,6 +282,7 @@
     },
     {
       "unpatchedName": "Fantasque Sans Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.8.0",
       "patchedName": "FantasqueSansM",
@@ -275,6 +296,7 @@
     },
     {
       "unpatchedName": "Fira Code",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "6.2",
       "patchedName": "FiraCode",
@@ -288,6 +310,7 @@
     },
     {
       "unpatchedName": "Fira",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "3.206",
       "patchedName": "FiraMono",
@@ -301,6 +324,7 @@
     },
     {
       "unpatchedName": "Geist Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.2.0 (1.3.0)",
       "patchedName": "GeistMono",
@@ -314,6 +338,7 @@
     },
     {
       "unpatchedName": "Go Mono",
+      "licenseId": "BSD-3-Clause-Clear",
       "RFN": false,
       "version": "2.010",
       "patchedName": "GoMono",
@@ -327,6 +352,7 @@
     },
     {
       "unpatchedName": "Gohu",
+      "licenseId": "WTFPL",
       "RFN": false,
       "version": "2.0",
       "patchedName": "GohuFont",
@@ -340,6 +366,7 @@
     },
     {
       "unpatchedName": "Hack",
+      "licenseId": "Bitstream-Vera AND MIT",
       "RFN": false,
       "version": "3.003",
       "patchedName": "Hack",
@@ -353,6 +380,7 @@
     },
     {
       "unpatchedName": "Hasklig",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.2",
       "patchedName": "Hasklug",
@@ -366,6 +394,7 @@
     },
     {
       "unpatchedName": "Heavy Data",
+      "licenseId": "LicenseRef-VicFieger",
       "RFN": false,
       "version": "1",
       "patchedName": "HeavyData",
@@ -379,6 +408,7 @@
     },
     {
       "unpatchedName": "Hermit",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2.0",
       "patchedName": "Hurmit",
@@ -392,6 +422,7 @@
     },
     {
       "unpatchedName": "iA Writer",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "Dec 2018",
       "patchedName": "iMWriting",
@@ -405,6 +436,7 @@
     },
     {
       "unpatchedName": "Inconsolata",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "3.000",
       "patchedName": "Inconsolata",
@@ -418,6 +450,7 @@
     },
     {
       "unpatchedName": "InconsolataGo",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.013",
       "patchedName": "InconsolataGo",
@@ -431,6 +464,7 @@
     },
     {
       "unpatchedName": "Inconsolata LGC",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.5.2",
       "patchedName": "Inconsolata LGC",
@@ -444,6 +478,7 @@
     },
     {
       "unpatchedName": "Intel One Mono",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.3.0",
       "patchedName": "IntoneMono",
@@ -457,6 +492,7 @@
     },
     {
       "unpatchedName": "Iosevka",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "29.0.4",
       "patchedName": "Iosevka",
@@ -470,6 +506,7 @@
     },
     {
       "unpatchedName": "Iosevka Term",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "29.0.4",
       "patchedName": "IosevkaTerm",
@@ -483,6 +520,7 @@
     },
     {
       "unpatchedName": "Iosevka Term Slab",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "29.0.4",
       "patchedName": "IosevkaTermSlab",
@@ -496,6 +534,7 @@
     },
     {
       "unpatchedName": "JetBrains Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "2.304",
       "patchedName": "JetBrainsMono",
@@ -509,6 +548,7 @@
     },
     {
       "unpatchedName": "Lekton",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "34",
       "patchedName": "Lekton",
@@ -522,6 +562,7 @@
     },
     {
       "unpatchedName": "Liberation Mono",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2.1.5",
       "patchedName": "LiterationMono",
@@ -535,6 +576,7 @@
     },
     {
       "unpatchedName": "Lilex",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "2.400",
       "patchedName": "Lilex",
@@ -548,6 +590,7 @@
     },
     {
       "unpatchedName": "MartianMono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.0.0",
       "patchedName": "MartianMono",
@@ -561,6 +604,7 @@
     },
     {
       "unpatchedName": "Meslo LG",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "1.21",
       "patchedName": "MesloLG",
@@ -574,6 +618,7 @@
     },
     {
       "unpatchedName": "Monaspace",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.0.0",
       "patchedName": "Monaspice",
@@ -587,6 +632,7 @@
     },
     {
       "unpatchedName": "Monofur",
+      "licenseId": "LicenseRef-Monofur",
       "RFN": false,
       "version": "1.0",
       "patchedName": "Monofur",
@@ -600,6 +646,7 @@
     },
     {
       "unpatchedName": "Monoid",
+      "licenseId": "MIT OR OFL-1.1-no-RFN",
       "RFN": false,
       "version": "0.61",
       "patchedName": "Monoid",
@@ -613,6 +660,7 @@
     },
     {
       "unpatchedName": "Mononoki",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.6",
       "patchedName": "Mononoki",
@@ -626,6 +674,7 @@
     },
     {
       "unpatchedName": "MPlus",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "2023/09",
       "patchedName": "M+",
@@ -639,6 +688,7 @@
     },
     {
       "unpatchedName": "Noto",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "div",
       "patchedName": "Noto",
@@ -652,6 +702,7 @@
     },
     {
       "unpatchedName": "OpenDyslexic",
+      "licenseId": "Bitstream-Vera",
       "RFN": false,
       "version": "2.001",
       "patchedName": "OpenDyslexic",
@@ -665,6 +716,7 @@
     },
     {
       "unpatchedName": "Overpass",
+      "licenseId": "OFL-1.1-no-RFN or LGPL-2.1-only",
       "RFN": false,
       "version": "3.0.5",
       "patchedName": "Overpass",
@@ -678,6 +730,7 @@
     },
     {
       "unpatchedName": "ProFont",
+      "licenseId": "MIT",
       "RFN": false,
       "version": "2.3/2.2",
       "patchedName": "ProFont",
@@ -691,6 +744,7 @@
     },
     {
       "unpatchedName": "ProggyCleanTT",
+      "licenseId": "MIT",
       "RFN": false,
       "version": "2004/04/15",
       "patchedName": "ProggyClean",
@@ -704,6 +758,7 @@
     },
     {
       "unpatchedName": "Recursive Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.085",
       "patchedName": "RecMono",
@@ -717,6 +772,7 @@
     },
     {
       "unpatchedName": "Roboto Mono",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "3.0",
       "patchedName": "RobotoMono",
@@ -730,6 +786,7 @@
     },
     {
       "unpatchedName": "Share Tech Mono",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "1.003",
       "patchedName": "ShureTechMono",
@@ -743,6 +800,7 @@
     },
     {
       "unpatchedName": "Source Code Pro",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "2.042",
       "patchedName": "SauceCodePro",
@@ -756,6 +814,7 @@
     },
     {
       "unpatchedName": "Space Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.001",
       "patchedName": "SpaceMono",
@@ -769,6 +828,7 @@
     },
     {
       "unpatchedName": "Symbols Only",
+      "licenseId": "MIT",
       "RFN": false,
       "version": "latest",
       "patchedName": "Symbols",
@@ -782,6 +842,7 @@
     },
     {
       "unpatchedName": "Terminus",
+      "licenseId": "OFL-1.1-RFN",
       "RFN": true,
       "version": "4.49.2",
       "patchedName": "Terminess",
@@ -795,6 +856,7 @@
     },
     {
       "unpatchedName": "Tinos",
+      "licenseId": "Apache-2.0",
       "RFN": false,
       "version": "1.23",
       "patchedName": "Tinos",
@@ -808,6 +870,7 @@
     },
     {
       "unpatchedName": "Ubuntu",
+      "licenseId": "LicenseRef-UbuntuFont",
       "RFN": false,
       "version": "0.83",
       "patchedName": "Ubuntu",
@@ -821,6 +884,7 @@
     },
     {
       "unpatchedName": "Ubuntu Mono",
+      "licenseId": "LicenseRef-UbuntuFont",
       "RFN": false,
       "version": "0.80",
       "patchedName": "UbuntuMono",
@@ -834,6 +898,7 @@
     },
     {
       "unpatchedName": "Ubuntu Sans",
+      "licenseId": "LicenseRef-UbuntuFont",
       "RFN": false,
       "version": "1.004",
       "patchedName": "UbuntuSans",
@@ -847,6 +912,7 @@
     },
     {
       "unpatchedName": "Victor Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.5.6",
       "patchedName": "VictorMono",
@@ -860,6 +926,7 @@
     },
     {
       "unpatchedName": "Zed Mono",
+      "licenseId": "OFL-1.1-no-RFN",
       "RFN": false,
       "version": "1.2.0",
       "patchedName": "ZedMono",

--- a/fonts.json
+++ b/fonts.json
@@ -1,0 +1,1 @@
+bin/scripts/lib/fonts.json

--- a/license-audit.md
+++ b/license-audit.md
@@ -45,7 +45,7 @@ All files created such as `font-patcher` and any `ph` or `sh` script/source file
 
 ### Additional notes
 
-* font awesome - we use the fonts which are SIL OFL 1.1, the icons are CC 4.0. We also adhere to the RFN condition to the best of our ability
+* font awesome - we use the icons which are CC 4.0.
 * weather icons - project is unfortunately dead, but added the OFL license files to comply.
 
 ## Fonts
@@ -55,7 +55,7 @@ All files created such as `font-patcher` and any `ph` or `sh` script/source file
 | Font                          | License                      |
 | ----------------------------- | ---------------------------- |
 | 0xProto                       | SIL OFL 1.1                  |
-| 3270                          | SIL OFL 1.1                  |
+| 3270                          | BSD-3-Clause                 |
 | Agave                         | MIT                          |
 | AnonymousPro                  | SIL OFL 1.1                  |
 | Arimo                         | Apache 2.0                   |
@@ -69,16 +69,16 @@ All files created such as `font-patcher` and any `ph` or `sh` script/source file
 | Cousine                       | Apache 2.0                   |
 | D2Coding                      | SIL OFL 1.1                  |
 | DaddyTimeMono                 | SIL OFL 1.1                  |
-| DejaVuSansMono                | Free license                 |
+| DejaVuSansMono                | Bitstream Vera License v1.00 |
 | DroidSansMono                 | Apache 2.0                   |
 | EnvyCodeR                     | SIL OFL 1.1                  |
 | FantasqueSansMono             | SIL OFL 1.1                  |
 | FiraCode                      | SIL OFL 1.1                  |
 | FiraMono                      | SIL OFL 1.1                  |
 | GeistMono                     | SIL OFL 1.1                  |
+| Go-Mono                       | BSD-3-Clause-Clear           |
 | Gohu                          | Do What The Fuck You Want To |
-| Go-Mono                       | Go License                   |
-| Hack                          | MIT                          |
+| Hack                          | Bitstream-Vera               |
 | Hasklig                       | SIL OFL 1.1                  |
 | HeavyData                     | Vic Fieger License           |
 | Hermit                        | SIL OFL 1.1                  |
@@ -99,12 +99,13 @@ All files created such as `font-patcher` and any `ph` or `sh` script/source file
 | Monofur                       | Monofur Free License         |
 | Monoid                        | MIT                          |
 | Mononoki                      | SIL OFL 1.1                  |
-| MPlus                         | Free License                 |
+| MPlus                         | SIL OFL 1.1                  |
 | Noto                          | SIL OFL 1.1                  |
 | OpenDyslexic                  | Bitstream License            |
 | Overpass                      | SIL OFL 1.1                  |
 | ProFont                       | MIT                          |
-| ProggyClean                   | Free License                 |
+| ProggyClean                   | MIT                          |
+| Recursive                     | SIL OFL 1.1                  |
 | RobotoMono                    | Apache 2.0                   |
 | ShareTechMono                 | SIL OFL 1.1                  |
 | SourceCodePro                 | SIL OFL 1.1                  |
@@ -113,4 +114,5 @@ All files created such as `font-patcher` and any `ph` or `sh` script/source file
 | Tinos                         | Apache 2.0                   |
 | Ubuntu                        | Ubuntu Font License 1.0      |
 | UbuntuMono                    | Ubuntu Font License 1.0      |
-| VictorMono                    | MIT                          |
+| VictorMono                    | SIL OFL 1.1                  |
+| Zed                           | SIL OFL 1.1                  |


### PR DESCRIPTION
#### Description

Add SPDX license info
    
[why]
It can be hard to find out which license a particular font is using.
Therefore we add a new field to the fonts.json with an SPDX license
identifier (if possible).
    
[how]
For fonts with a license that has no SPDX identifier we use a free
`LicenseRef-*` identifier, but that reference is not solved in the
fonts.json file.
    
[note]
Also correct some licensing info given in the license audit.
    
Related: #1578
    
Suggested-by:  Jan Christian Gruenhage <jan.christian@gruenhage.xyz>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] Verified the license of any newly added font, glyph, or glyph set

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
