### PR TITLE
Add new option to keep original glyphs as is when adding single-width icons

### DIFF
--- a/bin/scripts/archive-fonts.sh
+++ b/bin/scripts/archive-fonts.sh
@@ -88,7 +88,7 @@ while read -r filename; do
         (cd "$path" && tar rf "$outputdir/$basename.tar" --no-recursion "$file")
     done < <(find "${searchdir}" -type f -exec bash -c 'printf "%s\000" "{}" | sed "s!\(.*\)/!\1|!"' \; | sort -z -u '-t|' -k2,2 | sort -z)
 
-    if [ $expected -ne 0 ]; then
+    if [ "$expected" -ne 0 ]; then
         # Should never happen, but who knows
         echo "${LINE_PREFIX} Did not pack expected number of font files! Likely same font names for different paths."
         exit 1

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.16.3"
+script_version = "4.17.0"
 
 version = "3.3.0"
 projectName = "Nerd Fonts"
@@ -837,7 +837,7 @@ class font_patcher:
                 "results might be useless%s",
                 " - offending char: {:X}".format(offending_char) if offending_char is not None else "")
             if self.args.single <= 1:
-                logger.critical("Font will not be patched! Give --mono (or -s, or --use-single-width-glyphs) twice to force patching")
+                logger.critical("Font will not be patched! Give --mono (or -s) twice to force patching")
                 sys.exit(1)
         if width_mono:
             force_panose_monospaced(self.sourceFont)
@@ -1974,7 +1974,8 @@ def setup_arguments():
     # optional arguments
     parser.add_argument('font',                                      help='The path to the font to patch (e.g., Inconsolata.otf)')
     parser.add_argument('-v', '--version',                           action='version',        version=projectName + ": %(prog)s (" + version + ")")
-    parser.add_argument('-s', '--mono', '--use-single-width-glyphs', dest='single',           default=False, action='count',      help='Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)')
+    parser.add_argument('-s', '--mono',                              dest='single',           default=False, action='count',      help='Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)')
+    parser.add_argument('--use-single-width-glyphs',                 dest='single',           default=False, action='count',      help=argparse.SUPPRESS)
     parser.add_argument('--variable-width-glyphs',                   dest='nonmono',          default=False, action='store_true', help='Do not adjust advance width (no "overhang") (Nerd Font Propo)')
     parser.add_argument('--debug',                                   dest='debugmode',        default=0,     type=int, nargs='?', help='Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)', const=2, choices=range(0, 3 + 1))
     parser.add_argument('-q', '--quiet',                             dest='quiet',            default=False, action='store_true', help='Do not generate verbose output')
@@ -2089,7 +2090,7 @@ def setup_arguments():
         args.complete = font_complete
 
     if args.nonmono and args.single:
-        logger.warning("Specified contradicting --variable-width-glyphs and --use-single-width-glyph. Ignoring --variable-width-glyphs.")
+        logger.warning("Specified contradicting --variable-width-glyphs and --mono. Ignoring --variable-width-glyphs.")
         args.nonmono = False
 
     make_sure_path_exists(args.outputdir)

--- a/font-patcher
+++ b/font-patcher
@@ -358,7 +358,7 @@ class font_patcher:
         self.sourceFont.encoding = 'UnicodeFull'  # Update the font encoding to ensure that the Unicode glyphs are available
         self.onlybitmaps = self.sourceFont.onlybitmaps  # Fetch this property before adding outlines. NOTE self.onlybitmaps initialized and never used
 
-        if self.args.single:
+        if self.args.forcemono:
             # Force width to be equal on all glyphs to ensure the font is considered monospaced on Windows.
             # This needs to be done on all characters, as some information seems to be lost from the original font file.
             self.set_sourcefont_glyph_widths()
@@ -832,11 +832,11 @@ class font_patcher:
             logger.warning("Monospaced check: %s and %s",
                 report_advance_widths(self.sourceFont),
                 panose_check_to_text(panose_mono, self.sourceFont.os2_panose))
-        if self.args.single and not width_mono:
+        if self.args.forcemono and not width_mono:
             logger.warning("Sourcefont is not monospaced - forcing to monospace not advisable, "
                 "results might be useless%s",
                 " - offending char: {:X}".format(offending_char) if offending_char is not None else "")
