### PR TITLE
Improve patching-under-Windows compat

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.18.0"
+script_version = "4.18.1"
 
 version = "3.3.0"
 projectName = "Nerd Fonts"
@@ -1845,6 +1845,7 @@ def sanitize_filename(filename, allow_dirs = False):
     """ Enforces to not use forbidden characters in a filename/path. """
     if filename == '.' and not allow_dirs:
         return '_'
+    restore_colon = sys.platform == 'win32' and re.match('[a-z]:', filename, re.I)
     trans = filename.maketrans('<>:"|?*', '_______')
     for i in range(0x00, 0x20):
         trans[i] = ord('_')
@@ -1853,7 +1854,10 @@ def sanitize_filename(filename, allow_dirs = False):
         trans[ord('\\')] = ord('_')
     else:
         trans[ord('\\')] = ord('/') # We use Posix paths
-    return filename.translate(trans)
+    new_filename = filename.translate(trans)
+    if restore_colon:
+        new_filename = new_filename[ :1] + ':' + new_filename[2: ]
+    return new_filename
 
 def get_multiglyph_boundingBox(glyphs, destGlyph = None):
     """ Returns dict of the dimensions of multiple glyphs combined(, as if they are copied into destGlyph) """

--- a/font-patcher
+++ b/font-patcher
@@ -322,7 +322,7 @@ def fetch_glyphnames():
     """ Read the glyphname database and put it into a dictionary """
     try:
         glyphnamefile = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), 'glyphnames.json'))
-        with open(glyphnamefile, 'r') as f:
+        with open(glyphnamefile, 'rb') as f:
             namelist = json.load(f)
             return { int(v['code'], 16): k for k, v in namelist.items() if 'code' in v }
     except Exception as error:

--- a/font-patcher
+++ b/font-patcher
@@ -38,7 +38,7 @@ except ImportError:
         )
     )
 
-sys.path.insert(0, os.path.abspath(os.path.dirname(sys.argv[0])) + '/bin/scripts/name_parser/')
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'bin', 'scripts', 'name_parser'))
 try:
     from FontnameParser import FontnameParser
     from FontnameTools import FontnameTools
@@ -321,7 +321,7 @@ def create_filename(fonts):
 def fetch_glyphnames():
     """ Read the glyphname database and put it into a dictionary """
     try:
-        glyphnamefile = os.path.abspath(os.path.dirname(sys.argv[0])) + '/glyphnames.json'
+        glyphnamefile = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), 'glyphnames.json'))
         with open(glyphnamefile, 'r') as f:
             namelist = json.load(f)
             return { int(v['code'], 16): k for k, v in namelist.items() if 'code' in v }


### PR DESCRIPTION
#### Description

Improve Windows as patching OS compatibility by
* allowing absolute path to begin with a drive letter
* assembling path with the system path separator

And finally, for all systems:
* Specify encoding of glyphnames datafile to avoid surprises

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Apart from other stuff, allow a drive letter in the `outputdir` parameter:

Example:
```
PS C:\Program Files (x86)\FontForgeBuilds\bin> .\fontforge.exe
    --script C:\Users\jastr\Downloads\FontPatcher\font-patcher
    --outputdir c:\Users\jastr
    C:\Users\jastr\Downloads\Miosevka12.\Font\Miosevka12\Miosevka-Regular.ttf
```

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
* #1761 

#### Screenshots (if appropriate or helpful)
