### PR TITLE
Add MDI scales

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -1183,6 +1183,7 @@ class font_patcher:
             range(0xf13a2, 0xf13a9 + 1), # sizes
             range(0xf19b0, 0xf19b7 + 1), # arrows
             range(0xf1abc, 0xf1ac0 + 1), # tally marks
+            [0xf0210, 0xf081d, *range(0xf146c, 0xf1474 + 1), 0xf171d, 0xf1a3a], # fans
         ]}
 
 

--- a/font-patcher
+++ b/font-patcher
@@ -1165,7 +1165,25 @@ class font_patcher:
               *range(0xf0b2, 0xf0b6 + 1)
             ], # lots of clouds (weather states) (Please read note above!)
         ]}
-        MDI_SCALE_LIST = None # Maybe later add some selected ScaleGroups
+        MDI_SCALE_LIST = {'ShiftMode': '', 'ScaleGroups': [
+            [*range(0xf00da, 0xf00dc + 1), *range(0xf0f61, 0xf0f68 + 1)], # moons
+            range(0xf013c, 0xf0143 + 1), # chevrons
+            range(0xf035d, 0xf0360 + 1), # triangles
+            [*range(0xf0387, 0xf038d + 1), 0xf0f71, 0xf0f72, *range(0xf0f74, 0xf0f77 + 1)], # musical notes
+            range(0xf0504, 0xf0506 + 1), # temperature scale units
+            [*range(0xf0712, 0xf0716 + 1), 0xf0a6f ], # cellular signals
+            range(0xf0718, 0xf071e + 1), # commit symbols
+            range(0xf0857, 0xf085c + 1), # chess pieces
+            [0xf09dd, 0xf09de, 0xf09df, 0xf0a10, 0xf0a13, 0xf014, 0xf0a15, 0xf14dc, 0xf1554], # small circles etc (first glyph is size reference)
+            range(0xf0aee, 0xf0b07 + 1), # alpha
+            range(0xf0b39, 0xf0b42 + 1), # numerics
+            range(0xf0bb5, 0xf0bbe + 1), # pan buttons
+            range(0xf1088, 0xf1091 + 1), # roman numerals
+            range(0xf12ab, 0xf12b3 + 1), # f-keys (only 1-9, scale f10 etc independently)
+            range(0xf13a2, 0xf13a9 + 1), # sizes
+            range(0xf19b0, 0xf19b7 + 1), # arrows
+            range(0xf1abc, 0xf1ac0 + 1), # tally marks
+        ]}
 
 
         # Define the character ranges


### PR DESCRIPTION
#### Description

Add some ScaleGroups to the Material Design Icons

#### Requirements / Checklist

- [ ] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

* #1926
* #1898 

#### Screenshots (if appropriate or helpful)
