### PR TITLE
Fix/volume icon

### DIFF
--- a/bin/scripts/lib/i_fa.sh
+++ b/bin/scripts/lib/i_fa.sh
@@ -481,6 +481,7 @@ i='' i_fa_the_red_yeti=$i
 i='' i_fa_scroll_torah=$i
 i='' i_fa_torii_gate=$i
 i='' i_fa_vihara=$i
+i=$'\uf6a8' i_fa_volume=$i
 i='' i_fa_volume_xmark=$i
 i='' i_fa_yin_yang=$i
 i='' i_fa_blender_phone=$i

--- a/src/glyphs/font-awesome/mapping
+++ b/src/glyphs/font-awesome/mapping
@@ -478,6 +478,7 @@ F69D EEE4 brands/the-red-yeti.svg the_red_yeti
 F6A0 EEE5 solid/scroll-torah.svg scroll_torah
 F6A1 EEE6 solid/torii-gate.svg torii_gate
 F6A7 EEE7 solid/vihara.svg vihara
+F6A8 F6A8 solid/volume.svg volume
 F6A9 EEE8 solid/volume-xmark.svg volume_xmark
 F6AD EEE9 solid/yin-yang.svg yin_yang
 F6B6 EEEA solid/blender-phone.svg blender_phone


### PR DESCRIPTION
#### Description

Adds missing `fa-volume` icon (Unicode `f6a8`) to the Font Awesome mapping and shell variable definitions.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #1961
- [x] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [x] Verified the license of any newly added font, glyph, or glyph set. License is: Font Awesome Free (SIL OFL 1.1)

#### What does this Pull Request (PR) do?

* Adds the mapping for `fa-volume` (`f6a8`) to `src/glyphs/font-awesome/mapping`.
* Adds the shell variable `i_fa_volume` to `bin/scripts/lib/i_fa.sh` using the bash hex escape sequence.

#### What are the relevant tickets (if any)?

Fixes #1961