### PR TITLE
Expand has-no-italic to other slanted styles than Oblique

### DIFF
--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -55,7 +55,7 @@ class FontnameParser:
         self.keep_regular_in_family = keep
 
     def set_expect_no_italic(self, noitalic):
-        """Prevents rewriting Oblique as family name part"""
+        """Prevents rewriting Oblique/Slanted as family name part"""
         # To prevent naming clashes usually Oblique is moved out in the family name
         # because some fonts have Italic and Oblique, and we want to generate pure
         # RIBBI families in ID1/2.
@@ -224,8 +224,14 @@ class FontnameParser:
             (weights, styles) = FontnameTools.make_oblique_style(weights, [])
         if self.use_short_families[1]:
             [ other, weights ] = FontnameTools.short_styles([ other, weights ], aggressive)
-        weights = [ w if w != 'Oblique' else 'Obl' for w in weights ]
-        return FontnameTools.concat(name, rest, other, self.short_family_suff, weights)
+        new_weights = []
+        for w in weights:
+            # weights = [ w if w != 'Oblique' else 'Obl' for w in weights ]
+            if w not in FontnameTools.known_slope_types:
+                new_weights.append(w)
+                continue
+            new_weights.append(FontnameTools.known_slope_types[w][1])
+        return FontnameTools.concat(name, rest, other, self.short_family_suff, new_weights)
 
     def subfamily(self):
         """Get the SFNT SubFamily (ID 2)"""
@@ -234,10 +240,10 @@ class FontnameParser:
         if not self.rename_oblique:
             (weights, styles) = FontnameTools.make_oblique_style(weights, styles)
         if len(styles) == 0:
-            if 'Oblique' in weights:
+            if len(set(FontnameTools.known_slope_types) & set(weights)): # 'Oblique' in weights
                 return FontnameTools.concat(styles, 'Italic')
             return 'Regular'
-        if 'Oblique' in weights and not 'Italic' in styles:
+        if len(set(FontnameTools.known_slope_types) & set(weights)) and not 'Italic' in styles:
                 return FontnameTools.concat(styles, 'Italic')
         return FontnameTools.concat(styles)
 
@@ -262,7 +268,7 @@ class FontnameParser:
         if 'Bold' in self.style_token:
             b |= BOLD
         # Ignore Italic if we have Oblique
-        if 'Oblique' in self.weight_token:
+        if len(set(FontnameTools.known_slope_types) & set(self.weight_token)): # 'Oblique' in self.weight_token
             b |= OBLIQUE
             if not self.rename_oblique:
                 # If we have no dedicated italic, than oblique = italic

--- a/bin/scripts/name_parser/FontnameParser.py
+++ b/bin/scripts/name_parser/FontnameParser.py
@@ -50,6 +50,19 @@ class FontnameParser:
         else:
             return (FontnameTools.concat(self.basename, self.rest).replace(' ', ''), '')
 
+    def _remove_regular(self, styles, weights):
+        """Remove name part 'Regular' if it is superfluous or not really coorect"""
+        if self.keep_regular_in_family == None:
+            keep_regular = FontnameTools.is_keep_regular(self._basename + ' ' + self._rest)
+        else:
+            keep_regular = self.keep_regular_in_family
+        if ('Regular' in styles
+                and (not keep_regular
+                     or FontnameTools.check_contains_weight(self.weight_token))): # This is actually a malformed font name
+            styles = list(styles)
+            styles.remove('Regular')
+        return styles
+
     def set_keep_regular_in_family(self, keep):
         """Familyname may contain 'Regular' where it should normally be suppressed"""
         self.keep_regular_in_family = keep
@@ -146,15 +159,7 @@ class FontnameParser:
         """Get the SFNT Fullname (ID 4)"""
         styles = self.style_token
         weights = self.weight_token
-        if self.keep_regular_in_family == None:
-            keep_regular = FontnameTools.is_keep_regular(self._basename + ' ' + self._rest)
-        else:
-            keep_regular = self.keep_regular_in_family
-        if ('Regular' in styles
-                and (not keep_regular
-                    or FontnameTools.check_contains_weight(self.weight_token))): # This is actually a malformed font name
-            styles = list(self.style_token)
-            styles.remove('Regular')
+        styles = self._remove_regular(styles, weights)
         # For naming purposes we want Oblique to be part of the styles
         (weights, styles) = FontnameTools.make_oblique_style(weights, styles)
         (name, rest) = self._shortened_name()
