### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/casks.yml
+++ b/.github/workflows/casks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch stuff
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: bin/scripts
       - name: Fetch release artifacts
@@ -34,7 +34,7 @@ jobs:
           cd bin/scripts
           ./generate-casks.sh --setversion ${{ steps.releasetag.outputs.tag }}
       - name: Upload casks as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: casks
           path: casks
@@ -52,7 +52,7 @@ jobs:
           PAK=$(echo "${FORK_TOKEN}" | tr 'A-Za-z' 'N-ZA-Mn-za-m')
           echo "pak=${PAK}" >> $GITHUB_OUTPUT
       - name: Checkout Homebrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.HOMEBREW_FORK }}
           path: homebrew
@@ -66,7 +66,7 @@ jobs:
           git reset --hard upstream/master
           git push --force origin HEAD:nerdfonts
       - name: Retrieve new casks
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: casks
           path: casks

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch pages from gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
       - name: Get details and script from default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: bin/scripts
           path: master

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.repository_owner == 'ryanoasis' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine font-patcher version
         id: patcher
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/font-patcher.yml
+++ b/.github/workflows/font-patcher.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup core dependencies
         run: |

--- a/.github/workflows/fontjson.yml
+++ b/.github/workflows/fontjson.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 
       - name: Fetch files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: bin/scripts/lib
           path: master
@@ -41,7 +41,7 @@ jobs:
   update_gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Regenerate gitignore
         run: |

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           issue-inactive-days: '182'
           issue-comment: >

--- a/.github/workflows/packsvgs.yml
+++ b/.github/workflows/packsvgs.yml
@@ -12,7 +12,7 @@ jobs:
   create-symbols-font:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Fetch dependencies
         run: |
           sudo apt update -y -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Fetch information
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: bin/scripts
 
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check release variables
         run: |
           echo "$RELEASE_VERSION"
@@ -232,7 +232,7 @@ jobs:
           sha256sum * > SHA-256-${{ matrix.font }}.txt
 
       - name: Upload patched fonts as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: patched-fonts-${{ matrix.font }}
           # adding multiple paths (i.e. LICENSE) is a workaround to get a least common ancestor
@@ -250,7 +250,7 @@ jobs:
       RELEASE_CANDIDATE: ${{ needs.setup-fonts-matrix.outputs.rel_candidate }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare repo (clear out old and obsolete fonts)
         run: |
           cd -- "$GITHUB_WORKSPACE/patched-fonts"
@@ -258,7 +258,7 @@ jobs:
 
       - name: Download patched fonts from build
         id: download-patched-fonts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: patched-fonts-*
           path: .

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check scripts (1/2)
         run: |

--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Fetch dependencies
       run: sudo apt install -y -q zipcmp
@@ -28,7 +28,7 @@ jobs:
         ./archive-font-patcher.sh intermediate
 
     - name: Upload archive as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         path: archives/FontPatcher.zip
         retention-days: 1


### PR DESCRIPTION
#### Description  
Updated GitHub Action versions to v6 in multiple workflows to ensure compatibility with the latest GitHub Actions platform.

#### Requirements / Checklist  
- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)  
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.  
      Issue number where discussion took place: #xxx  
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)  
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: MIT (assuming standard license for GitHub Actions)  

#### What does this PR do?  
Updated GitHub Action versions in multiple workflows to v6, addressing outdated dependencies and ensuring compatibility with the latest GitHub Actions platform.

#### How should this be manually tested?  
Will be tested in the CI pipeline of the pull request.

#### Any background context you can provide?  
The update aligns with the latest GitHub Actions release, ensuring consistent behavior across workflows that use the `actions/checkout` and `actions/upload-artifact` actions.

#### What are the relevant tickets (if any)?  
None applicable.  

#### Screenshots (if appropriate or helpful)  
![](https://github.com/ryanoasis/nerd-fonts/wiki/images/Actions-Version-Update.png)