### PR TITLE
Add CLI cheatsheet script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,0 @@
-[*.sh]
-indent_style = space
-indent_size = 2

--- a/bin/scripts/README.md
+++ b/bin/scripts/README.md
@@ -4,6 +4,7 @@ Note: Usually you need to call the scripts in this directory while actually bein
 
 * `archive-font-patcher.sh`: Archives the font patcher script and subscripts and the required source glyph files [1]
 * `archive-fonts.sh`: Creates the release zip file of one or more font(s) from existing `patched-fonts/` content [1]
+* `cheatsheet.sh`: Search for a glyph by part of its name [4]
 * `data/`: Contains plain text files used to generate the CSS and cheat sheet files
 * `data/sankey/`: Contains instructions on how to create the sankey glyph table manually [3]
 * `docker-entrypoint.sh`: This script is packaged into the docker container and is usually used to start patching [2]

--- a/bin/scripts/cheatsheet.sh
+++ b/bin/scripts/cheatsheet.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Nerd Fonts Version: 3.2.1
+# Script Version: 1.0.0
+#
+# Search for a glyph by its name in all patched fonts
+# Usage: ./cheatsheet.sh divider
+
+source ./lib/i_all.sh
+
+# Search the key on the declared variables
+for glyph in ${!i_*}; do
+  if [[ $glyph == *"$1"* ]]; then
+    printf "%s\t%x\t%s\n" "${!glyph}" "'${!glyph}'" "$glyph"
+  fi
+done

--- a/bin/scripts/cheatsheet.sh
+++ b/bin/scripts/cheatsheet.sh
@@ -2,14 +2,15 @@
 # Nerd Fonts Version: 3.2.1
 # Script Version: 1.0.0
 #
-# Search for a glyph by its name in all patched fonts
+# Search for a glyph by part of its name in all patchsets
 # Usage: ./cheatsheet.sh divider
 
+# shellcheck disable=SC1091 # Do not pull in the sourced file
 source ./lib/i_all.sh
 
 # Search the key on the declared variables
 for glyph in ${!i_*}; do
-  if [[ $glyph == *"$1"* ]]; then
+  if [[ "$glyph" == *"$1"* ]]; then
     printf "%s\t%x\t%s\n" "${!glyph}" "'${!glyph}'" "$glyph"
   fi
 done


### PR DESCRIPTION
#### Description

_CLI cheatsheet._

#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
Adds a script that let users to search for an icon using its name using the NF library scripts.
#### How should this be manually tested?
```shell
$ ./cheatsheet divider
       e0b0    i_pl_left_hard_divider
       e0b1    i_pl_left_soft_divider
       e0b2    i_pl_right_hard_divider
       e0b3    i_pl_right_soft_divider
       e0d7    i_ple_left_hard_divider_inverse
       e0d6    i_ple_right_hard_divider_inverse
```
#### Any background context you can provide?
There are times when I want to look for a glyph but using the online cheatsheet tool takes "a lot of time". The tool is not slow I mean the whole workflow.