### PR TITLE
Fix Powerline glyphs position and size in some cases

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.14.7"
+script_version = "4.14.9"
 
 version = "3.2.1"
 projectName = "Nerd Fonts"
@@ -1568,7 +1568,7 @@ class font_patcher:
                 elif sym_attr['align'] == 'c':
                     if overlap_width > 0:
                         x_align_distance -= overlap_width / 2
-                elif sym_attr['align'] == 'r':
+                elif sym_attr['align'] == 'r' and not self.args.nonmono:
                     # Check and correct overlap; it can go wrong if we have a xy-ratio limit
                     target_xmax = (self.font_dim['xmin'] + self.font_dim['width']) * self.get_target_width(stretch)
                     target_xmax += overlap_width


### PR DESCRIPTION
#### Description

Correct right aligned glyphs in proportional fonts (i.e. `--variable`).

Only very few icons are right aligned, all Powerline glyphs.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

* #1695

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