@@ -168,6 +173,7 @@ class FontnameParser:
         (name, rest) = self._shortened_name()
         styles = self.style_token
         weights = self.weight_token
+        styles = self._remove_regular(styles, weights)
         if self.use_short_families[1]:
             styles = FontnameTools.short_styles(styles, self.use_short_families[2])
             weights = FontnameTools.short_styles(weights, self.use_short_families[2])
@@ -237,6 +243,7 @@ class FontnameParser:
         """Get the SFNT SubFamily (ID 2)"""
         styles = self.style_token
         weights = self.weight_token
+        styles = self._remove_regular(styles, weights)
         if not self.rename_oblique:
             (weights, styles) = FontnameTools.make_oblique_style(weights, styles)
         if len(styles) == 0:

--- a/bin/scripts/name_parser/FontnameTools.py
+++ b/bin/scripts/name_parser/FontnameTools.py
@@ -127,11 +127,12 @@ class FontnameTools:
     @staticmethod
     def make_oblique_style(weights, styles):
         """Move "Oblique" from weights to styles for font naming purposes"""
-        if 'Oblique' in weights:
-            weights = list(weights)
-            weights.remove('Oblique')
-            styles = list(styles)
-            styles.append('Oblique')
+        for oblique in FontnameTools.known_slopes.keys(): # 'Oblique', 'Slanted'...
+            if oblique in weights:
+                weights = list(weights)
+                weights.remove(oblique)
+                styles = list(styles)
+                styles.append(oblique)
         return (weights, styles)
 
     @staticmethod
@@ -267,13 +268,16 @@ class FontnameTools:
         'Narrow': ('Nr', 'Narrow'),
         'Compact': ('Ct', 'Compact'),
     }
-    known_slopes = { # can not take modifiers
+    known_slope_types = { # can not take modifiers
         'Inclined': ('Ic', 'Incl'),
         'Oblique': ('Obl', 'Obl'),
         'Italic': ('It', 'Italic'),
-        'Upright': ('Up', 'Uprght'),
         'Kursiv': ('Ks', 'Kurs'),
         'Sloped': ('Sl', 'Slop'),
+        'Slanted': ('St', 'Slnt'),
+    }
+    known_slopes = known_slope_types | { # can not take modifiers
+        'Upright': ('Up', 'Uprght'),
     }
     known_modifiers = {
         'Demi': ('Dm', 'Dem'),

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.24.0"
+script_version = "4.24.1"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"
@@ -2190,7 +2190,7 @@ def setup_arguments():
     expert_group.add_argument('--custom',                                  dest='custom',           default=False, type=str,            help='Specify a custom symbol font, all glyphs will be copied; absolute path suggested')
     expert_group.add_argument('--dry',                                     dest='dry_run',          default=False, action='store_true', help='Do neither patch nor store the font, to check naming')
     expert_group.add_argument('--glyphdir',                                dest='glyphdir',         default=__dir__ + "/src/glyphs/", type=str, help='Path to glyphs to be used for patching')
-    expert_group.add_argument('--has-no-italic',                           dest='noitalic',         default=False, action='store_true', help='Font family does not have Italic (but Oblique), to help create correct RIBBI set')
+    expert_group.add_argument('--has-no-italic',                           dest='noitalic',         default=False, action='store_true', help='Font family does not have Italic (but Oblique/Slanted), to help create correct RIBBI set')
     expert_group.add_argument('--metrics',                                 dest='metrics',          default=None, choices=get_metrics_names(), help='Select vertical metrics source (for problematic cases)')
     expert_group.add_argument('--name',                                    dest='force_name',       default=None, type=str,             help='Specify naming source (\'full\', \'postscript\', \'filename\', or concrete free name-string)')
     expert_group.add_argument('--postprocess',                             dest='postprocess',      default=False, type=str,            help='Specify a Script for Post Processing')


### PR DESCRIPTION
#### Description

If the font has one of the other possible (but very unlikely) slanted variant, other than `Oblique`, then the flag `--has-no-italic` is not helping in creating the RIBBI set.

The first commit allows to use `--has-no-italic` on any of the recognized-by-us slanted forms. As this has to be manually given there is no risk it triggers unwanted.

The second commit also addresses a naming quirk of Server Mono; or our not-correcting behavior. Usually we correct questionable stuff on patching.

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

https://github.com/internet-development/www-server-mono/releases/tag/v0.0.8 has a `Server Mono Slanted` font.

#### What are the relevant tickets (if any)?

Fixes: #1896 

#### Screenshots (if appropriate or helpful)
