### PR TITLE
fix(install.sh): prevent arbitrary command execution via unsafe user …

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,44 +132,29 @@ if [ -n "$*" ]; then
   done
 fi
 
-#
-# Start constructing `find` expression
-#
-implode() {
-    # $1 is return variable name
-    # $2 is sep
-    # $3... are the elements to join
-    local retname=$1 sep=$2 ret=$3
-    shift 3 || shift $(($#))
-    while [ $# -gt 0 ]; do
-        ret=$ret$sep$1
-        shift
-    done
-    printf -v "$retname" "%s" "$ret"
-}
 
-# Which Nerd Font variant
-if [ "$variant" = "M" ]; then
-  find_filter="-name '*NerdFontMono*'"
-elif [ "$variant" = "P" ]; then
-  find_filter="-name '*NerdFontPropo*'"
+# Build an array of find filter predicates based on $variant
+filter=()
+if [[ $variant == M ]]; then
+  filter=( -iname "*NerdFontMono*" )
+elif [[ $variant == P ]]; then
+  filter=( -iname "*NerdFontPropo*" )
 else
-  find_filter="-not -name '*NerdFontMono*' -and -not -name '*NerdFontPropo*' -and -name '*NerdFont*'"
+  filter=(
+    -not -iname "*NerdFontMono*" -a \
+    -not -iname "*NerdFontPropo*" -a \
+    -iname "*NerdFont*"
+  )
 fi
 
-# Construct directories to be searched
-implode find_dirs "\" \"" "${nerdfonts_dirs[@]}"
-find_dirs="\"$find_dirs\""
-
-# Put it all together into the find command we want
-find_command="find $find_dirs -iname '*.[ot]tf' $find_filter -type f -print0"
-
 # Find all the font files and store in array
-files=()
-while IFS=  read -r -d $'\0'; do
-  files+=("$REPLY")
-done < <(eval "$find_command")
-
+mapfile -d '' files < <(
+  find "${nerdfonts_dirs[@]}" \
+    -iname '*.[ot]tf' \
+    "${filter[@]}" \
+    -type f -print0
+)
+ 
 #
 # Remove duplicates (i.e. when both otf and ttf version present)
 #


### PR DESCRIPTION
#### Description

This PR eliminates a critical security vulnerability in `install.sh` where user-supplied font names were used to unsafely construct `find` command strings, which were then passed into `eval`. This vulnerability allows for arbitrary command execution. If the script was run with `--install-to-system-path` and root privileges (as documented), exploitation could result in full system compromise.

This fix:
- Removes the use of `eval`. 
- Properly handles directories and filters using safe Bash arrays.
- Ensure no untrusted input is used in unsafe ways.
--- 
#### Requirements / Checklist

- [X] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
- Fixes an arbitrary command execution vulnerability in the install script.
- Prevents malicious input from being evaluated as executable shell commands.
- Secures installation logic without changing core functionality for end users.

#### How should this be manually tested?
- Clone a clean copy of the project.
- Attempt to inject a malicious font directory name (e.g., backtick or `$()` style shell injection).
- Run the installer targeting the malicious input.
- Confirm that with this patch applied, no unintended files are created and no commands are executed.
- Standard font installations should still succeed.

**Examples of previously successful exploits:**

**Backticks Injection:**
```bash
mkdir -p patched-fonts/'`touch GOTYOU`'
./install.sh '`touch GOTYOU`'
ls GOTYOU
# Expected: No GOTYOU file created. (Before patch: file would be created.)
```

**$() Injection:**
```bash
mkdir -p patched-fonts/'$(touch GOTYOUTWICE)'
./install.sh '$(touch  GOTYOUTWICE)'
ls GOTYOUTWICE
# Expected: No "GOTYOUTWICE" file created. (Before patch: file would be created.)
```

#### Any background context you can provide?
- The risk is heightened because the script supports installation with root privileges, compounding the impact of any injection flaw.
- Multiple shell injection methods (`$()`, backticks) were tested and proven viable on the unpatched script.
- The original directory existence check (`-d`) does not prevent exploitation because it does not sanitize or escape dangerous characters in directory names.

#### What are the relevant tickets (if any)?
N/A - self discovered vulnerability.
Submitting the fix proactively.

#### Screenshots (if appropriate or helpful)
N/A — vulnerability demonstrated via terminal command output included above.