-            if self.args.single <= 1:
+            if self.args.forcemono <= 1:
                 logger.critical("Font will not be patched! Give --mono (or -s) twice to force patching")
                 sys.exit(1)
         if width_mono:
@@ -1974,8 +1974,9 @@ def setup_arguments():
     # optional arguments
     parser.add_argument('font',                                      help='The path to the font to patch (e.g., Inconsolata.otf)')
     parser.add_argument('-v', '--version',                           action='version',        version=projectName + ": %(prog)s (" + version + ")")
-    parser.add_argument('-s', '--mono',                              dest='single',           default=False, action='count',      help='Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)')
-    parser.add_argument('--use-single-width-glyphs',                 dest='single',           default=False, action='count',      help=argparse.SUPPRESS)
+    parser.add_argument('-s', '--mono',                              dest='forcemono',        default=False, action='count',      help='Create monospaced font, existing and added glyphs are single-width (implies --single-width-glyphs)')
+    parser.add_argument('--use-single-width-glyphs',                 dest='forcemono',        default=False, action='count',      help=argparse.SUPPRESS)
+    parser.add_argument('--single-width-glyphs',                     dest='single',           default=False, action='store_true', help='Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)')
     parser.add_argument('--variable-width-glyphs',                   dest='nonmono',          default=False, action='store_true', help='Do not adjust advance width (no "overhang") (Nerd Font Propo)')
     parser.add_argument('--debug',                                   dest='debugmode',        default=0,     type=int, nargs='?', help='Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)', const=2, choices=range(0, 3 + 1))
     parser.add_argument('-q', '--quiet',                             dest='quiet',            default=False, action='store_true', help='Do not generate verbose output')
@@ -2089,8 +2090,10 @@ def setup_arguments():
                 font_complete = False
         args.complete = font_complete
 
+    if args.forcemono:
+        args.single = True
     if args.nonmono and args.single:
-        logger.warning("Specified contradicting --variable-width-glyphs and --mono. Ignoring --variable-width-glyphs.")
+        logger.warning("Specified contradicting --variable-width-glyphs together with --mono or --single-width-glyphs. Ignoring --variable-width-glyphs.")
         args.nonmono = False
 
     make_sure_path_exists(args.outputdir)

--- a/font-patcher
+++ b/font-patcher
@@ -2168,6 +2168,7 @@ def setup_arguments():
             logger.critical("Can not create single font files from True Type Collections")
             sys.exit(1)
 
+    # The if might look ridiculous, but isinstance(False, int) is True!
     if isinstance(args.xavgwidth, int) and not isinstance(args.xavgwidth, bool):
         if args.xavgwidth < 0:
             logger.critical("--xavgcharwidth takes no negative numbers")

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.17.0"
+script_version = "4.18.0"
 
 version = "3.3.0"
 projectName = "Nerd Fonts"
@@ -1266,6 +1266,14 @@ class font_patcher:
             logger.debug("Metrics is strange")
             pass # Will fail the metrics check some line later
 
+        if self.args.cellopt:
+            logger.debug("Overriding cell Y{%d:%d} with Y{%d:%d}",
+                self.font_dim['ymin'], self.font_dim['ymax'],
+                self.args.cellopt[2], self.args.cellopt[3])
+            self.font_dim['ymin'] = self.args.cellopt[2]
+            self.font_dim['ymax'] = self.args.cellopt[3]
+            our_btb = self.args.cellopt[3] - self.args.cellopt[2]
+
         # Calculate font height
         self.font_dim['height'] = -self.font_dim['ymin'] + self.font_dim['ymax']
         if self.font_dim['height'] == 0:
@@ -1288,7 +1296,7 @@ class font_patcher:
             sys.exit(1)
 
         self.font_dim['iconheight'] = self.font_dim['height']
-        if self.args.single and self.sourceFont.capHeight > 0:
+        if self.args.single and self.sourceFont.capHeight > 0 and not isinstance(self.args.cellopt, list):
             # Limit the icon height on monospaced fonts because very slender and tall icons render
             # excessivly tall otherwise. We ignore that effect for the other variants because it
             # does not look so much out of place there.
