### PR TITLE
font-patcher: don't double-shrink heavy angle brackets

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -944,7 +944,7 @@ class font_patcher:
             0xf0de: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}}
         }
         SYM_ATTR_HEAVYBRACKETS = {
-            'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa1!', 'params': {'ypadding': 0.3, 'careful': True}}
+            'default': {'align': 'c', 'valign': 'c', 'stretch': '^pa1!', 'params': {'ypadding': 0.3, 'careful': True}}
         }
         SYM_ATTR_BOX = {
             'default': {'align': 'c', 'valign': 'c', 'stretch': '^xy', 'params': {'overlap': 0.02, 'dont_copy': box_keep}},

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.14.0"
+script_version = "4.14.1"
 
 version = "3.2.1"
 projectName = "Nerd Fonts"


### PR DESCRIPTION
Fixes: https://github.com/ryanoasis/nerd-fonts/issues/1611

Directly copied from https://github.com/ryanoasis/nerd-fonts/issues/1611#issuecomment-2061294859

#### Description

> Ah, the heavy brackets are now two times shrunken, there was an old rule that already sized them down relative to the full cell:
> 
> ![image](https://private-user-images.githubusercontent.com/16012374/323240564-eff2642b-20af-406f-85a1-6d8e63d648c3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTM4MjAzOTMsIm5iZiI6MTcxMzgyMDA5MywicGF0aCI6Ii8xNjAxMjM3NC8zMjMyNDA1NjQtZWZmMjY0MmItMjBhZi00MDZmLTg1YTEtNmQ4ZTYzZDY0OGMzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA0MjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNDIyVDIxMDgxM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTQwYzMyNjM3NTI4MGRiMWE4MDhmN2UwNDIyZTEyODcwNmE2MjkzYjZjYjQ0NjkxM2FkZTYwYjI5ZTJjNzFiMzMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.V76i2mzkFJwTA_eBXCjcLxAGVEk5cYBxzDqN-Kn5c_8)
> 
> The rule needs to be changed to `^pa1!` ....


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [x] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [x] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Restores heavy angle brackets to the size they were in 3.1.1 

#### How should this be manually tested?

Check size of heavy angle brackets before and after this change.

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/issues/1611

#### Screenshots (if appropriate or helpful)

 | 3.1.1 | 3.2.1 |
| --- | --- |
 | ![3.1.1](https://private-user-images.githubusercontent.com/15943089/323152204-3747a6df-1d62-40df-ac16-80388312c8e0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTM4MjAzOTMsIm5iZiI6MTcxMzgyMDA5MywicGF0aCI6Ii8xNTk0MzA4OS8zMjMxNTIyMDQtMzc0N2E2ZGYtMWQ2Mi00MGRmLWFjMTYtODAzODgzMTJjOGUwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA0MjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNDIyVDIxMDgxM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTEzNzNhZjYwZTc2MTRiNzkxNmFkMjdkMjBlYTdkNWM4YWQxY2VmNTA4ZTUzN2IyMDE0N2RhNGY4Y2JkMzQyN2QmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.aJEnGP9IfyZv8fzDbctm_x62uqduLM9GzCDQ74KqDYw)	| ![3.2.1](https://private-user-images.githubusercontent.com/15943089/323152315-de1fd3c3-fc56-406b-99f6-6576f0c09985.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTM4MjAzOTMsIm5iZiI6MTcxMzgyMDA5MywicGF0aCI6Ii8xNTk0MzA4OS8zMjMxNTIzMTUtZGUxZmQzYzMtZmM1Ni00MDZiLTk5ZjYtNjU3NmYwYzA5OTg1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA0MjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNDIyVDIxMDgxM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTExMGMyMmM0ZGIyZGFiZWE0Y2I0NWYyNjNkYmExZTdkNmVjZGMyNjFmOWMxM2FjNzg3YzhjMTgxMmM5MDkyMTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.qsJeNnemudL0--7W1l73eEs1eLO3gBtTNvFfV2FimAs) |
