### PR TITLE
fix: broken emoji key link in `contributing.md`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -25,7 +25,7 @@ Either:
 * Invoke the [@all-contributors bot](https://allcontributors.org/docs/en/bot/usage) by commenting on your Pull Request or Issue.
 * _(not advised)_ Shallow clone repo and execute `all-contributors add <YOUR_GITHUB_HANDLE> <CONTRIBUTION_TYPE>`
 
-Common types for this project include: `code`, `doc`, `translation`, `review`. For full list of contribution types see: https://allcontributors.org/docs/en/emoji-key
+Common types for this project include: `code`, `doc`, `translation`, `review`. For full list of contribution types see: https://allcontributors.org/en/reference/emoji-key
 
 ## Steps for updating an existing font
 


### PR DESCRIPTION
#### Description

##### Summary
Fixes a broken link to the emoji key in `contributing.md`.

##### Changes
- Updated the emoji key link from https://allcontributors.org/docs/en/emoji-key to https://allcontributors.org/en/reference/emoji-key

##### Why
The old URL no longer resolves (docs site restructured its paths). Contributors following the link were hitting a dead page.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Fixes a broken link to the emoji key in `contributing.md`.
- Updated the emoji key link from `https://allcontributors.org/docs/en/emoji-key` to `https://allcontributors.org/en/reference/emoji-key`

#### How should this be manually tested?
1. Open `contributing.md`
2. Click the emoji key link
3. Confirm it resolves to https://allcontributors.org/en/reference/emoji-key and loads the emoji key page (no 404)

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
