### PR TITLE
casks: Switch to tar.xz archives

### DIFF
--- a/bin/scripts/generate-casks.sh
+++ b/bin/scripts/generate-casks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.4.0
-# Script Version: 2.3.0
+# Script Version: 2.4.0
 #
 # Iterates over all [*] archived fonts
 # to generate ruby cask files for homebrew-fonts (https://github.com/Homebrew/homebrew-cask)
@@ -63,7 +63,7 @@ function write_header {
         printf "cask \"%s\" do\\n" "$caskname"
         printf "  version \"%s\"\\n" "$version"
         printf "  sha256 \"%s\"\\n\\n" "$sha256sum"
-        printf "  url \"%s%s.zip\"\\n" "$downloadarchive" "$basename"
+        printf "  url \"%s%s.tar.xz\"\\n" "$downloadarchive" "$basename"
     } >> "$outputfile"
 }
 


### PR DESCRIPTION
**[why]**
The xz archives are much smaller than the zip archives, so they should probably used to install fonts. The tar.xz's are supported through MacOS's `tar` nowadays, so there should be no problem anymore with installing the Casks.

See also the discussion in the Issue.

Note that there are still only very few font-Casks that use xz, and looking on all core Casks, it is still only very few.

Fixes: #1918

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Change the release file the Casks will download.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
