### PR TITLE
Optionally center most icons in 2 cell space

### DIFF
--- a/font-patcher
+++ b/font-patcher
@@ -931,7 +931,7 @@ class font_patcher:
             'default': {'align': 'c', 'valign': 'c', 'stretch': 'pa', 'params': {}}
         }
         SYM_ATTR_POWERLINE = {
-            'default': {'align': 'c', 'valign': 'c', 'stretch': '^pa', 'params': {}},
+            'default': {'align': 'c', 'valign': 'c', 'stretch': '^pa1', 'params': {}},
 
             # Arrow tips
             0xe0b0: {'align': 'l', 'valign': 'c', 'stretch': '^xy', 'params': {'overlap': 0.06, 'xy-ratio': 0.7}},
@@ -1757,7 +1757,7 @@ class font_patcher:
                 if sym_attr['align'] == 'c':
                     # Center align
                     x_width = cell_width
-                    if '2' in stretch:
+                    if '2' in stretch or (self.args.centerwide and 'pa' in stretch and '1' not in stretch):
                         x_width *= self.get_target_width(stretch)
                     x_align_distance += (x_width / 2) - (sym_dim['width'] / 2)
                 elif sym_attr['align'] == 'r':
@@ -2272,6 +2272,7 @@ def setup_arguments():
     experimental_features={
         # user-switch-name: ( PR number, description, variable in args )
         'nonmono-upscale': (1926, 'Scale non-mono icons to be at least as large as mono', 'upscale'),
+        'center-wide': (2034, 'Is it possible to "center" glyphs which overlap a single cell by padding them?', 'centerwide'),
     }
     args.experimental = list(set(args.experimental))
     if '?' in args.experimental or 'help' in args.experimental:


### PR DESCRIPTION
**[why]**
Except when a Nerd Font Mono font is created, i.e. for all non-mono fonts: The centered icons are centered within 1 cell space. If that is not big enough the icon is left-aligned (filling the left cell completely and a varying amount of the left part of the right cell).

Having vertical colums of these icons might look strange because a center alignment seems more natural in some situations.

**[how]**
A new experimental command line switch is added that switches the scaling for `'pa'` stretch to stretch into 2 cells.

For the Powerline glyphs `E0Ax` the rules are changed to explicitely require scaling into 1 cell to prevent application of the new rule here.

To use this add `--experimental center-wide` to the `font-patcher` command line.

Fixes: #1330
Fixes: #2012

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

The implementation follows @rivy closely and takes @powerman's finding about `E0Ax` into account.

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

The re-centered glyphs have a dark blue mark:

<img width="927" height="612" alt="image" src="https://github.com/user-attachments/assets/1bb93e8e-11f2-4a3d-86b8-d6c01db0261f" />

_Pomicons shifted slightly to the right, most Powerline glyphs stay where they are_

<img width="927" height="689" alt="image" src="https://github.com/user-attachments/assets/d8c62cfa-c661-408f-888a-f0dd918fe062" />
_Icons shifted to the right, so that they are center aligned on border of cell1 and cell2_