### PR TITLE
Fix Material Design icon names

### DIFF
--- a/bin/scripts/generate-glyph-info-from-set.py
+++ b/bin/scripts/generate-glyph-info-from-set.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # coding=utf8
 # Nerd Fonts Version: 3.4.0
-# Script Version: 1.3.0
+# Script Version: 1.4.0
 
 # Example Usage:
 # ./generate-glyph-info-from-set.py --font ../../src/glyphs/materialdesignicons-webfont.ttf --start f001 --end f847 --offset 4ff --prefix mdi
@@ -29,6 +29,25 @@ parser.add_argument('-nogaps', '--nogaps', action='store_true', dest='nogaps', h
 parser.add_argument('-font', '--font', type=str, nargs='?', dest='filepath', help='The file path to the font file to open')
 args = parser.parse_args()
 
+manual_name_substitudes = {
+        0xF0388: 'music_note_2',
+        0xF043D: 'radiobox_blank',
+        0xF0509: 'mountains',
+        0xF05FC: 'logout_variant_2',
+        0xF0765: 'circle',
+        0xF0766: 'circle_outline',
+        0xF08D0: 'cards_heart',
+        0xF0B39: 'numeric_0',
+        0xF0C9E: 'numeric_0_circle',
+        0xF0C9F: 'numeric_0_circle_outline',
+        0xF1088: 'roman_numeral_1',
+        0xF108C: 'roman_numeral_5',
+        0xF1091: 'roman_numeral_10',
+        0xF13A6: 'size_m',
+        0xF18A0: 'cards_heart_outline',
+        0xF18F0: 'navigation_variant',
+}
+
 print(args.symbolFontStart, args.symbolFontEnd)
 
 symbolFont = fontforge.open(args.filepath)
@@ -55,20 +74,24 @@ symbolFont.encoding = 'UnicodeFull'
 for index in range(args.symbolFontStart, args.symbolFontEnd + 1):
   if not index in symbolFont:
     continue
-  sym_glyph = symbolFont[index]
-  code = sym_glyph.unicode
-  name = sym_glyph.glyphname
+  if index in manual_name_substitudes:
+    code = index
+    name = manual_name_substitudes[index]
+  else:
+    sym_glyph = symbolFont[index]
+    code = sym_glyph.unicode
+    name = sym_glyph.glyphname
   sh_name = 'i_{}_{}'.format(args.prefix, name.replace('-', '_'))
 
   if args.nogaps:
     char = chr(hexPosition)
   else:
-    char = chr(code + signedOffset)
+    char = chr(index + signedOffset)
 
   entryString = 'i=\'{}\' {}=$i'.format(char, sh_name)
 
   if index != code:
-    suppressedEntries.append(entryString + ' (not main)')
+    suppressedEntries.append(entryString + ' ({:X} not main codepoint)'.format(index))
   elif name not in allNames:
     print(entryString)
   else:
@@ -81,5 +104,5 @@ for index in range(args.symbolFontStart, args.symbolFontEnd + 1):
 print('Done, generated {} glyphs'.format(ctr))
 
 if len(suppressedEntries) > 0:
-  print('FOLLOGING ENTRIES SUPPRESSED to prevent double names:')
+  print('FOLLOWING ENTRIES SUPPRESSED to prevent double names:')
   print('\n'.join(suppressedEntries))

--- a/bin/scripts/lib/i_md.sh
+++ b/bin/scripts/lib/i_md.sh
@@ -907,6 +907,7 @@ i='󰎄' i_md_music_box=$i
 i='󰎅' i_md_music_box_outline=$i
 i='󰎆' i_md_music_circle=$i
 i='󰎇' i_md_music_note=$i
+i='󰎈' i_md_music_note_2=$i
 i='󰎉' i_md_music_note_half=$i
 i='󰎊' i_md_music_note_off=$i
 i='󰎋' i_md_music_note_quarter=$i
@@ -1087,6 +1088,7 @@ i='󰐹' i_md_radio=$i
 i='󰐺' i_md_radio_handheld=$i
 i='󰐻' i_md_radio_tower=$i
 i='󰐼' i_md_radioactive=$i
+i='󰐽' i_md_radiobox_blank=$i
 i='󰐾' i_md_radiobox_marked=$i
 i='󰐿' i_md_raspberry_pi=$i
 i='󰑀' i_md_ray_end=$i
@@ -1290,6 +1292,7 @@ i='󰔅' i_md_temperature_fahrenheit=$i
 i='󰔆' i_md_temperature_kelvin=$i
 i='󰔇' i_md_tennis_ball=$i
 i='󰔈' i_md_tent=$i
+i='󰔉' i_md_mountains=$i
 i='󰔊' i_md_text_to_speech=$i
 i='󰔋' i_md_text_to_speech_off=$i
 i='󰔌' i_md_texture=$i
@@ -1532,6 +1535,7 @@ i='󰗸' i_md_home_map_marker=$i
 i='󰗹' i_md_incognito=$i
 i='󰗺' i_md_kettle=$i
 i='󰗻' i_md_lock_plus=$i
+i='󰗼' i_md_logout_variant_2=$i
 i='󰗽' i_md_logout_variant=$i
 i='󰗾' i_md_music_note_bluetooth=$i
 i='󰗿' i_md_music_note_bluetooth_off=$i
@@ -1892,6 +1896,8 @@ i='󰝡' i_md_unfold_more_vertical=$i
 i='󰝢' i_md_taco=$i
 i='󰝣' i_md_square_outline=$i
 i='󰝤' i_md_square=$i
+i='󰝥' i_md_circle=$i
+i='󰝦' i_md_circle_outline=$i
 i='󰝧' i_md_alert_octagram=$i
 i='󰝨' i_md_atom=$i
 i='󰝩' i_md_ceiling_light=$i
@@ -2253,6 +2259,7 @@ i='󰣌' i_md_camera_image=$i
 i='󰣍' i_md_car_limousine=$i
 i='󰣎' i_md_cards_club=$i
 i='󰣏' i_md_cards_diamond=$i
+i='󰣐' i_md_cards_heart=$i
 i='󰣑' i_md_cards_spade=$i
 i='󰣒' i_md_cellphone_text=$i
 i='󰣓' i_md_cellphone_message=$i
@@ -2869,6 +2876,7 @@ i='󰬵' i_md_format_letter_case_lower=$i
 i='󰬶' i_md_format_letter_case_upper=$i
 i='󰬷' i_md_language_java=$i
 i='󰬸' i_md_circle_multiple=$i
+i='󰬹' i_md_numeric_0=$i
 i='󰬺' i_md_numeric_1=$i
 i='󰬻' i_md_numeric_2=$i
 i='󰬼' i_md_numeric_3=$i
@@ -3225,6 +3233,8 @@ i='󰲚' i_md_minus_network_outline=$i
 i='󰲛' i_md_network_off=$i
 i='󰲜' i_md_network_off_outline=$i
 i='󰲝' i_md_network_outline=$i
+i='󰲞' i_md_numeric_0_circle=$i
+i='󰲟' i_md_numeric_0_circle_outline=$i
 i='󰲠' i_md_numeric_1_circle=$i
 i='󰲡' i_md_numeric_1_circle_outline=$i
 i='󰲢' i_md_numeric_2_circle=$i
@@ -4225,13 +4235,16 @@ i='󱂄' i_md_lungs=$i
 i='󱂅' i_md_math_log=$i
 i='󱂆' i_md_moped=$i
 i='󱂇' i_md_router_network=$i
+i='󱂈' i_md_roman_numeral_1=$i
 i='󱂉' i_md_roman_numeral_2=$i
 i='󱂊' i_md_roman_numeral_3=$i
 i='󱂋' i_md_roman_numeral_4=$i
+i='󱂌' i_md_roman_numeral_5=$i
 i='󱂍' i_md_roman_numeral_6=$i
 i='󱂎' i_md_roman_numeral_7=$i
 i='󱂏' i_md_roman_numeral_8=$i
 i='󱂐' i_md_roman_numeral_9=$i
+i='󱂑' i_md_roman_numeral_10=$i
 i='󱂒' i_md_soldering_iron=$i
 i='󱂓' i_md_stomach=$i
 i='󱂔' i_md_table_eye=$i
@@ -5020,6 +5033,7 @@ i='󱎢' i_md_size_xxs=$i
 i='󱎣' i_md_size_xs=$i
 i='󱎤' i_md_size_s=$i
 i='󱎥' i_md_size_m=$i
+i='󱎦' i_md_size_m=$i
 i='󱎧' i_md_size_xl=$i
 i='󱎨' i_md_size_xxl=$i
 i='󱎩' i_md_size_xxxl=$i
@@ -6293,6 +6307,7 @@ i='󱢜' i_md_bicycle_cargo=$i
 i='󱢝' i_md_calendar_collapse_horizontal=$i
 i='󱢞' i_md_calendar_expand_horizontal=$i
 i='󱢟' i_md_cards_club_outline=$i
+i='󱢠' i_md_cards_heart_outline=$i
 i='󱢡' i_md_cards_playing=$i
 i='󱢢' i_md_cards_playing_club=$i
 i='󱢣' i_md_cards_playing_club_multiple=$i
@@ -6372,6 +6387,7 @@ i='󱣬' i_md_filter_check=$i
 i='󱣭' i_md_filter_check_outline=$i
 i='󱣮' i_md_flag_off=$i
 i='󱣯' i_md_flag_off_outline=$i
+i='󱣰' i_md_navigation_variant=$i
 i='󱣱' i_md_navigation_variant_outline=$i
 i='󱣲' i_md_refresh_auto=$i
 i='󱣳' i_md_tilde_off=$i


### PR DESCRIPTION
[why]
They have the same glyphs on two different codepoints with different meanings, but of course only one name. This will break the cheat sheet.

[how]
Add some hand-picked names for the problematic glyphs/codepoints.

Rerun to update the library file:

        ./generate-glyph-info-from-set.py \
          --font ../../src/glyphs/materialdesign/MaterialDesignIconsDesktop.ttf \
          --start f0001 --end f1af0 --offset 0 --prefix md > lib/i_md.sh

On release that will update the glyphnames and cheat sheet databases.

[note]
Noticed when working on PR #1926.


#### Requirements / Checklist

- [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
