### PR TITLE
Add LESSUTFCHARDEF instructions for less PUA character display Fixes: #1337

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,13 @@ See [Wiki: Glyph Sets and Codepoints for more details][wiki-glyph-sets-codepoint
 
 See [Wiki: Icon names in shell][wiki-icon-names-in-shell]
 
+### Displaying Private Use Area (PUA) Characters in `less`
+
+If you are using `less` (version 633 or above) and notice that Private Use Area (PUA) characters from Nerd Fonts are not displaying, you can use the `LESSUTFCHARDEF` environment variable to specify the code points for PUA characters. This can be done as follows:
+
+```bash
+export LESSUTFCHARDEF=23fb-23fe:p,2665:p,26a1:p,2b58:p,e000-e00a:p,e0a0-e0a2:p,e0a3:p,e0b0-e0b3:p,e0b4-e0c8:p,e0ca:p,e0cc-e0d4:p,e200-e2a9:p,e300-e3e3:p,e5fa-e6a6:p,e700-e7c5:p,ea60-ebeb:p,f000-f2e0:p,f300-f32f:p,f400-f532:p,f500-fd46:p,f0001-f1af0:p
+```
 
 ## Patched Fonts
 


### PR DESCRIPTION
#### Description

_Please explain the changes you made here._

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
This PR adds documentation to explain how users can set the `LESSUTFCHARDEF` environment variable in `less` to correctly display Private Use Area (PUA) characters from Nerd Fonts.

#### How should this be manually tested?
This change is a documentation update, so no specific testing is needed. However, users can verify the instructions by running the following command to set the `LESSUTFCHARDEF` environment variable in their shell and viewing a file with PUA characters in `less`:

```bash
export LESSUTFCHARDEF=23fb-23fe:p,2665:p,26a1:p,2b58:p,e000-e00a:p,e0a0-e0a2:p,e0a3:p,e0b0-e0b3:p,e0b4-e0c8:p,e0ca:p,e0cc-e0d4:p,e200-e2a9:p,e300-e3e3:p,e5fa-e6a6:p,e700-e7c5:p,ea60-ebeb:p,f000-f2e0:p,f300-f32f:p,f400-f532:p,f500-fd46:p,f0001-f1af0:p
```

#### Any background context you can provide?
There have been issues with `less` not displaying Private Use Area (PUA) characters correctly. This is due to the way `less` handles characters that fall outside standard Unicode ranges. By setting the `LESSUTFCHARDEF` environment variable, users can ensure that PUA characters are properly rendered when using Nerd Fonts.

#### What are the relevant tickets (if any)?
Fixes: #1337

#### Screenshots (if appropriate or helpful)
