### PR TITLE
Fix cheatsheet footer last sentence tag

### DIFF
--- a/bin/scripts/data/cheatsheet-foot.txt
+++ b/bin/scripts/data/cheatsheet-foot.txt
@@ -5,7 +5,7 @@
 <h5 align="center">With Release <code>v3.0.0</code> the Material Design Icons were updated and moved to a new codepoint range (reasons for that are in the <a href="releases#v3.0.0">release notes</a>).</h5>
 <h5 align="center">They are still shown here for reference, but are missing in the actual fonts.</h5>
 <h5 align="center">To find for example the replacement for <code>nf-mdi-altimeter</code> enter just <code>altimeter</code> in the search box.</h5>
-+<h5 align="center">Some icons have been dropped without replacement.</h5>
+<h5 align="center">Some icons have been dropped without replacement.</h5>
 <br>
 
 <h3>Example Usages</h3>


### PR DESCRIPTION
#### Description

Fixes random plus sign at the start of the line, which prevents correct application of `<h5>`  tag to the added sentence. Bug was introduced by https://github.com/ryanoasis/nerd-fonts/commit/a27373efd7dfc92426fe9f9a26004e27c9acd1f2, which copied changes from https://github.com/ryanoasis/nerd-fonts/commit/7a6b90f19a2fcc59162af363aeae7271b6b48b30, but it seems was a little sloppy and left out plus sign from manual git diff copying.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### Relevant tickets
Original ticket is https://github.com/ryanoasis/nerd-fonts/issues/1795, fix to which introduced this bug.

#### Screenshots
![image](https://github.com/user-attachments/assets/dac2362f-ff35-47d7-bbfa-e3320c14cf30)
