### PR TITLE
feat: Add markdownlint configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+# Maintain consistent coding style across the entire project.
+
+# This is a configuration file for EditorConfig.  The settings for JavaScript, Python and C/C++
+# files are mirrored by languages in .prettierrc, .eslintrc, .flake8, .pylintrc, pyproject.toml and
+# .clang-format files that is shared accros all my codebase projects.  Keep them in sync.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+quote_type = double
+
+[*.{bash,eslint*,json*,md*,prettier*,sh,svg,todo,version*,vim,xml,yaml,yml,zsh*}]
+indent_size = 2
+max_line_length = 100
+
+[*.{css,html,js,jsx,mjs,ps1,psd1,psm1,scss,ts,tsx}]
+indent_size = 4
+max_line_length = 100
+
+[*.py]
+profile = black
+indent_size = 4
+max_line_length = 100
+
+[{.clang-format,.clang-tidy}]
+indent_size = 2
+max_line_length = 100
+
+[{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,hpp,cxx,hxx}}]
+indent_size = 4
+max_line_length = 100
+
+[{Makefile,.gitattributes,.gitconfig,.gitcredentials,.gitmessage,.gitmodules}]
+indent_size = 8
+indent_style = tab
+
+[COMMIT_EDITMSG]
+max_line_length = 72

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,39 @@
+# Maintain consistent coding style across the entire project.
+
+# Linter configuration file for Markdown and CommonMark files.  This tool is a style checker and
+# formatting tool for the files based on the CommonMark specification.  The tool is available as a
+# command line tool and works with Prettier.  See doc: https://github.com/DavidAnson/markdownlint
+
+# Default state for all rules
+default: true
+
+# Line length
+MD013: true
+
+# Trailing heading
+MD026:
+  punctuation: .,;:!。，；：！
+
+# Multiple spaces blockquote
+MD027: true
+
+# Inline HTML
+MD033: false
+
+# Emphasis heading
+MD036:
+  punctuation: .,;:!?。，；：！？
+
+# Link fragments
+MD051: true
+
+# Max line length
+line-length:
+  line_length: 100
+  heading_line_length: 60
+  code_block_line_length: 100
+  code_blocks: false
+  tables: false
+  headings: true
+  strict: false
+  stern: false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,33 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 4,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.md",
+      "excludeFiles": "CHANGELOG.md",
+      "options": {
+        "parser": "markdown",
+        "arrowParens": "always",
+        "bracketSpacing": true,
+        "endOfLine": "lf",
+        "printWidth": 100,
+        "proseWrap": "always",
+        "semi": false,
+        "singleQuote": false,
+        "tabWidth": 2,
+        "trailingComma": "none",
+        "useTabs": false
+      }
+    },
+    {
+      "files": [".clang*", ".eslint*", ".prettierrc", "*.json", "*.yaml", "*.yml"],
+      "options": {
+        "tabWidth": 2
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added `.markdownlint.yml` and `.prettierrc` configuration files to establish and maintain uniform coding and Markdown styling conventions across the project.

These configurations enforce rules such as consistent line lengths, the use of semi-colons, and the handling of inline HTML and link fragments in Markdown, ensuring readable and maintainable documentation and codebase. Moreover, revised the `CHANGELOG.md` section header in `.versionrc` for better clarity and readability, aligning with markdownlint's recommendations.

This initiative aims to minimize style discrepancies and improve code readability, facilitating a smoother collaboration process. It is an essential step towards a more structured and efficient development workflow, acknowledging that consistency is key to a project's long-term success.

Related: #1665


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx
