### PR TITLE
fix - Some glyph are not visually centered when patching monospaced variation

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1784,7 +1784,12 @@ class font_patcher:
                 # If width is not zero, correct the bearings such that they are within the width:
                 self.remove_glyph_neg_bearings(glyph)
 
+            # TODO: Debug code, will/should be removed after this PR is checked.
+            # if glyph.unicode == 0x25C6:
+            #     self.debug_glyph_metrics(glyph, "before set_glyph_width_mono")
             self.set_glyph_width_mono(glyph)
+            # if glyph.unicode == 0x25C6:
+            #     self.debug_glyph_metrics(glyph, "after  set_glyph_width_mono")
 
 
     def remove_glyph_neg_bearings(self, glyph):
@@ -1802,13 +1807,39 @@ class font_patcher:
         """ Sets passed glyph.width to self.font_dim.width.
 
         self.font_dim.width is set with self.get_sourcefont_dimensions().
+
+        If negative right side bearing appears, see if the glyph is
+         ought to be centered when changing to monospaced.
         """
         try:
             # Fontforge handles the width change like this:
             # - Keep existing left_side_bearing
             # - Set width
             # - Calculate and set new right_side_bearing
-            glyph.width = self.font_dim['width']
+            expected_mono_width = self.font_dim['width']
+            glyph.width = expected_mono_width
+
+            # Visually center some double width glyph that having a bbox width approx. equal to single width.
+            if glyph.right_side_bearing < 0:
+                # TODO: Should be set as a parameter, since regular/thin/bold have different bbox width.
+                glyph_centering_threshold = 20
+                xmin, ymin, xmax, ymax = glyph.boundingBox()
+                glyph_width = xmax - xmin
+
+                # Do not handle those character that cannot be squished into mono width.
+                if glyph_width > expected_mono_width + glyph_centering_threshold:
+                    return
+
+                # Calculate the value for centering visually.
+                glyph_center = (xmin + xmax) / 2.0
+                target_center = expected_mono_width / 2.0
+                x_shift = target_center - glyph_center
+
+                if x_shift != 0:
+                    glyph.transform(psMat.translate(x_shift, 0))
+
+                # Restores the width.
+                glyph.width = expected_mono_width
         except:
             pass
 
@@ -1905,6 +1936,22 @@ class font_patcher:
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
         return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.braille, 0.6)
+
+    def debug_glyph_metrics(self, glyph, label):
+        # TODO: Debug code, will/should be removed after this PR is checked.
+        try:
+            xmin, ymin, xmax, ymax = glyph.boundingBox()
+            print(
+                f"[DEBUG] {label} "
+                f"name={glyph.glyphname} unicode=U+{glyph.unicode:04X} "
+                f"width={glyph.width} "
+                f"lsb={glyph.left_side_bearing} "
+                f"rsb={glyph.right_side_bearing} "
+                f"bbox=({xmin},{ymin},{xmax},{ymax}) "
+                f"bbox_w={xmax - xmin}"
+            )
+        except Exception as e:
+            print(f"[DEBUG] {label} failed: {e}")
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """

--- a/font-patcher
+++ b/font-patcher
@@ -13,16 +13,16 @@ projectName = "Nerd Fonts"
 projectNameAbbreviation = "NF"
 projectNameSingular = projectName[:-1]
 
-import sys
-import re
-import os
 import argparse
-from argparse import RawTextHelpFormatter
-import errno
-import subprocess
-import json
 from enum import Enum
+import errno
+import json
 import logging
+import os
+import re
+import subprocess
+import sys
+
 try:
     import configparser
 except ImportError:
@@ -2131,7 +2131,7 @@ def setup_arguments():
             '* Version: ' + version + '\n'
             '* Development Website: https://github.com/ryanoasis/nerd-fonts\n'
             '* Changelog: https://github.com/ryanoasis/nerd-fonts/blob/-/changelog.md'),
-        formatter_class=RawTextHelpFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
     )
 

--- a/font-patcher
+++ b/font-patcher
@@ -1804,10 +1804,11 @@ class font_patcher:
             if (glyph.width == 2 * mono_width
                 and self.source_monospaced
                 and glyph.unicode > 0
+                and glyph.unicode not in range(0xEE00, 0xEE0B + 1)
                 and unicodedata.east_asian_width(chr(glyph.unicode)) not in 'WF'):
                 # Move glyph into the monospaced cell if
                 # - it is in a double size cell
-                # - it is not part of the WIDE asian glyphs
+                # - it is not part of the WIDE asian glyphs or is likely a progress indicator in PUA
                 # - it is centered inside the double cell
                 # - it fits roughly into a singe cell (5% lenience)
                 (xmin, _, xmax, _) = glyph.boundingBox()

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.22.4"
+script_version = "4.23.0"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"
@@ -1791,13 +1791,29 @@ class font_patcher:
     def set_sourcefont_glyph_widths(self):
         """ Makes self.sourceFont monospace compliant """
 
+        mono_width = self.font_dim['width']
+        recentered = []
+
         for glyph in self.sourceFont.glyphs():
-            if (glyph.width == self.font_dim['width']):
+            if glyph.width == mono_width:
                 # Don't touch the (negative) bearings if the width is ok
                 # Ligatures will have these.
                 continue
 
-            if (glyph.width != 0):
+            if glyph.width == 2 * mono_width and self.source_monospaced:
+                # Move glyph into the monospaced cell if
+                # - it is in a double size cell
+                # - it is centered inside the double cell
+                # - it fits roughly into a singe cell (5% lenience)
+                (xmin, _, xmax, _) = glyph.boundingBox()
+                glyph_width = xmax - xmin
+                glyph_center = xmin + glyph_width / 2.0
+                is_centered = abs(glyph_center - mono_width) <= 1.0
+                if is_centered and glyph_width < mono_width * 1.05:
+                    glyph.left_side_bearing = int(glyph.left_side_bearing - mono_width / 2.0)
+                    recentered += [ glyph.unicode ]
+
+            if glyph.width != 0:
                 # If the width is zero this glyph is intended to be printed on top of another one.
                 # In this case we need to keep the negative bearings to shift it 'left'.
                 # Things like &Auml; have these: composed of U+0041 'A' and U+0308 'double dot above'
@@ -1805,12 +1821,11 @@ class font_patcher:
                 # If width is not zero, correct the bearings such that they are within the width:
                 self.remove_glyph_neg_bearings(glyph)
 
-            # TODO: Debug code, will/should be removed after this PR is checked.
-            # if glyph.unicode == 0x25C6:
-            #     self.debug_glyph_metrics(glyph, "before set_glyph_width_mono")
             self.set_glyph_width_mono(glyph)
-            # if glyph.unicode == 0x25C6:
-            #     self.debug_glyph_metrics(glyph, "after  set_glyph_width_mono")
+
+        if len(recentered) > 0:
+            logger.info("Recentered %d double size glyphs", len(recentered))
+            logger.debug("Recentered:%s", ''.join(' {:X}'.format(x) for x in sorted(recentered)))
 
 
     def remove_glyph_neg_bearings(self, glyph):
@@ -1828,39 +1843,13 @@ class font_patcher:
         """ Sets passed glyph.width to self.font_dim.width.
 
         self.font_dim.width is set with self.get_sourcefont_dimensions().
-
-        If negative right side bearing appears, see if the glyph is
-         ought to be centered when changing to monospaced.
         """
         try:
             # Fontforge handles the width change like this:
             # - Keep existing left_side_bearing
             # - Set width
             # - Calculate and set new right_side_bearing
-            expected_mono_width = self.font_dim['width']
-            glyph.width = expected_mono_width
-
-            # Visually center some double width glyph that having a bbox width approx. equal to single width.
-            if glyph.right_side_bearing < 0:
-                # TODO: Should be set as a parameter, since regular/thin/bold have different bbox width.
-                glyph_centering_threshold = 20
-                xmin, ymin, xmax, ymax = glyph.boundingBox()
-                glyph_width = xmax - xmin
-
-                # Do not handle those character that cannot be squished into mono width.
-                if glyph_width > expected_mono_width + glyph_centering_threshold:
-                    return
-
-                # Calculate the value for centering visually.
-                glyph_center = (xmin + xmax) / 2.0
-                target_center = expected_mono_width / 2.0
-                x_shift = target_center - glyph_center
-
-                if x_shift != 0:
-                    glyph.transform(psMat.translate(x_shift, 0))
-
-                # Restores the width.
-                glyph.width = expected_mono_width
+            glyph.width = self.font_dim['width']
         except:
             pass
 
@@ -1957,22 +1946,6 @@ class font_patcher:
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
         return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.braille, 0.6)
-
-    def debug_glyph_metrics(self, glyph, label):
-        # TODO: Debug code, will/should be removed after this PR is checked.
-        try:
-            xmin, ymin, xmax, ymax = glyph.boundingBox()
-            print(
-                f"[DEBUG] {label} "
-                f"name={glyph.glyphname} unicode=U+{glyph.unicode:04X} "
-                f"width={glyph.width} "
-                f"lsb={glyph.left_side_bearing} "
-                f"rsb={glyph.right_side_bearing} "
-                f"bbox=({xmin},{ymin},{xmax},{ymax}) "
-                f"bbox_w={xmax - xmin}"
-            )
-        except Exception as e:
-            print(f"[DEBUG] {label} failed: {e}")
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """

--- a/font-patcher
+++ b/font-patcher
@@ -1528,9 +1528,6 @@ class font_patcher:
             indexoffset = self.copy_glyphs_last['maximum']
         else:
             indexoffset = 0
-            if self.args.progressbars and len(self.copy_glyphs_last['header']):
-                sys.stdout.write("\n")
-
 
         for index, sym_glyph in enumerate(symbolFontSelection):
 
@@ -1787,6 +1784,8 @@ class font_patcher:
         # end for
         self.copy_glyphs_last['header'] = progressHeader
         self.copy_glyphs_last['maximum'] = glyphSetLength + indexoffset
+        if self.args.progressbars and len(self.copy_glyphs_last['header']):
+            sys.stdout.write("\n")
 
 
     def set_sourcefont_glyph_widths(self):

--- a/font-patcher
+++ b/font-patcher
@@ -22,6 +22,7 @@ import os
 import re
 import subprocess
 import sys
+import unicodedata
 
 try:
     import configparser
@@ -1800,9 +1801,13 @@ class font_patcher:
                 # Ligatures will have these.
                 continue
 
-            if glyph.width == 2 * mono_width and self.source_monospaced:
+            if (glyph.width == 2 * mono_width
+                and self.source_monospaced
+                and glyph.unicode > 0
+                and unicodedata.east_asian_width(chr(glyph.unicode)) not in 'WF'):
                 # Move glyph into the monospaced cell if
                 # - it is in a double size cell
+                # - it is not part of the WIDE asian glyphs
                 # - it is centered inside the double cell
                 # - it fits roughly into a singe cell (5% lenience)
                 (xmin, _, xmax, _) = glyph.boundingBox()

--- a/font-patcher
+++ b/font-patcher
@@ -1805,7 +1805,12 @@ class font_patcher:
                 # If width is not zero, correct the bearings such that they are within the width:
                 self.remove_glyph_neg_bearings(glyph)
 
+            # TODO: Debug code, will/should be removed after this PR is checked.
+            # if glyph.unicode == 0x25C6:
+            #     self.debug_glyph_metrics(glyph, "before set_glyph_width_mono")
             self.set_glyph_width_mono(glyph)
+            # if glyph.unicode == 0x25C6:
+            #     self.debug_glyph_metrics(glyph, "after  set_glyph_width_mono")
 
 
     def remove_glyph_neg_bearings(self, glyph):
@@ -1823,13 +1828,39 @@ class font_patcher:
         """ Sets passed glyph.width to self.font_dim.width.
 
         self.font_dim.width is set with self.get_sourcefont_dimensions().
+
+        If negative right side bearing appears, see if the glyph is
+         ought to be centered when changing to monospaced.
         """
         try:
             # Fontforge handles the width change like this:
             # - Keep existing left_side_bearing
             # - Set width
             # - Calculate and set new right_side_bearing
-            glyph.width = self.font_dim['width']
+            expected_mono_width = self.font_dim['width']
+            glyph.width = expected_mono_width
+
+            # Visually center some double width glyph that having a bbox width approx. equal to single width.
+            if glyph.right_side_bearing < 0:
+                # TODO: Should be set as a parameter, since regular/thin/bold have different bbox width.
+                glyph_centering_threshold = 20
+                xmin, ymin, xmax, ymax = glyph.boundingBox()
+                glyph_width = xmax - xmin
+
+                # Do not handle those character that cannot be squished into mono width.
+                if glyph_width > expected_mono_width + glyph_centering_threshold:
+                    return
+
+                # Calculate the value for centering visually.
+                glyph_center = (xmin + xmax) / 2.0
+                target_center = expected_mono_width / 2.0
+                x_shift = target_center - glyph_center
+
+                if x_shift != 0:
+                    glyph.transform(psMat.translate(x_shift, 0))
+
+                # Restores the width.
+                glyph.width = expected_mono_width
         except:
             pass
 
