### PR TITLE
font-patcher: Fix behavior when trying to patch non-font files

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.14.3"
+script_version = "4.14.4"
 
 version = "3.2.1"
 projectName = "Nerd Fonts"
@@ -2127,6 +2127,9 @@ def main():
 
     sourceFonts = []
     all_fonts = fontforge.fontsInFile(args.font)
+    if not all_fonts:
+        logger.critical("Can not find any fonts in '%s'", args.font)
+        sys.exit(1)
     for i, subfont in enumerate(all_fonts):
         if len(all_fonts) > 1:
           print("\n")


### PR DESCRIPTION
**[why]**
When the file specified to be patched is not a font file the patcher run errors out with an out of index runtime error:

```
Traceback (most recent call last):
  File "/home/fini/extra/git/nerd-fonts/font-patcher", line 2155, in <module>
    main()
  File "/home/fini/extra/git/nerd-fonts/font-patcher", line 2147, in main
    patcher.generate(sourceFonts)
  File "/home/fini/extra/git/nerd-fonts/font-patcher", line 415, in generate
    sourceFont = sourceFonts[0]
                 ~~~~~~~~~~~^^^
IndexError: list index out of range
```

**[how]**
Do not assume that the specified file will be a font file but rather check if fontforge detects a font in the file and error out if there is no font found.

Fixes: #1647

Reported-by: Kristopher James Kent <kris@kjkent.dev>

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Prevent a runtime error in certain situations and instead prints an understandable explanation why processing can not continue.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