@@ -1348,9 +1356,21 @@ class font_patcher:
         if self.font_dim['width'] <= 0:
             logger.critical("Can not detect sane font width")
             sys.exit(1)
+        if isinstance(self.args.cellopt, list):
+            logger.debug("Overriding cell X{%d:%d} with X{%d:%d}",
+                self.font_dim['xmin'], self.font_dim['xmin'] + self.font_dim['width'],
+                self.args.cellopt[0], self.args.cellopt[1])
+            self.font_dim['xmin'] = self.args.cellopt[0]
+            self.font_dim['xmax'] = self.args.cellopt[1]
+            self.font_dim['width'] = self.args.cellopt[1]
         logger.debug("Final font cell dimensions %d w x %d h%s",
             self.font_dim['width'], self.font_dim['height'],
             ' (with icon cell {} h)'.format(int(self.font_dim['iconheight'])) if self.font_dim['iconheight'] != self.font_dim['height'] else '')
+        if self.args.cellopt:
+            logger.info("Cell coordinates %s%d:%d:%d:%d",
+                '' if not isinstance(self.args.cellopt, list) else 'overridden with ',
+                self.font_dim['xmin'], self.font_dim['width'],
+                self.font_dim['ymax'] - self.font_dim['height'], self.font_dim['ymax'])
 
         self.xavgwidth.append(self.args.xavgwidth)
         if isinstance(self.xavgwidth[-1], int) and self.xavgwidth[-1] == 0:
@@ -2030,6 +2050,7 @@ def setup_arguments():
     # <none>  - copy from sourcefont (default)
     # 0       - calculate from font according to OS/2-version-2
     # 500     - set to 500
+    expert_group.add_argument('--cell',                                    dest='cellopt',          default=None,  type=str,            help='Adjust or quiery the call size, e.g. use "0:1000:-200:800" resp "?"')
 
     # progress bar arguments - https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
     progressbars_group_parser.add_argument('--progressbars',         dest='progressbars',     action='store_true',                help='Show percentage completion progress bars per Glyph Set (default)')
@@ -2095,6 +2116,23 @@ def setup_arguments():
     if args.nonmono and args.single:
         logger.warning("Specified contradicting --variable-width-glyphs together with --mono or --single-width-glyphs. Ignoring --variable-width-glyphs.")
         args.nonmono = False
+
+    if args.cellopt:
+        if args.cellopt != '?':
+            try:
+                parts = [ int(v) for v in args.cellopt.split(':') ]
+                if len(parts) != 4:
+                    raise
+            except:
+                logger.critical("Parameter for --cell is not 4 colon seprated integer numbers: '%s'", args.cellopt)
+                sys.exit(2)
+            if parts[0] >= parts[1] or parts[2] >= parts[3]:
+                logger.critical("Parameter for --cell do not result in positive cell size: %d x %d",
+                    parts[1] - parts[0], parts[3] - parts[2])
+                sys.exit(2)
+            if parts[0] != 0:
+                logger.warn("First parameter for --cell should be zero, this is probably not working")
+            args.cellopt = parts
 
     make_sure_path_exists(args.outputdir)
     if not os.path.isfile(args.font):

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install Nerd Fonts
-__ScriptVersion="0.7"
+__ScriptVersion="0.8"
 
 # Default values for option variables:
 quiet=false
@@ -15,7 +15,7 @@ installpath="user"
 usage() {
   cat << EOF
 Usage: ./install.sh [-q -v -h] [[--copy | --link] --clean | --list | --remove]
-                    [--use-single-width-glyphs] [--windows] [--otf | --ttf]
+                    [--mono] [--windows] [--otf | --ttf]
                     [--install-to-user-path | --install-to-system-path ]
                     [FONT...]
 
@@ -36,7 +36,7 @@ General options:
                                 with this script).
                                 Can be combined with -L for a dry run.
 
-  -s, --use-single-width-glyphs Install single-width glyphs variants.
+  -s, --mono                    Install single-width glyphs variants.
   -p, --use-proportional-glyphs Install proportional glyphs variants.
 
   -U, --install-to-user-path    Install fonts to users home font path [default].
