### PR TITLE
Add GSC(Google Sans Code) Nerd Font

### DIFF
--- a/patched-fonts/GSCNerdFont/README.md
+++ b/patched-fonts/GSCNerdFont/README.md
@@ -1,0 +1,24 @@
+# GSC Nerd Font
+
+**GSC Nerd Font** is a patched version of **Google Sans Code** with additional icons and symbols from **Nerd Fonts**.
+
+## Why "GSC Nerd Font"?
+
+The name **GSC Nerd Font** is used to comply with the **SIL Open Font License (OFL)**, specifically the **Reserved Font Name** clause.
+
+## Installation & Usage
+
+- Download the fonts from this [repository](https://github.com/tourcoder/GSC-Nerd-Font).
+- Set the font in your terminal or editor (e.g., iTerm, nvim, etc.).
+
+## Screenshots
+
+![](https://github.com/tourcoder/GSC-Nerd-Font/blob/main/ss.png)
+
+## License
+
+This font is licensed under the **SIL Open Font License, Version 1.1**. See the [full license](https://raw.githubusercontent.com/tourcoder/GSC-Nerd-Font/refs/heads/main/LICENSE) for more details.
+
+## Contact
+
+For any issues or feedback, contact: **[TOURCODER](mailto:code@tourcoder.com)**.


### PR DESCRIPTION
#### Description

This PR adds the patched version of **Google Sans Code** to Nerd Fonts. The patch includes the additional icons and symbols from Nerd Fonts, making it compatible with development environments that require these symbols.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [x] If this contains a font/glyph add its origin as background info below (e.g. URL)
      The **Google Sans Code** font is licensed under the [SIL Open Font License (OFL)](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL).
- [x] Verified the license of any newly added font, glyph, or glyph set. License is: SIL Open Font License (OFL)

#### What does this Pull Request (PR) do?

This PR introduces the **Google Sans Code** font patched with Nerd Font icons. It adds additional developer-centric symbols to the original Google Sans Code font.

#### How should this be manually tested?

1. Download and install the patched **Google Sans Code Nerd Font**.
2. Verify that it works as intended in your terminal or IDE by displaying Nerd Font icons alongside regular text.

#### Any background context you can provide?

The **Google Sans Code Nerd Font** was created by combining **Google Sans Code** with symbols from the Nerd Fonts collection, providing a more complete font for developers that need both standard text and additional icons. The patch ensures that these glyphs are compatible and render correctly across various platforms and tools.

#### What are the relevant tickets (if any)?
-

#### Screenshots (if appropriate or helpful)
- 
