### PR TITLE
fix: update brew instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,10 +223,10 @@ curl -OL https://github.com/ryanoasis/nerd-fonts/releases/latest/download/JetBra
 
 > Best option if on **macOS** and want to use **Homebrew**.
 
-All fonts are available via [Homebrew Cask](https://github.com/Homebrew/homebrew-cask) on macOS (OS X)
+All fonts are available via [Homebrew Cask](https://formulae.brew.sh/cask-font/) on macOS (OS X)
 
 ```sh
-brew install font-hack-nerd-font
+brew install --cask font-ubuntu-nerd-font
 ```
 
 ### `Option 3: Unofficial Chocolatey or Scoop Repositories`


### PR DESCRIPTION
Fix installation instructions using brew

#### Description
Current brew installation instructions do not work, this should fix it.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
Fix the installation instructions

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![image](https://github.com/user-attachments/assets/5278e83b-34ee-4f32-8c4b-0a8e75c00855)