### PR TITLE
MacOS compatibility for gotta-patch-em-all!.sh

### DIFF
--- a/bin/scripts/generate-original-source.py
+++ b/bin/scripts/generate-original-source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Nerd Fonts Version: 3.4.0
-# Script Version: 1.0.1
+# Script Version: 1.0.2
 # Generates original-source.otf from individual glyphs
 #
 # Idea & original code taken from

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.4.0
-# Script Version: 1.4.5
+# Script Version: 1.4.6
 #
 # You can supply options to the font-patcher via environment variable NERDFONTS
 # That option will override the defaults (also defaults of THIS script).
@@ -210,18 +210,12 @@ then
   export SOURCE_DATE_EPOCH=$(date +%s)
 fi
 # Detect GNU vs BSD date implementations reliably
-if date --version >/dev/null 2>&1; then
+if date -R "--date=@${SOURCE_DATE_EPOCH}" >/dev/null 2>&1; then
   # GNU date (Linux and others)
-  release_timestamp=$(date -R "--date=@${SOURCE_DATE_EPOCH}" 2>/dev/null) || {
-    echo >&2 "$LINE_PREFIX Invalid release timestamp SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
-    exit 2
-  }
+  release_timestamp=$(date -R "--date=@${SOURCE_DATE_EPOCH}" 2>/dev/null)
 elif date -r "${SOURCE_DATE_EPOCH}" "+%a, %d %b %Y %H:%M:%S %z" >/dev/null 2>&1; then
   # BSD date (macOS) - uses -r with epoch seconds
-  release_timestamp=$(date -r "${SOURCE_DATE_EPOCH}" "+%a, %d %b %Y %H:%M:%S %z") || {
-    echo >&2 "$LINE_PREFIX Invalid release timestamp SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
-    exit 2
-  }
+  release_timestamp=$(date -r "${SOURCE_DATE_EPOCH}" "+%a, %d %b %Y %H:%M:%S %z")
 else
   echo >&2 "$LINE_PREFIX Invalid release timestamp SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
   exit 2


### PR DESCRIPTION
#### Description

This PR improves the gotta-patch-em-all-font-patcher!.sh script with enhanced font filtering logic and cross-platform compatibility fixes for macOS/BSD systems.

##### Key changes:

1. Refactored filename filtering logic - Replaced -iregex pattern matching with -iname conditions grouped with parentheses, supporting both directory-based filtering (path starts with "/") and filename-based filtering with proper wildcard matching for .ttf, .otf, and .sfd files
2. Added macOS/BSD compatibility for date commands - The script now detects whether GNU or BSD date is available and uses the appropriate syntax:
GNU: date -R "--date=@${SOURCE_DATE_EPOCH}"
BSD: date -r "${SOURCE_DATE_EPOCH}" "+%a, %d %b %Y %H:%M:%S %z"
3. Improved code clarity - Added extensive comments explaining parentheses placement and glob expansion handling
4. Minor Python syntax fix - Updated generate-original-source.py to use idiomatic i not in data instead of not i in data

#### Requirements / Checklist

- [ x ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ x ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ n/a ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ n/a ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?
Fixes cross-platform compatibility issues in the font patching script, particularly for macOS users. The filtering logic now works correctly on BSD-based systems (macOS) where find -iregex and date command syntax differ from GNU coreutils.

#### How should this be manually tested?
- On a macOS system, run the gotta-patch-em-all-font-patcher!.sh script with a filter argument (e.g., ./gotta-patch-em-all-font-patcher!.sh Hack)
- Verify the date commands execute without errors (previously would fail on BSD date)
- Confirm font filtering correctly matches fonts by directory path or filename
- Test on Linux (GNU) to ensure no regressions

#### Any background context you can provide?
Intended to add icons for CachyOS and zsh, and while doing that using a Mac (M4max MacBook Pro, macOS 26.2, stock Mac bash 3.2.57 and Homebrew bash 5.3.9 used for testing) discovered that the command syntax for some of the basic utils was not cleanly compatible with Mac's BSD-origin utils. Found issues with filtering logic that presented similar incompatibility. Separating the code contribution from new icons request.

#### What are the relevant tickets (if any)?
(no tickets)

#### Screenshots (if appropriate or helpful)
(not particularly helpful here I think)
