### PR TITLE
Cleanup logfile generation

### DIFF
--- a/.github/workflows/font-patcher.yml
+++ b/.github/workflows/font-patcher.yml
@@ -16,12 +16,9 @@ jobs:
     strategy:
       matrix:
         FontForgeRelease: [
+          { name: "FontForge October 2025 Release", version: "20251009", archiveType: "tar.xz" },
           { name: "FontForge January 2023 Release", version: "20230101", archiveType: "tar.xz" },
           { name: "FontForge March 2022 Release", version: "20220308", archiveType: "tar.xz" },
-          { name: "FontForge 20th Anniversary Edition", version: "20201107", archiveType: "tar.xz" },
-          { name: "FontForge 2020 March Release", version: "20200314", archiveType: "tar.xz" },
-          # @TODO we need to build this FontForge version differently or just skip for now:
-          # { name: "Februrary 2015 (version after mimimum supported version)", version: "20150228", archiveType: "tar.gz" }
         ]
 
     steps:
@@ -36,7 +33,7 @@ jobs:
 
       - name: Install FontForge
         run: |
-          sudo apt install libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev python3-dev ninja-build cmake build-essential gettext libuninameslist-dev -y -q
+          sudo apt install libjpeg-dev libtiff5-dev libpng-dev libfreetype-dev libgif-dev libgtk-3-dev libgtkmm-3.0-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext libuninameslist-dev -y -q
           curl -Lv "https://github.com/fontforge/fontforge/releases/download/${{matrix.FontForgeRelease.version}}/fontforge-${{matrix.FontForgeRelease.version}}.${{matrix.FontForgeRelease.archiveType}}" \
             --output "FontForge.${{matrix.FontForgeRelease.archiveType}}"
           echo "what files we got::"

--- a/bin/scripts/gotta-patch-em-all-font-patcher!.sh
+++ b/bin/scripts/gotta-patch-em-all-font-patcher!.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Nerd Fonts Version: 3.4.0
-# Script Version: 1.4.6
+# Script Version: 1.5.0
 #
 # You can supply options to the font-patcher via environment variable NERDFONTS
 # That option will override the defaults (also defaults of THIS script).
@@ -182,14 +182,14 @@ if [ -n "$find_path_filter" ]; then
   # Disable glob expansion to prevent shell from expanding wildcard patterns in find_cmd_args
   while IFS= read -d $'\0' -r file ; do
     source_fonts=("${source_fonts[@]}" "$file")
-  done < <(set -f; find "$source_fonts_dir" "${find_path_filter_with_pattern[@]}" "(" "${find_cmd_args[@]}" ")" -type f -print0)
+  done < <(set -f; find "$source_fonts_dir" "${find_path_filter_with_pattern[@]}" "(" "${find_cmd_args[@]}" ")" -type f -print0 | sort -z)
 else
   # Filename filter or no filter: group conditions with parentheses
   # -type f must be outside parentheses to apply to all -iname conditions
   # Disable glob expansion to prevent shell from expanding wildcard patterns in find_cmd_args
   while IFS= read -d $'\0' -r file ; do
     source_fonts=("${source_fonts[@]}" "$file")
-  done < <(set -f; find "$source_fonts_dir" "(" "${find_cmd_args[@]}" ")" -type f -print0)
+  done < <(set -f; find "$source_fonts_dir" "(" "${find_cmd_args[@]}" ")" -type f -print0 | sort -z)
 fi
 
 # print total number of source fonts found

--- a/font-patcher
+++ b/font-patcher
@@ -2339,6 +2339,9 @@ def setup_arguments():
 
     if args.forcemono:
         args.single = True
+        if config.getboolean("Config", "abort-mono-patch", fallback=False):
+            logger.info("No trying --mono as requested by configfile; exiting")
+            sys.exit(0)
     if args.nonmono and args.single:
         logger.warning("Specified contradicting --variable-width-glyphs together with --mono or --single-width-glyphs. Ignoring --variable-width-glyphs.")
         args.nonmono = False

--- a/font-patcher
+++ b/font-patcher
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Change the script version when you edit this script:
-script_version = "4.26.0"
+script_version = "4.27.0"
 
 version = "3.4.0"
 projectName = "Nerd Fonts"
@@ -813,6 +813,16 @@ class font_patcher:
                 return
             ligature_subtables = json.loads(self.config.get('Subtables', 'ligatures', fallback='[]'))
             for subtable in ligature_subtables:
+                if not isinstance(subtable, str):
+                    # Complex entries have the form [ regex, table ].
+                    # If the first character of the regex is '!' the regex must NOT match
+                    regex = subtable[0]
+                    invert = regex[0] == '!'
+                    if invert:
+                        regex = regex[1:]
+                    if  (re.search(regex, self.sourceFont.fullname) is None) != invert:
+                        continue
+                    subtable = subtable[1]
                 logger.debug("Removing subtable: %s", subtable)
                 try:
                     self.sourceFont.removeLookupSubtable(subtable)

