### PR TITLE
bugfix: Obey two-cell scale rule /w c alignment AND some Braille fixes

### DIFF
--- a/bin/scripts/braille/Braille.py
+++ b/bin/scripts/braille/Braille.py
@@ -3,6 +3,7 @@
 
 import fontforge
 import math
+import sys
 
 
 def get_circle_center(dot, width, ymax, ymin):
@@ -69,6 +70,8 @@ def draw_braille_glyph(glyph, idx, width, ymax, ymin, style, rx, ry):
                 draw_rectangle(pen, center, rx, ry)
             elif style == 'circle':
                 draw_circle(pen, center, min(rx, ry))
+            else:
+                sys.exit('Braille style "{}" unknown'.format(style))
     pen = None
 
 

--- a/font-patcher
+++ b/font-patcher
@@ -888,7 +888,9 @@ class font_patcher:
 
         # Automatically added Braille glyphs only for monospaced and not for Symbols Only
         # unless they are requested specifically (i.e. not via --complete)
-        if self.args.braille == 'complete':
+        if not self.args.braille:
+            braille_enabled = False
+        elif self.args.braille == 'complete':
             self.args.braille = 'rectangle'
             braille_enabled = self.source_monospaced and not self.symbolsonly
             if braille_enabled and self.args.careful and braille_glyphs_target == braille_glyphs_current:
@@ -896,7 +898,7 @@ class font_patcher:
                 # do not replace if set is already complete
                 logger.debug("Found complete Braille glyphs set. Skipping...")
                 braille_enabled = False
-        elif self.args.braille is not None:
+        else:
             braille_enabled = True
         if braille_enabled:
             if braille_glyphs_current > 0:

--- a/font-patcher
+++ b/font-patcher
@@ -889,7 +889,7 @@ class font_patcher:
         # Automatically added Braille glyphs only for monospaced and not for Symbols Only
         # unless they are requested specifically (i.e. not via --complete)
         if self.args.braille == 'complete':
-            self.args.braille = 'rectangular'
+            self.args.braille = 'rectangle'
             braille_enabled = self.source_monospaced and not self.symbolsonly
             if braille_enabled and self.args.careful and braille_glyphs_target == braille_glyphs_current:
                 # If `--careful` is given and Braille glyphs just come from `--complete`

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.22.2"
+script_version = "4.22.3"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"
@@ -1697,7 +1697,10 @@ class font_patcher:
                     cell_width = self.font_dim['width']
                 if sym_attr['align'] == 'c':
                     # Center align
-                    x_align_distance += (cell_width * self.get_target_width(stretch) / 2) - (sym_dim['width'] / 2)
+                    x_width = cell_width
+                    if '2' in stretch:
+                        x_width *= self.get_target_width(stretch)
+                    x_align_distance += (x_width / 2) - (sym_dim['width'] / 2)
                 elif sym_attr['align'] == 'r':
                     # Right align
                     # (not really supported with pa scaling and 2x stretch in NFP)


### PR DESCRIPTION
#### Description


The commit
  3761af0b5 font-patcher: Obey two-cell scale rule also with center alignment

should center glyphs with a stretch rule '2' within that 2 cell wide space. But the commit centered all glyphs (regardless if they had a '2' rule or not; but not including glyphs with a '1' rule) in that 2 cell space.

Has been introduced with #1992.

Fixes: #2019




#### Requirements / Checklist

- [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Restore the release-font-patcher result, i.e. without changing scale rules the non-mono glyphs are still left aligned.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
