### PR TITLE
docs: improve contributors badge

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-118-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/ryanoasis/nerd-fonts?color=ee8449&style=flat-square)](#contributors)
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):


### PR DESCRIPTION
#### Description

Made the all-contributors badge (at the top here https://github.com/ryanoasis/nerd-fonts/blob/master/CONTRIBUTORS.md) update live and changed the color (`orange` → `#ee8449`).

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

#### What does this Pull Request (PR) do?
Improves the all-contributors badge in CONTRIBUTORS.md

#### Any background context you can provide?
All in accordance with https://allcontributors.org/docs/en/bot/faq and https://shields.io/badges/git-hub-contributors-from-allcontributors-org