@@ -87,7 +87,7 @@ while getopts "$optspec" optchar; do
               [ "$mode" != "remove" ] && mode="list";;
         remove) mode="remove";;
         clean) clean=true;;
-        use-single-width-glyphs) variant="M";;
+        mono) variant="M";;
         use-proportional-glyphs) variant="P";;
         otf) extension="otf";;
         ttf) extension="ttf";;

--- a/readme.md
+++ b/readme.md
@@ -482,8 +482,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width) (Nerd Font Mono)
   --variable-width-glyphs
                         Do not adjust advance width (no "overhang") (Nerd Font Propo)
   --debug [{0,1,2,3}]   Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)
@@ -538,7 +537,7 @@ Expert Options:
 ```
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 
 ./font-patcher Inconsolata.otf --fontawesome
 ./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -349,8 +349,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -404,7 +403,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_es.md
+++ b/readme_es.md
@@ -378,8 +378,7 @@ argumentos posicionales:
 argumentos opcionales:
   -h, --help            muestra este mensaje de ayuda y sale
   -v, --version         muestra la versión del programa y sale
-  -s, --mono, --use-single-width-glyphs
-                        Indica si genera los glifos como ancho simple, no doble (por defecto es ancho doble)
+  -s, --mono            Indica si genera los glifos como ancho simple, no doble (por defecto es ancho doble)
   -l, --adjust-line-height
                         Indica si se ajustan las alturas de línea (para intentar centrar los separadores de powerline más parejo)
   -q, --quiet, --shutup
@@ -434,7 +433,7 @@ Symbol Fonts:
 ```
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 
 ./font-patcher Inconsolata.otf --fontawesome
 ./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -410,8 +410,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -465,7 +464,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_hi.md
+++ b/readme_hi.md
@@ -387,8 +387,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -442,7 +441,7 @@ Symbol Fonts:
 
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-    ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+    ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_it.md
+++ b/readme_it.md
@@ -331,8 +331,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -386,7 +385,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -326,8 +326,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -381,7 +380,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_ko.md
+++ b/readme_ko.md
@@ -327,8 +327,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -382,7 +381,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_pl.md
+++ b/readme_pl.md
@@ -403,8 +403,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -458,7 +457,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_pt-pt.md
+++ b/readme_pt-pt.md
@@ -327,8 +327,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -382,7 +381,7 @@ Symbol Fonts:
 
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 	./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -376,8 +376,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -432,7 +431,7 @@ Symbol Fonts:
 ```
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 
 ./font-patcher Inconsolata.otf --fontawesome
 ./font-patcher Inconsolata.otf --fontawesome --octicons --pomicons

--- a/readme_tw.md
+++ b/readme_tw.md
@@ -376,8 +376,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -432,7 +431,7 @@ Symbol Fonts:
 ```
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
 ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet

--- a/readme_uk.md
+++ b/readme_uk.md
@@ -324,8 +324,7 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -s, --mono, --use-single-width-glyphs
-                        Whether to generate the glyphs as single-width not double-width (default is double-width)
+  -s, --mono            Whether to generate the glyphs as single-width not double-width (default is double-width)
   -l, --adjust-line-height
                         Whether to adjust line heights (attempt to center powerline separators more evenly)
   -q, --quiet, --shutup
@@ -378,7 +377,7 @@ Symbol Fonts:
 
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -s -q
-    ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --use-single-width-glyphs --quiet
+    ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --mono --quiet
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf -w
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --quiet
     ./font-patcher Droid\ Sans\ Mono\ for\ Powerline.otf --windows --pomicons --quiet


### PR DESCRIPTION
#### Description

At the moment, if you want to have "monospaces" icons you always also force the font to be monospaced in Windows terms.
That has biten us in the past. Maybe It is better to leave that choice to the user and make this two options.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Remove `--use-single-width-glyphs` (to avoid confusion)
Add `--single-with-glyphs` which is analogous to `--variable-with-glyphs` and just affects our added icons.
The old `-s` and `--mono` force any font to be strictly monospaced and also sets the new `single-with-glyphs` option.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #1772 

#### Screenshots (if appropriate or helpful)
