### PR TITLE
Improve font preview

### DIFF
--- a/bin/scripts/generate-font-image-previews.sh
+++ b/bin/scripts/generate-font-image-previews.sh
@@ -43,7 +43,7 @@ generate_preview() {
   fontText=$2
   echo "[Generating] $font"
   sed -e "s/000000/ffffff/" -e "s/sans-serif/${font}/" -e "s/Font Name/${fontText}/" <"$template_svg" >"${output_dir}${font}.svg"
-  inkscape "${output_dir}${font}.svg" --actions="select-all; object-to-path; vacuum-defs; fit-canvas-to-selection; export-filename:${output_dir}${font}.svg; export-do"
+  inkscape "${output_dir}${font}.svg" --actions="select-all; object-to-path; fit-canvas-to-selection; export-filename:${output_dir}${font}.svg; export-do" --export-type=svg --vacuum-defs --export-plain-svg
   # svgo "${output_dir}${font}.svg"
 }
 
@@ -52,7 +52,7 @@ generate_preview_symbols() {
   fontText=$2
   echo "[Gen. Symb.] $font"
   sed -e "s/000000/ffffff/" -e "40,80s/sans-serif/${font}/" -e "s/Font Name/${fontText}/" <"$template2_svg" >"${output_dir}${font}.svg"
-  inkscape "${output_dir}${font}.svg" --actions="select-all; object-to-path; vacuum-defs; fit-canvas-to-selection; export-filename:${output_dir}${font}.svg; export-do"
+  inkscape "${output_dir}${font}.svg" --actions="select-all; object-to-path; fit-canvas-to-selection; export-filename:${output_dir}${font}.svg; export-do" --export-type=svg --vacuum-defs --export-plain-svg
   # svgo "${output_dir}${font}.svg"
 }
 

--- a/bin/scripts/lib/template-font-preview.svg
+++ b/bin/scripts/lib/template-font-preview.svg
@@ -10,20 +10,6 @@
    viewBox="0 0 744.09448819 1052.3622047"
    height="297mm"
    width="210mm">
-  <defs
-     id="defs4" />
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
      id="layer1">
     <text
@@ -43,12 +29,12 @@
        xml:space="preserve"><tspan
          y="140.93362"
          x="65.419403"
-         id="tspan4142">abcdefghijklmnopqrstuvwxyz</tspan><tspan
+         id="tspan4142">abcdefghijklmnopqrstuvwxyz [0xX]</tspan><tspan
          id="tspan4144"
          y="162.80862"
-         x="65.419403">ABCDEFGHIJKLMNOPQRSTUVWXYZ </tspan><tspan
+         x="65.419403">ABCDEFGHIJKLMNOPQRSTUVWXYZ (0xX) </tspan><tspan
          id="tspan4148"
          y="184.68362"
-         x="65.419403">oO08 iIlL1 {} [] g9qCGQ ~-+=&gt;</tspan></text>
+         x="65.419403">oO08 iIlL1 g9qCGQ ~-+=&gt;    {0xX}</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
[why]
The preview does not show normal parens next to curlies and brackets.

[how]
See Issue.

Also some adaptations for Inkscape 1.4.3.

Fixes: #1857

**Note:**
**The previews are only updated at release time.**

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

<img width="1004" height="309" alt="image" src="https://github.com/user-attachments/assets/7fd4d661-7c6e-49ab-8de4-df5ddb94572c" />

