### PR TITLE
Add progress indicators to cheat sheet

### DIFF
--- a/bin/scripts/lib/README.md
+++ b/bin/scripts/lib/README.md
@@ -45,5 +45,6 @@ Only glyphs listed here could be found with the cheat sheet.
 * `PowerlineExtraSymbols.otf`: `i_ple.sh`
 * `powerline-symbols/PowerlineSymbols.otf`: _is a subset of PowerlineExtraSymbols_
 * `Pomicons.otf`: `i_pom.sh`
+* `extraglyphs.sfd`: `i_extra.sh` _(only a subset)_
 * `original-source.otf`: `i_seti.sh`
 * `weather-icons/weathericons-regular-webfont.ttf`: `i_weather.sh`

--- a/bin/scripts/lib/i_all.sh
+++ b/bin/scripts/lib/i_all.sh
@@ -6,7 +6,7 @@
 # is 'include-old-material' the old material design icons will be
 # included. This is needed for the cheat sheet.
 
-sets=('cod' 'dev' 'fae' 'fa' 'iec' 'logos' 'oct' 'ple' 'pom' 'seti' 'weather' 'md')
+sets=('cod' 'dev' 'extra' 'fae' 'fa' 'iec' 'logos' 'oct' 'ple' 'pom' 'seti' 'weather' 'md')
 base=$(dirname "${BASH_SOURCE[0]:-$0}")
 
 if [ "$1" = "include-old-material" ]; then

--- a/bin/scripts/lib/i_extra.sh
+++ b/bin/scripts/lib/i_extra.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Progress indicators from Fira Code (12 icons)
+# Codepoints: EE00-EE0B
+# Nerd Fonts Version: 3.3.0
+# Script Version: 1.0.0
+test -n "$__i_prog_loaded" && return || __i_prog_loaded=1
+i='' i_extra_progress_empty_left=$i
+i='' i_extra_progress_empty_mid=$i
+i='' i_extra_progress_empty_right=$i
+i='' i_extra_progress_full_left=$i
+i='' i_extra_progress_full_mid=$i
+i='' i_extra_progress_full_right=$i
+i='' i_extra_progress_spinner_1=$i
+i='' i_extra_progress_spinner_2=$i
+i='' i_extra_progress_spinner_3=$i
+i='' i_extra_progress_spinner_4=$i
+i='' i_extra_progress_spinner_5=$i
+i='' i_extra_progress_spinner_6=$i
+unset i


### PR DESCRIPTION
[why]
The progress indicators can not be found, people need to know that they are there.

The progress indicators (taken from Fira Code) were introduced with #1733 and then moved:
    bd5936856  font-patcher: Add progress indicators
    41f91bcb4  Combine extraglyphs fonts

But no entry in the cheat sheet has been added. Which is the same for the boxdrawing glyphs and others in extraglyphs, but those other will probably be not searched for.

[how]
Add a new i_*.sh file for the extraglyphs icon set and introduce a new prefix just for the progress indicators to improve discoverability.

Fixes: #1827

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
