### PR TITLE
fix: replace `int()` with `round()` to implement rounding in `scale_bounding_box()`

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.20.5"
+script_version = "4.20.6"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"
@@ -1944,11 +1944,11 @@ def scale_bounding_box(bbox, scale_x, scale_y):
     """ Return a scaled version of a glyph dimensions dict """
     # Simulate scaling on combined bounding box, round values for better simulation
     new_dim = {
-        'xmin'   : int(bbox['xmin'] * scale_x),
-        'ymin'   : int(bbox['ymin'] * scale_y),
-        'xmax'   : int(bbox['xmax'] * scale_x),
-        'ymax'   : int(bbox['ymax'] * scale_y),
-        'advance': int(bbox['advance'] * scale_x) if bbox['advance'] is not None else None,
+        'xmin'   : round(bbox['xmin'] * scale_x),
+        'ymin'   : round(bbox['ymin'] * scale_y),
+        'xmax'   : round(bbox['xmax'] * scale_x),
+        'ymax'   : round(bbox['ymax'] * scale_y),
+        'advance': round(bbox['advance'] * scale_x) if bbox['advance'] is not None else None,
         }
     new_dim['width'] = new_dim['xmax'] + (-new_dim['xmin'])
     new_dim['height'] = new_dim['ymax'] + (-new_dim['ymin'])


### PR DESCRIPTION
#### Description
The following function is used to simulate `transform`, so its comment mentions **"round values for better simulation"**. However, its implementation uses `int()` instead of `round()`.
https://github.com/ryanoasis/nerd-fonts/blob/a861c72656f180f9061af5d46dd705620194d311/font-patcher#L1943-L1955
This may introduce minor errors (**results being 1 less than `transform`**). While this likely has negligible impact on final outcomes, it can cause **confusion during debugging**—leaving developers(eg. me) scratching their heads over two values that should be equal but consistently differ by 1.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
Replace `int()` with `round()` to implement rounding in `scale_bounding_box()`
#### How should this be manually tested?
When patching `Go-Mono.ttf`, glyph `0x259f` has **the same bounding box as scale_data**. In this specific case, the expected outcome is that `scale_bounding_box()` should yield the same result as `sys_dim`. However, `sym_dim` **does not equal** `scaleglyph_dim`. This can be tested as shown in the **image below**.
![SharedScreenshot](https://github.com/user-attachments/assets/2d16f5f9-5849-4ddf-9154-71616c7a6bdf)

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
