### PR TITLE
font-patcher: Create smaller otf files

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1586,17 +1586,11 @@ class font_patcher:
                     scale_ratio_x = scale_ratio_x * xy_ratio_max / xy_ratio
 
             if scale_ratio_x != 1.0 or scale_ratio_y != 1.0:
+                scale_ratio_x *= self.sourceFont.em / (self.sourceFont.em + 1) # scale a tiny bit too small to avoid rounding problems
                 self.sourceFont[currentSourceFontGlyph].transform(psMat.scale(scale_ratio_x, scale_ratio_y))
 
             # Drop nonintegral part of nodes' coordinates; ttf will do it anyhow, otf will be much smaller
             self.sourceFont[currentSourceFontGlyph].round()
-            if self.args.single:
-                (xmin, _, xmax, _) = self.sourceFont[currentSourceFontGlyph].boundingBox()
-                dest_width = self.font_dim['width'] * (1 + (overlap or 0))
-                if int(xmax - xmin) > dest_width:
-                    self.sourceFont.paste()
-                    self.sourceFont[currentSourceFontGlyph].transform(
-                            psMat.scale(scale_ratio_x * (dest_width / (dest_width + 1)), scale_ratio_y))
 
             # We pasted and scaled now we want to align/move
             # Use the dimensions from the newly pasted and stretched glyph to avoid any rounding errors

--- a/font-patcher
+++ b/font-patcher
@@ -1588,6 +1588,16 @@ class font_patcher:
             if scale_ratio_x != 1.0 or scale_ratio_y != 1.0:
                 self.sourceFont[currentSourceFontGlyph].transform(psMat.scale(scale_ratio_x, scale_ratio_y))
 
+            # Drop nonintegral part of nodes' coordinates; ttf will do it anyhow, otf will be much smaller
+            self.sourceFont[currentSourceFontGlyph].round()
+            if self.args.single:
+                (xmin, _, xmax, _) = self.sourceFont[currentSourceFontGlyph].boundingBox()
+                dest_width = self.font_dim['width'] * (1 + (overlap or 0))
+                if int(xmax - xmin) > dest_width:
+                    self.sourceFont.paste()
+                    self.sourceFont[currentSourceFontGlyph].transform(
+                            psMat.scale(scale_ratio_x * (dest_width / (dest_width + 1)), scale_ratio_y))
+
             # We pasted and scaled now we want to align/move
             # Use the dimensions from the newly pasted and stretched glyph to avoid any rounding errors
             sym_dim = get_glyph_dimensions(self.sourceFont[currentSourceFontGlyph])
@@ -1675,9 +1685,6 @@ class font_patcher:
                 # - Set width
                 # - Calculate and set new right_side_bearing
                 self.sourceFont[currentSourceFontGlyph].width = int(width)
-
-            # Drop nonintegral part of nodes' coordinates; ttf will do it anyhow, otf will be much smaller
-            self.sourceFont[currentSourceFontGlyph].round()
 
             # Check if the inserted glyph is scaled correctly for monospace
             if self.args.single:

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.18.2"
+script_version = "4.19.0"
 
 version = "3.3.0"
 projectName = "Nerd Fonts"
@@ -1675,6 +1675,9 @@ class font_patcher:
                 # - Set width
                 # - Calculate and set new right_side_bearing
                 self.sourceFont[currentSourceFontGlyph].width = int(width)
+
+            # Drop nonintegral part of nodes' coordinates; ttf will do it anyhow, otf will be much smaller
+            self.sourceFont[currentSourceFontGlyph].round()
 
             # Check if the inserted glyph is scaled correctly for monospace
             if self.args.single:


### PR DESCRIPTION
[why]
The patched fonts in otf format are much bigger than the ttf counterparts. Even when the same font is used as source. The factor is about 2 to 3.5 in size.

[how]
Fonts in ttf format can not store nodes with sub-integer precision. The coordinates are rounded on export. But otf fonts can have real numbers (may it be floating point or fixed point notation, I am not sure right now and it does not matter) for coordinates, but the more precise numbers take much more space in the font file. If an otf is created where the coordinates are already integer this extra space is not needed.

So we do all the calculations with real numbers (including decimals) and only in the last step the coordinates of the added glyphs are rounded to integer (i.e. to the EM size grid).

Fixes: #1848

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
