### PR TITLE
Bugfix glyphnames in released fonts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,13 @@ jobs:
           fontforge --version
           fontforge --version 2>&1 | grep libfontforge | awk '{print $NF}'
 
-      - name: Bump version for source files
+      - name: Bump version for source files and update glyphnames.json
+        # and check if generated glyphnames.json is valid
         run: |
           cd -- "$GITHUB_WORKSPACE/bin/scripts"
           ./version-bump.sh "$RELEASE_VERSION"
+          ./generate-css.sh
+          jq . ../../glyphnames.json > /dev/null
 
       - name: Patch all the variations of the font family
         run: |

--- a/bin/scripts/generate-css.sh
+++ b/bin/scripts/generate-css.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.3.0
-# Script Version: 1.2.1
+# Script Version: 1.3.0
 # Generates CSS file for the font and cheat sheet code
 
 # shellcheck disable=SC1091 # Do not pull in the sourced file
@@ -70,13 +70,11 @@ for var in "${!i@}"; do
   # replace _ with -
   glyph_name=${glyph_name/_/-}
   glyph_char=${!var}
-  glyph_code=$(printf "%x" "'$glyph_char'")
 
   #echo "$var=${!var}"
 
   #echo "$glyph_name"
   #echo "$glyph_char"
-  #echo "$glyph_code"
   #printf "%x" "'$glyph_char'"
 
   if [[ "$glyph_name" != mdi-* ]]; then
@@ -84,7 +82,7 @@ for var in "${!i@}"; do
     {
       printf ".nf-%s:before {" "$glyph_name"
       printf "\\n"
-      printf "  content: \"\\%s\";" "$glyph_code"
+      printf "  content: \"\\%x\";" "'$glyph_char'"
       printf "\\n"
       printf "}"
       printf "\\n"
@@ -92,18 +90,18 @@ for var in "${!i@}"; do
 
     # generate css min rules
     {
-      printf ".nf-%s:before{content:\"\\%s\"}" "$glyph_name" "$glyph_code"
+      printf ".nf-%s:before{content:\"\\%x\"}" "$glyph_name" "'$glyph_char'"
     } >> "$output_css_min_file"
 
     # generate json entry
     {
-      printf ",\"%s\":{\"char\":\"%s\",\"code\":\"%s\"}" "$glyph_name" "$glyph_char" "$glyph_code"
+      printf ",\"%s\":{\"char\":\"%s\",\"code\":\"%x\"}" "$glyph_name" "$glyph_char" "'$glyph_char'"
     } >> "$output_json_file"
 
   else
     # generate css min rules for removed glyphs
     {
-      printf ".nfold-%s:before{content:\"\\%s\"}" "$glyph_name" "$glyph_code"
+      printf ".nfold-%s:before{content:\"\\%x\"}" "$glyph_name" "'$glyph_char'"
     } >> "$output_css_min_rem_file"
   fi
 
@@ -114,7 +112,7 @@ for var in "${!i@}"; do
     else
       namespace="nf"
     fi
-    printf "  \"%s-%s\": \"%s\",\\n" "$namespace" "$glyph_name" "$glyph_code"
+    printf "  \"%s-%s\": \"%x\",\\n" "$namespace" "$glyph_name" "'$glyph_char'"
   } >> "$output_cheat_sheet_file"
 
 done


### PR DESCRIPTION
#### Description
```
    CI: Regenerate glyphnames before release
    
    [why]
    When the icon sets have changed (added or names changed) the i_*.sh
    files are (hopefully) up to date, but the glyphnames.json file is only
    updated on release.
    
    Unfortunately the font-patcher uses the glyphnames.json to determine the
    patched-in glyphs' names, but in the workflow the json file is only
    updated after all fonts have been patched.
    
    [how]
    Like the version number in the font-patcher file we also create a
    transient glyphnames.json in each patching job, that the font-patcher
    can then utilize.
    
    Still the in-repo glyphnames.json is only updated after successful
    release. So in pinciple we call the generate-css.sh (which also
    generates the glyphnames.json) once for every font in the font matrix
    (just before patching) and then finally after all patching has been done
    again and that is committed back to the repo.
    
    Fixes: #1745
 ```

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Update the `glyphnames.json` in the release workflow _**before**_ the fonts are patched, because an up-to-date glyphname database is needed for patching.

The first commit speeds up the `glyphnames.json` creator script which is extremely slow - that has never been tackled because it was only once called after a 3 hour patch run, and so it did not matter match anyhow.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