@@ -1926,6 +1957,22 @@ class font_patcher:
         ymax = self.font_dim["ymax"]
         ymin = self.font_dim["ymin"]
         return get_braille_font(self.sourceFont.em, width, ymax, ymin, self.args.braille, 0.6)
+
+    def debug_glyph_metrics(self, glyph, label):
+        # TODO: Debug code, will/should be removed after this PR is checked.
+        try:
+            xmin, ymin, xmax, ymax = glyph.boundingBox()
+            print(
+                f"[DEBUG] {label} "
+                f"name={glyph.glyphname} unicode=U+{glyph.unicode:04X} "
+                f"width={glyph.width} "
+                f"lsb={glyph.left_side_bearing} "
+                f"rsb={glyph.right_side_bearing} "
+                f"bbox=({xmin},{ymin},{xmax},{ymax}) "
+                f"bbox_w={xmax - xmin}"
+            )
+        except Exception as e:
+            print(f"[DEBUG] {label} failed: {e}")
 
 def half_gap(gap, top):
     """ Divides integer value into two new integers """

--- a/font-patcher
+++ b/font-patcher
@@ -868,7 +868,8 @@ class font_patcher:
     def setup_patch_set(self):
         """ Creates list of dicts to with instructions on copying glyphs from each symbol font into self.sourceFont """
 
-        box_enabled = self.source_monospaced and not self.symbolsonly # Box glyph only for monospaced and not for Symbols Only
+        basics_enabled = True # This enables the standard patch sets that will always be patched in, regardless of other options
+        box_enabled = basics_enabled and self.source_monospaced and not self.symbolsonly # Box glyph only for monospaced and not for Symbols Only
         box_keep = False
         if box_enabled or self.args.forcebox:
             self.sourceFont.selection.select(("ranges",), 0x2500, 0x259f)
@@ -902,7 +903,7 @@ class font_patcher:
                 logger.debug("Found complete Braille glyphs set. Skipping...")
                 braille_enabled = False
         else:
