### PR TITLE
Improve gitlab icon

### DIFF
--- a/src/svgs/gitlab.svg
+++ b/src/svgs/gitlab.svg
@@ -30,7 +30,7 @@
   <defs
      id="defs74">
     <style
-       id="style72">.cls-1{fill:#e24329;}.cls-2{fill:#fc6d26;}.cls-3{fill:#fca326;}</style>
+       id="style72">.cls-1{fill:#000;}.cls-2{fill:#000;}.cls-3{fill:#000;}</style>
   </defs>
   <g
      id="LOGO"

--- a/src/svgs/gitlab.svg
+++ b/src/svgs/gitlab.svg
@@ -1,18 +1,55 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="32"
-   height="32"
-   viewBox="0 0 125.785 125.785"
-   class="footer-logo"
-   version="1.1"
-   id="svg969"
+   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1000"
+   height="963.197"
+   viewBox="0 0 1000 963.197"
+   version="1.1"
+   id="svg85">
+  <sodipodi:namedview
+     id="namedview87"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="991.5"
+     inkscape:cy="964.5"
+     inkscape:window-width="1126"
+     inkscape:window-height="895"
+     inkscape:window-x="774"
+     inkscape:window-y="12"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg85" />
   <defs
-     id="defs973" />
-  <path
-     id="path955"
-     class="logo-svg-shape logo-dark-orange-shape"
-     d="M 10.363281 7 C 10.225809 7 10.088371 7.0956265 10.037109 7.2851562 L 8.0410156 14.646484 L 7.0332031 18.361328 C 6.9416183 18.700192 7.0427929 19.071877 7.2832031 19.28125 L 16 26.871094 L 24.716797 19.28125 C 24.957462 19.071877 25.058636 18.700192 24.966797 18.361328 L 23.958984 14.646484 L 21.962891 7.2851562 C 21.860112 6.9060967 21.413071 6.9060967 21.310547 7.2851562 L 19.314453 14.646484 L 12.685547 14.646484 L 10.689453 7.2851562 C 10.638064 7.0956265 10.500754 7 10.363281 7 z "
-     transform="scale(3.9307812)" />
+     id="defs74">
+    <style
+       id="style72">.cls-1{fill:#e24329;}.cls-2{fill:#fc6d26;}.cls-3{fill:#fca326;}</style>
+  </defs>
+  <g
+     id="LOGO"
+     transform="matrix(5.2068817,0,0,5.2068817,-489.30756,-507.76085)">
+    <path
+       class="cls-1"
+       d="m 282.83,170.73 -0.27,-0.69 -26.14,-68.22 a 6.81,6.81 0 0 0 -2.69,-3.24 7,7 0 0 0 -8,0.43 7,7 0 0 0 -2.32,3.52 l -17.65,54 h -71.47 l -17.65,-54 a 6.86,6.86 0 0 0 -2.32,-3.53 7,7 0 0 0 -8,-0.43 6.87,6.87 0 0 0 -2.69,3.24 L 97.44,170 l -0.26,0.69 a 48.54,48.54 0 0 0 16.1,56.1 l 0.09,0.07 0.24,0.17 39.82,29.82 19.7,14.91 12,9.06 a 8.07,8.07 0 0 0 9.76,0 l 12,-9.06 19.7,-14.91 40.06,-30 0.1,-0.08 a 48.56,48.56 0 0 0 16.08,-56.04 z"
+       id="path76" />
+    <path
+       class="cls-2"
+       d="m 282.83,170.73 -0.27,-0.69 a 88.3,88.3 0 0 0 -35.15,15.8 L 190,229.25 c 19.55,14.79 36.57,27.64 36.57,27.64 l 40.06,-30 0.1,-0.08 a 48.56,48.56 0 0 0 16.1,-56.08 z"
+       id="path78" />
+    <path
+       class="cls-3"
+       d="m 153.43,256.89 19.7,14.91 12,9.06 a 8.07,8.07 0 0 0 9.76,0 l 12,-9.06 19.7,-14.91 c 0,0 -17.04,-12.89 -36.59,-27.64 -19.55,14.75 -36.57,27.64 -36.57,27.64 z"
+       id="path80" />
+    <path
+       class="cls-2"
+       d="M 132.58,185.84 A 88.19,88.19 0 0 0 97.44,170 l -0.26,0.69 a 48.54,48.54 0 0 0 16.1,56.1 l 0.09,0.07 0.24,0.17 39.82,29.82 c 0,0 17,-12.85 36.57,-27.64 z"
+       id="path82" />
+  </g>
 </svg>


### PR DESCRIPTION
#### Description

Updates the GitLab icon as per https://about.gitlab.com/press/press-kit/.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [x] Verified the license of any newly added font, glyph, or glyph set. License is: CC-BY-SA-4.0,3.0,2.5,2.0,1.0 license