--- a/src/config.sample.cfg
+++ b/src/config.sample.cfg
@@ -4,7 +4,12 @@
 commandline: --removeligatures --makegroups 2
 abort-mono-patch: True
 [Subtables]
+# List of either
+# - a simple string (of the subtable to be removed)
+# - a 2 element list consisting of regex on font fullname and subtable name
+#   the regex can be prepended with '!' to invert it
 ligatures: [
-        "'dlig' Discretionary Ligatures lookup 9 subtable",
+        "'dlig' Discretionary Ligatures lookup 12 contextual 0",
         "'dlig' Discretionary Ligatures lookup 11 subtable",
-        "'dlig' Discretionary Ligatures lookup 12 contextual 0" ]
+        "'dlig' Discretionary Ligatures lookup 9 subtable",
+        ["!Italic", "'liga' Standard Ligatures in Latin lookup 6 subtable"] ]

--- a/src/config.sample.cfg
+++ b/src/config.sample.cfg
@@ -2,6 +2,7 @@
 # They are INI style files, but some keys have JSON values
 [Config]
 commandline: --removeligatures --makegroups 2
+abort-mono-patch: True
 [Subtables]
 ligatures: [
         "'dlig' Discretionary Ligatures lookup 9 subtable",

--- a/src/unpatched-fonts/Arimo/config.cfg
+++ b/src/unpatched-fonts/Arimo/config.cfg
@@ -1,0 +1,2 @@
+[Config]
+abort-mono-patch: True

--- a/src/unpatched-fonts/HeavyData/config.cfg
+++ b/src/unpatched-fonts/HeavyData/config.cfg
@@ -1,0 +1,2 @@
+[Config]
+abort-mono-patch: True

--- a/src/unpatched-fonts/Lekton/config.cfg
+++ b/src/unpatched-fonts/Lekton/config.cfg
@@ -1,6 +1,8 @@
 [Config]
 commandline: --removeligatures
 [Subtables]
+# 5 and 6 are in Regular and Bold
+# Italic has none
 ligatures: [
-    "'liga' Standard Ligatures in Latin lookup 6 subtable",
-    "'liga' Standard Ligatures in Latin lookup 5 subtable" ]
+    ["!Italic", "'liga' Standard Ligatures in Latin lookup 6 subtable"],
+    ["!Italic", "'liga' Standard Ligatures in Latin lookup 5 subtable"] ]

--- a/src/unpatched-fonts/MPlus/M_Plus_1/config.cfg
+++ b/src/unpatched-fonts/MPlus/M_Plus_1/config.cfg
@@ -1,0 +1,3 @@
+[Config]
+commandline: --makegroups 2
+abort-mono-patch: True

--- a/src/unpatched-fonts/MPlus/M_Plus_2/config.cfg
+++ b/src/unpatched-fonts/MPlus/M_Plus_2/config.cfg
@@ -1,0 +1,3 @@
+[Config]
+commandline: --makegroups 2
+abort-mono-patch: True

--- a/src/unpatched-fonts/Noto/Sans/config.cfg
+++ b/src/unpatched-fonts/Noto/Sans/config.cfg
@@ -1,5 +1,6 @@
 [Config]
 commandline: --removeligatures --makegroups 5
+abort-mono-patch: True
 [Subtables]
 ligatures: [
     "'liga' Standard Ligatures lookup 41 subtable",

--- a/src/unpatched-fonts/Noto/Sans/config.cfg
+++ b/src/unpatched-fonts/Noto/Sans/config.cfg
@@ -2,8 +2,13 @@
 commandline: --removeligatures --makegroups 5
 abort-mono-patch: True
 [Subtables]
+# NotoSans has two sets, one in the 'normal' and one different
+# in the *Italic* styles.
 ligatures: [
-    "'liga' Standard Ligatures lookup 41 subtable",
-    "Ligature Substitution lookup 15 subtable",
-    "Ligature Substitution lookup 14 subtable",
-    "Ligature Substitution lookup 13 subtable" ]
+    ["!Italic", "'liga' Standard Ligatures lookup 41 subtable"],
+    ["!Italic", "Ligature Substitution lookup 15 subtable"],
+    ["!Italic", "Ligature Substitution lookup 14 subtable"],
+    ["!Italic", "Ligature Substitution lookup 13 subtable"],
+    ["Italic", "'liga' Standard Ligatures lookup 39 subtable"],
+    ["Italic", "Ligature Substitution lookup 12 subtable"],
+    ["Italic", "Ligature Substitution lookup 11 subtable"] ]

--- a/src/unpatched-fonts/Noto/Serif/config.cfg
+++ b/src/unpatched-fonts/Noto/Serif/config.cfg
@@ -1,0 +1,3 @@
+[Config]
+commandline: --makegroups 5
+abort-mono-patch: True

