### PR TITLE
Add Braille support (with generator)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 !font-patcher
 !glyphnames.json
 !bin/scripts/name_parser/Fontname*.py
+!bin/scripts/braille/Braille.py
 !bin/scripts/docker-entrypoint.sh
 !.codeclimate.yml

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,7 @@ on:
       # Keep this in line with .dockerignore
       - bin/scripts/docker-entrypoint.sh
       - bin/scripts/name_parser/Fontname*.py
+      - bin/scripts/braille/Braille.py
       - src/glyphs/**
       - .dockerignore
       - Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ package-lock.json
 *.uuid
 bin/scripts/name_parser/__pycache__/*
 bin/scripts/name_parser/log
+bin/scripts/braille/__pycache__/*
 # This is just needed for the cheat sheet and not go into the repo:
 css/nerd-fonts-generated-removed.min.css
 font-patcher-log.txt

--- a/bin/scripts/archive-font-patcher.sh
+++ b/bin/scripts/archive-font-patcher.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.4.0
-# Script Version: 1.1.0
+# Script Version: 1.2.0
 # Archives the font patcher script and the required source files
 # If some (any) argument is given this is though of as intermediate version
 # used for debugging
@@ -28,6 +28,7 @@ find "${outputdir:?}" -name "FontPatcher.zip" -type f -delete
 
 cd -- "$scripts_root_dir/../../" || exit 1
 find "src/glyphs" | zip -9 "$outputdir/FontPatcher" -@
+find "bin/scripts/braille" -name "Braille.py" | zip -9 "$outputdir/FontPatcher" -@
 find "bin/scripts/name_parser" -name "Fontname*.py" | zip -9 "$outputdir/FontPatcher" -@
 find "glyphnames.json" | zip -9 "$outputdir/FontPatcher" -@
 find "font-patcher" | zip -9 "$outputdir/FontPatcher" -@

--- a/bin/scripts/braille/Braille.py
+++ b/bin/scripts/braille/Braille.py
@@ -51,21 +51,16 @@ def draw_braille_glyph(glyph, idx, width, ymax, ymin, r):
     pen = None
 
 
-def set_scent(font, ymax, ymin, ascent, descent):
+def set_scent(font, ymax, ymin):
     """" Set ascent and descent """
     # This may not impact the final patch result,
     # but to better check middle result, we set them.
-    # Note: Sometimes `ymax` may exceed `ascent`. 
-    #       This is because some fonts have a system ascent (e.g., `hhea_ascent`) that bigger than 
-    #       their own `ascent` value. Setting `font.ascent` directly to `ymax` may cause the height to 
-    #       exceed the em, triggering the em adjustment mechanism and resulting in errors.
-    font.ascent = ascent
-    font.descent = descent
-
     # We set them simply, because this is enough
     # to reveal the true situation when we check the middle result.
     font.hhea_ascent = ymax
     font.hhea_descent = ymin
+    font.hhea_ascent_add = 0
+    font.hhea_descent_add = 0
     font.hhea_linegap = 0
 
     font.os2_winascent = ymax
@@ -75,11 +70,13 @@ def set_scent(font, ymax, ymin, ascent, descent):
 
     font.os2_typoascent = ymax
     font.os2_typodescent = ymin
+    font.os2_typoascent_add = 0
+    font.os2_typodescent_add = 0
     font.os2_typolinegap = 0
 
 
 
-def get_braille_font(em, width, ymax, ymin, descent, ascent, r_ratio):
+def get_braille_font(em, width, ymax, ymin, r_ratio):
     """ Get braille font where the ratio of the radius to the shortest distance from the center is `r_ratio` """
     braille_font = fontforge.font()
 
@@ -92,15 +89,16 @@ def get_braille_font(em, width, ymax, ymin, descent, ascent, r_ratio):
     braille_font.version = "1.0.0"
 
     braille_font.em = em
-    set_scent(braille_font, ymax, ymin, descent, ascent)
+    set_scent(braille_font, ymax, ymin)
 
     r = min(width / 4, (ymax - ymin) / 8) * r_ratio
 
     START = 0x2800
     END = 0x28FF
     for i in range(START, END + 1):
-        glyph = braille_font.createChar(i)
+        idx = i - START
+        glyph = braille_font.createChar(i, f'braille-{idx}')
         glyph.width = width
-        draw_braille_glyph(glyph, i - START, width, ymax, ymin, r)
+        draw_braille_glyph(glyph, idx, width, ymax, ymin, r)
 
     return braille_font

--- a/bin/scripts/braille/Braille.py
+++ b/bin/scripts/braille/Braille.py
@@ -1,0 +1,106 @@
+import fontforge
+import math
+
+
+def get_circle_center(dot, width, ymax, ymin):
+    """ Get the center of the circle centered at the point with ID `dot` """
+    # Note dots' position(a little strange):
+    # 0 3 
+    # 1 4
+    # 2 5
+    # 6 7
+    if dot < 6:
+        row = dot % 3
+        col = dot // 3
+    else:
+        row = 3
+        col = dot - 6
+
+    height = ymax - ymin
+    x0 = width / 4
+    y0 = -height / 8 + ymax
+    return (x0 + col * width / 2, y0 - row * height / 4)
+
+
+def draw_circle(pen, center, r):
+    """ Control the pen to draw a circle """
+    K = 4 / 3 * (math.sqrt(2) - 1)  # a ratio for determining control points
+    offset = r * K  # offset distance of control points
+
+    cx, cy = center
+    tx, ty = cx, cy + r  # top
+    rx, ry = cx + r, cy  # right
+    bx, by = cx, cy - r  # bottom
+    lx, ly = cx - r, cy  # left
+
+    pen.moveTo((tx, ty))
+    pen.curveTo((tx + offset, ty), (rx, ry + offset), (rx, ry))  # top -> right
+    pen.curveTo((rx, ry - offset), (bx + offset, by), (bx, by))  # right -> bottom
+    pen.curveTo((bx - offset, by), (lx, ly - offset), (lx, ly))  # bottom -> left
+    pen.curveTo((lx, ly + offset), (tx - offset, ty), (tx, ty))  # left -> top
+    pen.closePath()
+
+
+def draw_braille_glyph(glyph, idx, width, ymax, ymin, r):
+    """ Draw the braille glyph with the corresponding number """
+    pen = glyph.glyphPen()
+    for i in range(8):
+        if (1 << i) & idx > 0:
+            center = get_circle_center(i, width, ymax, ymin)
+            draw_circle(pen, center, r)
+    pen = None
+
+
+def set_scent(font, ymax, ymin, ascent, descent):
+    """" Set ascent and descent """
+    # This may not impact the final patch result,
+    # but to better check middle result, we set them.
+    # Note: Sometimes `ymax` may exceed `ascent`. 
+    #       This is because some fonts have a system ascent (e.g., `hhea_ascent`) that bigger than 
+    #       their own `ascent` value. Setting `font.ascent` directly to `ymax` may cause the height to 
+    #       exceed the em, triggering the em adjustment mechanism and resulting in errors.
+    font.ascent = ascent
+    font.descent = descent
+
+    # We set them simply, because this is enough
+    # to reveal the true situation when we check the middle result.
+    font.hhea_ascent = ymax
+    font.hhea_descent = ymin
+    font.hhea_linegap = 0
+
+    font.os2_winascent = ymax
+    font.os2_windescent = -ymin
+    font.os2_winascent_add = 0
+    font.os2_windescent_add = 0
+
+    font.os2_typoascent = ymax
+    font.os2_typodescent = ymin
+    font.os2_typolinegap = 0
+
+
+
+def get_braille_font(em, width, ymax, ymin, descent, ascent, r_ratio):
+    """ Get braille font where the ratio of the radius to the shortest distance from the center is `r_ratio` """
+    braille_font = fontforge.font()
+
+    braille_font.fontname = "BrailleFont-Regular"
+    braille_font.familyname = "Braille Font"
+    braille_font.fullname = "Braille Font Regular"
+    braille_font.encoding = "UnicodeFull"
+
+    braille_font.copyright = ""
+    braille_font.version = "1.0.0"
+
+    braille_font.em = em
+    set_scent(braille_font, ymax, ymin, descent, ascent)
+
+    r = min(width / 4, (ymax - ymin) / 8) * r_ratio
+
+    START = 0x2800
+    END = 0x28FF
+    for i in range(START, END + 1):
+        glyph = braille_font.createChar(i)
+        glyph.width = width
+        draw_braille_glyph(glyph, i - START, width, ymax, ymin, r)
+
+    return braille_font

--- a/bin/scripts/braille/Braille.py
+++ b/bin/scripts/braille/Braille.py
@@ -1,11 +1,15 @@
+#!/usr/bin/env python
+# coding=utf8
+
 import fontforge
 import math
 
 
 def get_circle_center(dot, width, ymax, ymin):
     """ Get the center of the circle centered at the point with ID `dot` """
-    # Note dots' position(a little strange):
-    # 0 3 
+    # The dot ID is one less than the official dot number
+    # Note dots' position (a little strange):
+    # 0 3
     # 1 4
     # 2 5
     # 6 7
@@ -92,7 +96,6 @@ def set_scent(font, ymax, ymin):
     font.os2_typolinegap = 0
 
 
-
 def get_braille_font(em, width, ymax, ymin, style, r_ratio):
     """
     Get braille font
@@ -114,16 +117,15 @@ def get_braille_font(em, width, ymax, ymin, style, r_ratio):
     if style == 'gapless':
         r_ratio = 1
         style = 'rectangle'
-    rx = width / 4 *r_ratio
+    rx = width / 4 * r_ratio
     ry = (ymax - ymin) / 8 * r_ratio
 
     START = 0x2800
     END = 0x28FF
     for i in range(START, END + 1):
         idx = i - START
-        glyph = braille_font.createChar(i, f'braille-{idx}')
+        glyph = braille_font.createChar(i, f'uni{i:04X}')
         glyph.width = width
         draw_braille_glyph(glyph, idx, width, ymax, ymin, style, rx, ry)
 
     return braille_font
-

--- a/bin/scripts/braille/README.md
+++ b/bin/scripts/braille/README.md
@@ -4,4 +4,6 @@ This module is used to generate a braille font with specified width, ymax, ymin.
 
 ## Motivation
 
-Achieving a perfect isometric font with braille support solely through scaling appears extremely challenging. Therefore, I've opted to utilize a module for dynamically generating braille. For further details, please refer to PR 837.
+Achieving a perfect isometric font with braille support solely through scaling
+appears extremely challenging. Therefore, I've opted to utilize a module for
+dynamically generating braille. For further details, please refer to PR 837 and PR 1980.

--- a/bin/scripts/braille/README.md
+++ b/bin/scripts/braille/README.md
@@ -1,0 +1,7 @@
+# Generate Appropriate Braille Font
+
+This module is used to generate a braille font with specified width, ymax, ymin... for patching.
+
+## Motivation
+
+Achieving a perfect isometric font with braille support solely through scaling appears extremely challenging. Therefore, I've opted to utilize a module for dynamically generating braille. For further details, please refer to PR 837.

--- a/font-patcher
+++ b/font-patcher
@@ -972,7 +972,7 @@ class font_patcher:
         }
         SYM_ATTR_BRAILLE = {
             # Don't scale because we generate font in the suitable size directly
-            'default': {'align': 'c', 'valign': 'c', 'stretch': '', 'params': {}}
+            'default': {'align': '', 'valign': '', 'stretch': '', 'params': {}}
         }
         SYM_ATTR_HEAVYBRACKETS = {
             'default': {'align': 'c', 'valign': 'c', 'stretch': '^pa1!', 'params': {'ypadding': 0.3, 'careful': True}}
@@ -1056,9 +1056,6 @@ class font_patcher:
             [*range(0x2500, 0x2570 + 1), *range(0x2574, 0x257f + 1)], # box drawing
             range(0x2571, 0x2573 + 1), # diagonals
             range(0x2580, 0x259f + 1), # blocks and greys (greys are less tall originally, so overlap will be less)
-        ]}
-        BRAILLE_SCALE_LIST = {'ShiftMode': '', 'ScaleGroups': [
-            range(0x2800, 0x28ff + 1), # all Braille glyphs
         ]}
         CODI_SCALE_LIST = {'ShiftMode': 'xy', 'ScaleGroups': [
             [0xea61, 0xeb13], # lightbulb
@@ -1180,7 +1177,7 @@ class font_patcher:
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': True,  'SymStart': 0X26A1, 'SymEnd': 0X26A1, 'SrcStart': None,   'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},  # Zap
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': False, 'SymStart': 0xF27C, 'SymEnd': 0xF306, 'SrcStart': 0xF4A9, 'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.codicons,             'Name': "Codicons",                'Filename': "codicons/codicon.ttf",                           'Exact': True,  'SymStart': 0xEA60, 'SymEnd': 0xEC1E, 'SrcStart': None,   'ScaleRules': CODI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
-            {'Enabled': self.args.braille,              'Name': "Braille",                 'Font'    : self.get_braille_font,                            'Exact': True,  'SymStart': 0x2800, 'SymEnd': 0x28FF, 'SrcStart': None,   'ScaleRules': BRAILLE_SCALE_LIST, 'Attributes': SYM_ATTR_BRAILLE},
+            {'Enabled': self.args.braille,              'Name': "Braille",                 'Font'    : self.get_braille_font,                            'Exact': True,  'SymStart': 0x2800, 'SymEnd': 0x28FF, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_BRAILLE},
             {'Enabled': self.args.custom,               'Name': "Custom",                  'Filename': self.args.custom,                                 'Exact': True,  'SymStart': 0x0000, 'SymEnd': 0x0000, 'SrcStart': None,   'ScaleRules': None,             'Attributes': CUSTOM_ATTR}
         ]
 

--- a/font-patcher
+++ b/font-patcher
@@ -2096,7 +2096,7 @@ def setup_arguments():
     #  6  HugoSansMono NF XCn Lt It                                [X] [X] [X]
 
     sym_font_group = parser.add_argument_group('Symbol Fonts')
-    sym_font_group.add_argument('--braille',                                    dest='braille',              default=False, action='store_true', help='Add Braille Glyphs')
+    sym_font_group.add_argument('--braille',                                    dest='braille',              default=False, const='rectangle',   help='Add Braille Glyphs, can pass a string to control style (optional: *rectangle, circle, gapless)', nargs='?', choices=['rectangle', 'circle', 'gapless'])
     sym_font_group.add_argument('--complete', '-c',                             dest='complete',             default=False, action='store_true', help='Add all available Glyphs')
     sym_font_group.add_argument('--codicons',                                   dest='codicons',             default=False, action='store_true', help='Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)')
     sym_font_group.add_argument('--fontawesome',                                dest='fontawesome',          default=False, action='store_true', help='Add Font Awesome Glyphs (http://fontawesome.io/)')
@@ -2112,7 +2112,6 @@ def setup_arguments():
 
     expert_group = parser.add_argument_group('Expert Options')
     expert_group.add_argument('--adjust-line-height', '-l',                dest='adjustLineHeight', default=False, action='store_true', help='Whether to adjust line heights (attempt to center powerline separators more evenly)')
-    expert_group.add_argument('--braille-style',                           dest='brailleStyle',     default='rectangle', type=str,      help='The style of the braille font (optional: *rectangle, circle, gapless)', choices=['rectangle', 'circle', 'gapless'])
     expert_group.add_argument('--boxdrawing',                              dest='forcebox',         default=False, action='store_true', help='Force patching in (over existing) box drawing glyphs')
     expert_group.add_argument('--cell',                                    dest='cellopt',          default=None,  type=str,            help='Adjust or query the cell size, e.g. use "0:1000:-200:800" or "?"')
     expert_group.add_argument('--configfile',                              dest='configfile',       default=False, type=str,            help='Specify a file path for configuration file (see sample: src/config.sample.cfg)')
@@ -2163,6 +2162,11 @@ def setup_arguments():
     if args.braille and not BrailleGenerator:
         logger.critical("Braille module missing (bin/scripts/braille/Braille.py), do not include Braille Glyphs")
         sys.exit(1)
+
+    args.brailleStyle = 'rectangle'
+    if args.braille:
+        args.brailleStyle = args.braille
+        args.braille = True
 
     # if you add a new font, set it to True here inside the if condition
     if args.complete:

--- a/font-patcher
+++ b/font-patcher
@@ -1882,9 +1882,7 @@ class font_patcher:
         width = self.font_dim["width"]
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
-        descent = self.sourceFont.descent
-        ascent = self.sourceFont.ascent
-        return get_braille_font(self.sourceFont.em, width, ymax, ymin, descent, ascent , 0.6)
+        return get_braille_font(self.sourceFont.em, width, ymax, ymin, 0.6)
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """
@@ -2097,6 +2095,7 @@ def setup_arguments():
     #  6  HugoSansMono NF XCn Lt It                                [X] [X] [X]
 
     sym_font_group = parser.add_argument_group('Symbol Fonts')
+    sym_font_group.add_argument('--braille',                                    dest='braille',              default=False, action='store_true', help='Add Braille Glyphs')
     sym_font_group.add_argument('--complete', '-c',                             dest='complete',             default=False, action='store_true', help='Add all available Glyphs')
     sym_font_group.add_argument('--codicons',                                   dest='codicons',             default=False, action='store_true', help='Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)')
     sym_font_group.add_argument('--fontawesome',                                dest='fontawesome',          default=False, action='store_true', help='Add Font Awesome Glyphs (http://fontawesome.io/)')

--- a/font-patcher
+++ b/font-patcher
@@ -46,6 +46,13 @@ try:
 except ImportError:
     FontnameParserOK = False
 
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'bin', 'scripts', 'braille'))
+try:
+    from Braille import get_braille_font
+    BrailleGenerator = True
+except ImportError:
+    BrailleGenerator = False
+
 class TableHEADWriter:
     """ Access to the HEAD table without external dependencies """
     def getlong(self, pos = None):
@@ -1873,12 +1880,6 @@ class font_patcher:
 
     def get_braille_font(self):
         """ Get suitable braille font """
-        sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'bin', 'scripts', 'braille'))
-        try:
-            from Braille import get_braille_font
-        except ImportError:
-            logger.critical("Braille module missing (bin/scripts/braille/Braille.py)")
-            sys.exit(1)
         width = self.font_dim["width"]
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
@@ -2159,9 +2160,12 @@ def setup_arguments():
         logger.critical("FontnameParser module missing (bin/scripts/name_parser/Fontname*), specify --makegroups 0")
         sys.exit(1)
 
+    if args.braille and not BrailleGenerator:
+        logger.critical("Braille module missing (bin/scripts/braille/Braille.py), do not include Braille Glyphs")
+        sys.exit(1)
+
     # if you add a new font, set it to True here inside the if condition
     if args.complete:
-        args.braille = True
         args.codicons = True
         args.fontawesome = True
         args.fontawesomeextension = True
@@ -2173,6 +2177,10 @@ def setup_arguments():
         args.powerlineextra = True
         args.powersymbols = True
         args.weather = True
+        if BrailleGenerator:
+            args.braille = True
+        else:
+            logger.warning("Braille module missing (bin/scripts/braille/Braille.py), generating font without Braille Glyphs!")
 
     if not args.complete:
         sym_font_args = []

--- a/font-patcher
+++ b/font-patcher
@@ -573,6 +573,9 @@ class font_patcher:
             if self.args.weather:
                 additionalFontNameSuffix += " WEA"
                 verboseAdditionalFontNameSuffix += " Plus Weather Icons"
+            if self.args.braille:
+                additionalFontNameSuffix += " B"
+                verboseAdditionalFontNameSuffix += " Plus Braille Icons"
 
         # add mono signifier to beginning of name suffix
         if self.args.single:

--- a/font-patcher
+++ b/font-patcher
@@ -2096,7 +2096,7 @@ def setup_arguments():
     #  6  HugoSansMono NF XCn Lt It                                [X] [X] [X]
 
     sym_font_group = parser.add_argument_group('Symbol Fonts')
-    sym_font_group.add_argument('--braille',                                    dest='braille',              default=False, const='rectangle',   help='Add Braille Glyphs, can pass a string to control style (optional: *rectangle, circle, gapless)', nargs='?', choices=['rectangle', 'circle', 'gapless'])
+    sym_font_group.add_argument('--braille',                                    dest='braille',              default=False, type=str, nargs='?', help='Add Braille Glyphs, can pass a string to control style (optional: *rectangle, circle, gapless)', const='rectangle', choices=['rectangle', 'circle', 'gapless'])
     sym_font_group.add_argument('--complete', '-c',                             dest='complete',             default=False, action='store_true', help='Add all available Glyphs')
     sym_font_group.add_argument('--codicons',                                   dest='codicons',             default=False, action='store_true', help='Add Codicons Glyphs (https://github.com/microsoft/vscode-codicons)')
     sym_font_group.add_argument('--fontawesome',                                dest='fontawesome',          default=False, action='store_true', help='Add Font Awesome Glyphs (http://fontawesome.io/)')

--- a/font-patcher
+++ b/font-patcher
@@ -370,7 +370,7 @@ class font_patcher:
 
         # Prevent opening and closing the fontforge font. Makes things faster when patching
         # multiple ranges using the same symbol font.
-        PreviousSymbolFilename = ""
+        PreviousSymbol = ""
         symfont = None
 
         if not os.path.isdir(self.args.glyphdir):
@@ -383,26 +383,35 @@ class font_patcher:
 
         for patch in self.patch_set:
             if patch['Enabled']:
-                if PreviousSymbolFilename != patch['Filename']:
+                if 'Filename' in patch and 'Font' in patch:
+                    logger.critical("Conflicting patch params: Filename and Font")
+                    sys.exit(1)
+
+                use_Filename = 'Filename' in patch
+                if (use_Filename and PreviousSymbol != patch['Filename']) or (not use_Filename and PreviousSymbol != patch['Font']):
                     # We have a new symbol font, so close the previous one if it exists
                     if symfont:
                         symfont.close()
                         symfont = None
-                    symfont_file = os.path.join(self.args.glyphdir, patch['Filename'])
-                    if not os.path.isfile(symfont_file):
-                        logger.critical("Can not find symbol source for '%s' (i.e. %s)",
-                            patch['Name'], symfont_file)
-                        sys.exit(1)
-                    if not os.access(symfont_file, os.R_OK):
-                        logger.critical("Can not open symbol source for '%s' (i.e. %s)",
-                            patch['Name'], symfont_file)
-                        sys.exit(1)
-                    symfont = fontforge.open(symfont_file)
+                    if use_Filename:
+                        symfont_file = os.path.join(self.args.glyphdir, patch['Filename'])
+                        if not os.path.isfile(symfont_file):
+                            logger.critical("Can not find symbol source for '%s' (i.e. %s)",
+                                patch['Name'], symfont_file)
+                            sys.exit(1)
+                        if not os.access(symfont_file, os.R_OK):
+                            logger.critical("Can not open symbol source for '%s' (i.e. %s)",
+                                patch['Name'], symfont_file)
+                            sys.exit(1)
+                        symfont = fontforge.open(symfont_file)
+                        PreviousSymbol = patch['Filename']
+                    else:
+                        symfont = patch['Font']()
+                        PreviousSymbol = patch['Font']
                     symfont.encoding = 'UnicodeFull'
 
                     # Match the symbol font size to the source font size
                     symfont.em = self.sourceFont.em
-                    PreviousSymbolFilename = patch['Filename']
 
                 # If patch table doesn't include a source start, re-use the symbol font values
                 SrcStart = patch['SrcStart']
@@ -1119,6 +1128,17 @@ class font_patcher:
 
         # Define the character ranges
         # Symbol font ranges
+        # Fonts can be imported in two ways:
+        #   - Filename
+        #       File path relative to glyphdir.
+        #   - Font
+        #       A hook function has a return value of type `fontforge.font`. 
+        #       This hook function will be called before `copy_glyphs`.
+        #       This provides greater flexibility when complex adjustments/generation  based on the sourceFont are required.
+        # Note: 
+        #   Only one of the two can exist.
+        #   When complex dynamic adjustments/generation based on sourceFont are unnecessary, 
+        #   it is better to use `Filename`, then adjust via attributes (in fact, this is more usual).
         self.patch_set = [
             {'Enabled': True,                           'Name': "Seti-UI + Custom",        'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5FF, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': True,                           'Name': "Heavy Angle Brackets",    'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x276C, 'SymEnd': 0x2771, 'SrcStart': None,   'ScaleRules': HEAVY_SCALE_LIST, 'Attributes': SYM_ATTR_HEAVYBRACKETS},

--- a/font-patcher
+++ b/font-patcher
@@ -963,6 +963,10 @@ class font_patcher:
             0xf0dd: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}},
             0xf0de: {'align': 'c', 'valign': '', 'stretch': 'pa', 'params': {}}
         }
+        SYM_ATTR_BRAILLE = {
+            # Don't scale because we generate font in the suitable size directly
+            'default': {'align': 'c', 'valign': 'c', 'stretch': '', 'params': {}}
+        }
         SYM_ATTR_HEAVYBRACKETS = {
             'default': {'align': 'c', 'valign': 'c', 'stretch': '^pa1!', 'params': {'ypadding': 0.3, 'careful': True}}
         }
@@ -1045,6 +1049,9 @@ class font_patcher:
             [*range(0x2500, 0x2570 + 1), *range(0x2574, 0x257f + 1)], # box drawing
             range(0x2571, 0x2573 + 1), # diagonals
             range(0x2580, 0x259f + 1), # blocks and greys (greys are less tall originally, so overlap will be less)
+        ]}
+        BRAILLE_SCALE_LIST = {'ShiftMode': '', 'ScaleGroups': [
+            range(0x2800, 0x28ff + 1), # all Braille glyphs
         ]}
         CODI_SCALE_LIST = {'ShiftMode': 'xy', 'ScaleGroups': [
             [0xea61, 0xeb13], # lightbulb
@@ -1166,6 +1173,7 @@ class font_patcher:
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': True,  'SymStart': 0X26A1, 'SymEnd': 0X26A1, 'SrcStart': None,   'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},  # Zap
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': False, 'SymStart': 0xF27C, 'SymEnd': 0xF306, 'SrcStart': 0xF4A9, 'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.codicons,             'Name': "Codicons",                'Filename': "codicons/codicon.ttf",                           'Exact': True,  'SymStart': 0xEA60, 'SymEnd': 0xEC1E, 'SrcStart': None,   'ScaleRules': CODI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
+            {'Enabled': self.args.braille,              'Name': "Braille",                 'Font'    : self.get_braille_font,                            'Exact': True,  'SymStart': 0x2800, 'SymEnd': 0x28FF, 'SrcStart': None,   'ScaleRules': BRAILLE_SCALE_LIST, 'Attributes': SYM_ATTR_BRAILLE},
             {'Enabled': self.args.custom,               'Name': "Custom",                  'Filename': self.args.custom,                                 'Exact': True,  'SymStart': 0x0000, 'SymEnd': 0x0000, 'SrcStart': None,   'ScaleRules': None,             'Attributes': CUSTOM_ATTR}
         ]
 
@@ -1863,6 +1871,20 @@ class font_patcher:
                     return (scale, box)
         return None
 
+    def get_braille_font(self):
+        """ Get suitable braille font """
+        sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'bin', 'scripts', 'braille'))
+        try:
+            from Braille import get_braille_font
+        except ImportError:
+            logger.critical("Braille module missing (bin/scripts/braille/Braille.py)")
+            sys.exit(1)
+        width = self.font_dim["width"]
+        ymax = self.font_dim["ymax"]
+        ymin = self.font_dim["ymin"]
+        descent = self.sourceFont.descent
+        ascent = self.sourceFont.ascent
+        return get_braille_font(self.sourceFont.em, width, ymax, ymin, descent, ascent , 0.6)
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """
@@ -2139,16 +2161,17 @@ def setup_arguments():
 
     # if you add a new font, set it to True here inside the if condition
     if args.complete:
+        args.braille = True
+        args.codicons = True
         args.fontawesome = True
         args.fontawesomeextension = True
         args.fontlogos = True
+        args.material = True
         args.octicons = True
-        args.codicons = True
-        args.powersymbols = True
         args.pomicons = True
         args.powerline = True
         args.powerlineextra = True
-        args.material = True
+        args.powersymbols = True
         args.weather = True
 
     if not args.complete:

--- a/font-patcher
+++ b/font-patcher
@@ -1882,7 +1882,7 @@ class font_patcher:
         width = self.font_dim["width"]
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
-        return get_braille_font(self.sourceFont.em, width, ymax, ymin, 0.6)
+        return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.brailleStyle, 0.6)
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """
@@ -2070,6 +2070,7 @@ def setup_arguments():
 
     parser.add_argument('font',                                      help='The path to the font to patch (e.g., Inconsolata.otf)')
     # optional arguments
+    parser.add_argument('--braille-style',                           dest='brailleStyle',     default='rectangle', type=str,      help='The style of the braille font(optional: rectangle, circle, gapless)', choices=['rectangle', 'circle', 'gapless'])
     parser.add_argument('--careful',                                 dest='careful',          default=False, action='store_true', help='Do not overwrite existing glyphs if detected')
     parser.add_argument('--debug',                                   dest='debugmode',        default=0,     type=int, nargs='?', help='Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)', const=2, choices=range(0, 3 + 1))
     parser.add_argument('--extension', '-ext',                       dest='extension',        default="",    type=str,            help='Change font file type to create (e.g., ttf, otf)')

--- a/font-patcher
+++ b/font-patcher
@@ -1180,7 +1180,7 @@ class font_patcher:
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': True,  'SymStart': 0X26A1, 'SymEnd': 0X26A1, 'SrcStart': None,   'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},  # Zap
             {'Enabled': self.args.octicons,             'Name': "Octicons",                'Filename': "octicons/octicons.otf",                          'Exact': False, 'SymStart': 0xF27C, 'SymEnd': 0xF306, 'SrcStart': 0xF4A9, 'ScaleRules': OCTI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.codicons,             'Name': "Codicons",                'Filename': "codicons/codicon.ttf",                           'Exact': True,  'SymStart': 0xEA60, 'SymEnd': 0xEC1E, 'SrcStart': None,   'ScaleRules': CODI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
-            {'Enabled': self.args.braille,              'Name': "Braille",                 'Font'    : self.get_braille_font,                            'Exact': True,  'SymStart': 0x2800, 'SymEnd': 0x28FF, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_BRAILLE},
+            {'Enabled': self.args.braille is not None,  'Name': "Braille",                 'Font'    : self.get_braille_font,                            'Exact': True,  'SymStart': 0x2800, 'SymEnd': 0x28FF, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_BRAILLE},
             {'Enabled': self.args.custom,               'Name': "Custom",                  'Filename': self.args.custom,                                 'Exact': True,  'SymStart': 0x0000, 'SymEnd': 0x0000, 'SrcStart': None,   'ScaleRules': None,             'Attributes': CUSTOM_ATTR}
         ]
 
@@ -1883,7 +1883,7 @@ class font_patcher:
         width = self.font_dim["width"]
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
-        return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.brailleStyle, 0.6)
+        return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.braille, 0.6)
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """
@@ -2163,11 +2163,6 @@ def setup_arguments():
         logger.critical("Braille module missing (bin/scripts/braille/Braille.py), do not include Braille Glyphs")
         sys.exit(1)
 
-    args.brailleStyle = 'rectangle'
-    if args.braille:
-        args.brailleStyle = args.braille
-        args.braille = True
-
     # if you add a new font, set it to True here inside the if condition
     if args.complete:
         args.codicons = True
@@ -2181,10 +2176,10 @@ def setup_arguments():
         args.powerlineextra = True
         args.powersymbols = True
         args.weather = True
-        if BrailleGenerator:
-            args.braille = True
-        else:
+        if not BrailleGenerator:
             logger.warning("Braille module missing (bin/scripts/braille/Braille.py), generating font without Braille Glyphs!")
+        elif not args.braille:
+            args.braille = 'rectangle'
 
     if not args.complete:
         sym_font_args = []

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.21.0"
+script_version = "4.22.0"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"

--- a/font-patcher
+++ b/font-patcher
@@ -2068,7 +2068,6 @@ def setup_arguments():
 
     parser.add_argument('font',                                      help='The path to the font to patch (e.g., Inconsolata.otf)')
     # optional arguments
-    parser.add_argument('--braille-style',                           dest='brailleStyle',     default='rectangle', type=str,      help='The style of the braille font(optional: rectangle, circle, gapless)', choices=['rectangle', 'circle', 'gapless'])
     parser.add_argument('--careful',                                 dest='careful',          default=False, action='store_true', help='Do not overwrite existing glyphs if detected')
     parser.add_argument('--debug',                                   dest='debugmode',        default=0,     type=int, nargs='?', help='Verbose mode (optional: 1=just to file; 2*=just to terminal; 3=display and file)', const=2, choices=range(0, 3 + 1))
     parser.add_argument('--extension', '-ext',                       dest='extension',        default="",    type=str,            help='Change font file type to create (e.g., ttf, otf)')
@@ -2110,6 +2109,7 @@ def setup_arguments():
 
     expert_group = parser.add_argument_group('Expert Options')
     expert_group.add_argument('--adjust-line-height', '-l',                dest='adjustLineHeight', default=False, action='store_true', help='Whether to adjust line heights (attempt to center powerline separators more evenly)')
+    expert_group.add_argument('--braille-style',                           dest='brailleStyle',     default='rectangle', type=str,      help='The style of the braille font (optional: *rectangle, circle, gapless)', choices=['rectangle', 'circle', 'gapless'])
     expert_group.add_argument('--boxdrawing',                              dest='forcebox',         default=False, action='store_true', help='Force patching in (over existing) box drawing glyphs')
     expert_group.add_argument('--cell',                                    dest='cellopt',          default=None,  type=str,            help='Adjust or query the cell size, e.g. use "0:1000:-200:800" or "?"')
     expert_group.add_argument('--configfile',                              dest='configfile',       default=False, type=str,            help='Specify a file path for configuration file (see sample: src/config.sample.cfg)')


### PR DESCRIPTION
#### Description

Add Braille Glyphs that are generated on the fly to exactly match the 'cell' size of the patched font.
Just scaling is not really possible for circular dots. When they are expected to be circular in the patched font.

Created this PR in @GoldPigg's stead.

I believe it is easier to discuss details in this/a separate PR.

Thanks for preparing the code extension!

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

See discussion in 'parent' PR
* #837 

#### What are the relevant tickets (if any)?

Closes #482

#### Screenshots (if appropriate or helpful)
