### PR TITLE
Bugfix 2 cell wide SymbolsOnly

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1697,7 +1697,7 @@ class font_patcher:
                     cell_width = self.font_dim['width']
                 if sym_attr['align'] == 'c':
                     # Center align
-                    x_align_distance += (cell_width / 2) - (sym_dim['width'] / 2)
+                    x_align_distance += (cell_width * self.get_target_width(stretch) / 2) - (sym_dim['width'] / 2)
                 elif sym_attr['align'] == 'r':
                     # Right align
                     # (not really supported with pa scaling and 2x stretch in NFP)

--- a/font-patcher
+++ b/font-patcher
@@ -1408,9 +1408,6 @@ class font_patcher:
         if self.font_dim['width'] < self.font_dim['xmax']:
             logger.debug("Font has negative right side bearing in extended glyphs")
             self.font_dim['xmax'] = self.font_dim['width'] # In fact 'xmax' is never used
-        if self.font_dim['width'] <= 0:
-            logger.critical("Can not detect sane font width")
-            sys.exit(1)
         if isinstance(self.args.cellopt, list):
             logger.debug("Overriding cell X{%d:%d} with X{%d:%d}",
                 self.font_dim['xmin'], self.font_dim['xmin'] + self.font_dim['width'],
@@ -1418,6 +1415,9 @@ class font_patcher:
             self.font_dim['xmin'] = self.args.cellopt[0]
             self.font_dim['xmax'] = self.args.cellopt[1]
             self.font_dim['width'] = self.args.cellopt[1]
+        if self.font_dim['width'] <= 0:
+            logger.critical("Can not detect sane font width")
+            sys.exit(1)
         if self.args.cellopt:
             logger.info("Cell coordinates (Xmin:Xmax:Ymin:Ymax) %s%d:%d:%d:%d",
                 '' if not isinstance(self.args.cellopt, list) else 'overridden with ',

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.22.1"
+script_version = "4.22.2"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"


### PR DESCRIPTION
#### Description

Two changes by @ningw42 that came up when he wanted to create a 2 cell wide monospaced SymbolsOnly font.

Thanks for the contribution.


#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#1774

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
