### PR TITLE
SpaceMono: Remove arrow-calts

### DIFF
--- a/src/unpatched-fonts/SpaceMono/README.md
+++ b/src/unpatched-fonts/SpaceMono/README.md
@@ -6,4 +6,7 @@ https://fonts.google.com/specimen/Space+Mono
 
 The `fi` and `fl` ligatures are removed because they map to only one advance width.
 
+The arrow alternatives (e.g. `/>`) are removed because they come unexpected in almost
+all cases and can not be turned off easily by many users.
+
 Version: 1.001

--- a/src/unpatched-fonts/SpaceMono/config.cfg
+++ b/src/unpatched-fonts/SpaceMono/config.cfg
@@ -3,4 +3,5 @@ commandline: --removeligatures
 [Subtables]
 ligatures: [
     "'liga' Standard Ligatures in Latin lookup 9 subtable",
-    "'liga' Standard Ligatures in Latin lookup 8 subtable" ]
+    "'liga' Standard Ligatures in Latin lookup 8 subtable",
+    "'calt' Contextual Alternates in Latin lookup 4 subtable" ]


### PR DESCRIPTION
#### Description

**[why]**
The arrow substitutions come somewhat unexpected and not all users can turn 'calt' off. There were multiple complains as HTML code becomes unreadable; and I can not see any (programming) language that would benefit from it.

**[how]**
Add the specific calt term to the config file for release patching.

Fixes: #1955

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #1955
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Remove the arrow calt terms from the release files of Space Mono Nerd Font.

#### How should this be manually tested?

#### Any background context you can provide?

https://github.com/googlefonts/spacemono/pull/2

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