--- a/src/unpatched-fonts/OpenDyslexic/Mono-Regular/config.cfg
+++ b/src/unpatched-fonts/OpenDyslexic/Mono-Regular/config.cfg
@@ -1,6 +1,5 @@
 [Config]
 commandline: --removeligatures
-abort-mono-patch: True
 [Subtables]
 ligatures: [
     "Ligature Substitution lookup 8 subtable",

--- a/src/unpatched-fonts/OpenDyslexic/Mono-Regular/config.cfg
+++ b/src/unpatched-fonts/OpenDyslexic/Mono-Regular/config.cfg
@@ -2,7 +2,4 @@
 commandline: --removeligatures
 [Subtables]
 ligatures: [
-    "Ligature Substitution lookup 8 subtable",
-    "Ligature Substitution lookup 7 subtable",
-    "'liga' Standard Ligature lookup 7 subtable",
-    "'liga' Standard Ligature lookup 4 subtable" ]
+    "Ligature Substitution lookup 7 subtable" ]

--- a/src/unpatched-fonts/OpenDyslexic/config.cfg
+++ b/src/unpatched-fonts/OpenDyslexic/config.cfg
@@ -2,8 +2,10 @@
 commandline: --removeligatures
 abort-mono-patch: True
 [Subtables]
+# Regular, Italic, Alta Regular have 7 & 8
+# all others (e.g. Alta Italic) have 4
+# Mono has it's own config.cfg
 ligatures: [
-    "Ligature Substitution lookup 8 subtable",
-    "Ligature Substitution lookup 7 subtable",
-    "'liga' Standard Ligature lookup 7 subtable",
-    "'liga' Standard Ligature lookup 4 subtable" ]
+    ["Dyslexic Italic|Regular", "Ligature Substitution lookup 8 subtable"],
+    ["Dyslexic Italic|Regular", "'liga' Standard Ligatures lookup 7 subtable"],
+    ["!Dyslexic Italic|Regular", "'liga' Standard Ligatures lookup 4 subtable"] ]

--- a/src/unpatched-fonts/Overpass/Non-Mono/config.cfg
+++ b/src/unpatched-fonts/Overpass/Non-Mono/config.cfg
@@ -1,5 +1,6 @@
 [Config]
 commandline: --removeligatures --makegroups 2
+abort-mono-patch: True
 [Subtables]
 ligatures: [
     "Ligature Substitution lookup 20 subtable",

--- a/src/unpatched-fonts/Tinos/config.cfg
+++ b/src/unpatched-fonts/Tinos/config.cfg
@@ -1,0 +1,2 @@
+[Config]
+abort-mono-patch: True

--- a/src/unpatched-fonts/Ubuntu/config.cfg
+++ b/src/unpatched-fonts/Ubuntu/config.cfg
@@ -1,5 +1,6 @@
 [Config]
 commandline: --removeligatures --makegroups 2
+abort-mono-patch: True
 [Subtables]
 ligatures: [
     "'liga' Standard Ligatures in Latin lookup 20 subtable",

--- a/src/unpatched-fonts/UbuntuSans/Sans/config.cfg
+++ b/src/unpatched-fonts/UbuntuSans/Sans/config.cfg
@@ -1,0 +1,3 @@
+[Config]
+commandline: --makegroups 4
+abort-mono-patch: True

--- a/src/unpatched-fonts/iA-Writer/Duo/config.cfg
+++ b/src/unpatched-fonts/iA-Writer/Duo/config.cfg
@@ -1,0 +1,2 @@
+[Config]
+abort-mono-patch: True

--- a/src/unpatched-fonts/iA-Writer/Quattro/config.cfg
+++ b/src/unpatched-fonts/iA-Writer/Quattro/config.cfg
@@ -1,0 +1,2 @@
+[Config]
+abort-mono-patch: True


### PR DESCRIPTION
#### Description

The logfile has hundredth of lines that are 'expected', with CRITICAL and ERROR levels...

#### Requirements / Checklist

- [x] Read the [Contributing Guidelines](https://github.com/ryanoasis/nerd-fonts/blob/-/contributing.md)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
      Issue number where discussion took place: #xxx
- [ ] If this contains a font/glyph add its origin as background info below (e.g. URL)
- [ ] Verified the license of any newly added font, glyph, or glyph set. License is: xxx

#### What does this Pull Request (PR) do?

Avoid errors from `gotta-patch-em` on proportional fonts, because the script always also tried to generate a `Nerd Font Mono` from it, which is not possible.

Avoid errors from ligature removal, where we have at the moment a superset of rules that fit the different font file specific ligature names. Now we can specify which rule should be active for which font (in that subdirectory).

The fonts are now processed in alphabetical order. That always drove me crazy. Locally. In the CI all the fonts are processed individually in jobs (one job per font) - so it did not matter much there.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
