### PR TITLE
Increase weather icons 'other' icons scale

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.14.6"
+script_version = "4.14.7"
 
 version = "3.2.1"
 projectName = "Nerd Fonts"
@@ -1071,6 +1071,8 @@ class font_patcher:
             range(0xf095, 0xf0b0 + 1), # moon phases
             range(0xf0b7, 0xf0c3 + 1), # wind strengths
             [0xf06e, 0xf070 ], # solar/lunar eclipse
+            [0xf051, 0xf052, 0xf0c9, 0xf0ca, 0xf072 ], # sun/moon up/down
+            [0xf049, 0xf056, 0xf071, *range(0xf073, 0xf07c + 1), 0xf08a], # other things
             # Note: Codepoints listed before that are also in the following range
             # will take the scaling of the previous group (the ScaleGroups are
             # searched through in definition order).
@@ -1078,7 +1080,12 @@ class font_patcher:
             # _will_ include all glyphs in its definition: Make sure the exempt
             # glyphs from above are smaller (do not extend) the combined bounding
             # box of this range:
-            range(0xf000, 0xf0cb + 1), # lots of clouds and other (Please read note above!)
+            [ *range(0xf000, 0xf041 + 1),
+              *range(0xf064, 0xf06d + 1),
+              *range(0xf07d, 0xf083 + 1),
+              *range(0xf085, 0xf086 + 1),
+              *range(0xf0b2, 0xf0b6 + 1)
+            ], # lots of clouds (weather states) (Please read note above!)
         ]}
         MDI_SCALE_LIST = None # Maybe later add some selected ScaleGroups
 


### PR DESCRIPTION
**[why]**
A lot of icons that do not represent a 'weather state' but rather a 'weather event' are in the 'weather state' scaling group which scales the icons waaaay down. This makes those icons almost unusable in stand alone use cases.

**[how]**
Put all the extra icons into a new scaling group that is defined before the weather state scaling group and thus takes precedence.

Split the final scaling group to have some icons on individual scale.

Fixes: #1708

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Scale some icons bigger, that are currently in the same scale group as all the clouds and stuff and thus get very small.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #1708 

#### Screenshots (if appropriate or helpful)

Top the weather set with the changed-in-size icons marked with blue background.
Bottom the set before this PR.

![image](https://github.com/user-attachments/assets/8af8c2b8-cbbe-43ea-b1d2-11cbd6f1a6cc)

_Icons in a Nerd Font Mono variant_