-            braille_enabled = True
+            braille_enabled = basics_enabled
         if braille_enabled:
             if braille_glyphs_current > 0:
                 logger.debug("%d/%d Braille glyphs will be replaced",
@@ -1180,11 +1181,11 @@ class font_patcher:
         #   When complex dynamic adjustments/generation based on sourceFont are unnecessary,
         #   it is better to use `Filename`, then adjust via attributes (in fact, this is more usual).
         self.patch_set = [
-            {'Enabled': True,                           'Name': "Seti-UI + NerdFonts",  'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5FF, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
-            {'Enabled': True,                           'Name': "Heavy Angle Brackets", 'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x276C, 'SymEnd': 0x2771, 'SrcStart': None,   'ScaleRules': HEAVY_SCALE_LIST, 'Attributes': SYM_ATTR_HEAVYBRACKETS},
+            {'Enabled': basics_enabled,                 'Name': "Seti-UI + NerdFonts",  'Filename': "original-source.otf",                            'Exact': False, 'SymStart': 0xE4FA, 'SymEnd': 0xE5FF, 'SrcStart': 0xE5FA, 'ScaleRules': None,             'Attributes': SYM_ATTR_DEFAULT},
+            {'Enabled': basics_enabled,                 'Name': "Heavy Angle Brackets", 'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x276C, 'SymEnd': 0x2771, 'SrcStart': None,   'ScaleRules': HEAVY_SCALE_LIST, 'Attributes': SYM_ATTR_HEAVYBRACKETS},
             {'Enabled': box_enabled,                    'Name': "Box Drawing",          'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0x2500, 'SymEnd': 0x259F, 'SrcStart': None,   'ScaleRules': BOX_SCALE_LIST,   'Attributes': SYM_ATTR_BOX},
-            {'Enabled': True,                           'Name': "Progress Indicators",  'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0xEE00, 'SymEnd': 0xEE0B, 'SrcStart': None,   'ScaleRules': PROGR_SCALE_LIST, 'Attributes': SYM_ATTR_PROGRESS},
-            {'Enabled': True,                           'Name': "Devicons",             'Filename': "devicons/devicons.otf",                          'Exact': False, 'SymStart': 0xE600, 'SymEnd': 0xE7EF, 'SrcStart': 0xE700, 'ScaleRules': DEVI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
+            {'Enabled': basics_enabled,                 'Name': "Progress Indicators",  'Filename': "extraglyphs.sfd",                                'Exact': True,  'SymStart': 0xEE00, 'SymEnd': 0xEE0B, 'SrcStart': None,   'ScaleRules': PROGR_SCALE_LIST, 'Attributes': SYM_ATTR_PROGRESS},
+            {'Enabled': basics_enabled,                 'Name': "Devicons",             'Filename': "devicons/devicons.otf",                          'Exact': False, 'SymStart': 0xE600, 'SymEnd': 0xE7EF, 'SrcStart': 0xE700, 'ScaleRules': DEVI_SCALE_LIST,  'Attributes': SYM_ATTR_DEFAULT},
             {'Enabled': self.args.powerline,            'Name': "Powerline Symbols",    'Filename': "powerline-symbols/PowerlineSymbols.otf",         'Exact': True,  'SymStart': 0xE0A0, 'SymEnd': 0xE0A2, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_POWERLINE},
             {'Enabled': self.args.powerline,            'Name': "Powerline Symbols",    'Filename': "powerline-symbols/PowerlineSymbols.otf",         'Exact': True,  'SymStart': 0xE0B0, 'SymEnd': 0xE0B3, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_POWERLINE},
             {'Enabled': self.args.powerlineextra,       'Name': "Powerline Extra",      'Filename': "powerline-extra/PowerlineExtraSymbols.otf",      'Exact': True,  'SymStart': 0xE0A3, 'SymEnd': 0xE0A3, 'SrcStart': None,   'ScaleRules': None,             'Attributes': SYM_ATTR_POWERLINE},


### PR DESCRIPTION
#### Description

See issue #1997 for detail.

Some glyph in font `Noto`, has some double width glyph with the bounding box width around single width.

Some debug code is preserved, and would be deleted once the PR is ready to be merged.

If this PR could be merged, it will:
fixes #1997

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #1997
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

This PR fixes that by re-centering glyph that could be visually centered while creating monospaced variation.

A variable `glyph_centering_threshold` (currently set to `20`) is used to decide whether a glyph will go into the "visually center" process or not. When the glyph's bounding box is less than single glyph width plus threshold, it will be considered able to be visually centered.

Notice: This threshold is currently empirical, and may need to be derived from font metrics, weight, or be exposed as a parameter and then defined in config.

#### How should this be manually tested?

Use fontforge to compare the previous font and newly patched font, the new one would have a correct bearing for glyph listed in #1997 (`affected_chars` at the bottom of issue, not bottom of discussion).

#### Any background context you can provide?

When I am using `jj-vcs`, I found the "◆" (U+25C6) for immutable commit in `jj log`, is not horizontally centered with the verticle bar in the line above/below.

I pasted the char into [Google Fonts](https://fonts.google.com/noto/specimen/Noto+Sans+Mono) and saw the tofu, so I misunderstood and thinking about this is caused by `copy_glyph` when I read the source code.

However, when I see the file in the unpatched font (`src/unpatched-fonts/Noto/Sans-Mono/NotoSansMono-Regular.ttf`) by fontforge, I found they were having a width of 1200 (double width), and the RBearing becomes negative after `font_patcher.set_glyph_width_mono`.

I checked all the glyph in the unpatched font, and found some glyphs having a bounding box width less or around 600, but all having a negative RBearing (`affected_chars`).
So I tried to visually center those glyph that:
* Having negative RBearing after `glyph.width` was set.
* Having a bounding box width around 600 or less than 600.

Of course, there are also some glyph that should not be vertically centered into monospace width, such as:

```
should_keep_original_chars = [
    "▭",        # U+25AD, width:  600, LBearing:  100, RBearing: -500, bbox_width: 1000
    "▰",        # U+25B0, width:  600, LBearing:  103, RBearing: -497, bbox_width:  994
    "▱",        # U+25B1, width:  600, LBearing:  103, RBearing: -497, bbox_width:  994
    "▻",        # U+25BB, width:  600, LBearing:  284, RBearing: -316, bbox_width:  632
    "◅",        # U+25C5, width:  600, LBearing:  285, RBearing: -316, bbox_width:  631
    "◍",        # U+25CD, width:  600, LBearing:  149, RBearing: -452, bbox_width:  903
    "◯",        # U+25EF, width:  600, LBearing:  230, RBearing: -370, bbox_width:  740
]
```

In order to not introduce compability changes, those kind of glyph is kept their original metrics in this PR.

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

This image, taken from fontforge metrics window, shows the result of patched font, L/R Bearing fixed by this PR.

<img width="898" height="412" alt="image" src="https://github.com/user-attachments/assets/e8ac2e51-409d-473d-95e9-1bdbc080e765" />

See also #1997 for more screenshots explaning why this bug exists and how it could be solved.